### PR TITLE
Fix off-by-one error.

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -854,8 +854,7 @@ class SchedulerContinuous(Scheduler):
 
         # TODO: single_node should be enforced for e.g. non-message passing
         #       tasks, but we don't have that info here.
-        # NOTE AM: why should non-messaging tasks be confined to one node?
-        if cores_requested < self._lrms.cores_per_node:
+        if cores_requested <= self._lrms.cores_per_node:
             single_node = True
         else:
             single_node = False


### PR DESCRIPTION
This resolves #621 and #572.

My hunch is that there still is an underlying issue in the multinode scheduler,
will create a separate ticket for that.

Andre: To answer your (now removed question), a non-communicating task
can not have concurrency beyond node boundary. This seems obvious, so I might
miss the point of your question?