### PR TITLE
fix agent argument handling for empty parameters

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -3939,6 +3939,9 @@ class ExecWorker_SHELL(ExecWorker):
             ret = list()
             for arg in args :
 
+                if not arg:
+                    continue
+
                 # if string is between outer single quotes,
                 #    pass it as is.
                 # if string is between outer double quotes,


### PR DESCRIPTION
very simple fix for a problem which got triggered by some swift integration test.