### PR TITLE
SuperMUC resource config changes.

### DIFF
--- a/src/radical/pilot/configs/lrz.json
+++ b/src/radical/pilot/configs/lrz.json
@@ -21,16 +21,15 @@
         "agent_spawner"               : "POPEN",
         "task_launch_method"          : "SSH",
         "mpi_launch_method"           : "MPIEXEC",
-        "agent_mongodb_endpoint"      : "mongodb://login03:24242",
+        "forward_tunnel_endpoint"     : "login03",
         "pre_bootstrap"               : ["source /etc/profile",
                                          "source /etc/profile.d/modules.sh",
                                          "module load python/2.7.6",
-                                         "module unload mpi.ibm", "module load mpi.intel",
-                                         "source /home/hpc/pr87be/di29sut/pilotve/bin/activate"
+                                         "module unload mpi.ibm", "module load mpi.intel"
                                         ],
         "valid_roots"                 : ["/home", "/gpfs/work", "/gpfs/scratch"],
-        "rp_version"                  : "installed",
-        "virtenv"                     : "/home/hpc/pr87be/di29sut/pilotve",
+        "rp_version"                  : "debug",
+        "virtenv"                     : "/home/hpc/pr87be/di29sut/ve_supermuc_shared_20150505",
         "virtenv_mode"                : "use"
     }
 }


### PR DESCRIPTION
- Change mongodb tunnel endpoint.
  As connections can procede from the login nodes to the mongodb, we no longer
  need a static tunnel. (I'm pretty sure I made this mod before ...)
- Create and point to new populated virtenv.
  This one has pymongo==2.8 apache-libcloud colorama python-hostlist,
  the RADICAL stack is flown in real-time.
- The latter is enforced by setting rp_version to "debug".
- Remove the sourcing of the VE from the pre_bootstrap .. don't know why it was
  there in the first place ...