### PR TITLE
Really disable timeout mechanism.

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-spawner.sh
+++ b/src/radical/pilot/agent/radical-pilot-spawner.sh
@@ -80,7 +80,7 @@ EXIT_VAL=1
 \trap cleanup_handler_term TERM
 \trap cleanup_handler_exit EXIT
 # \trap idle_handler ALRM
-\trap '' ALRM
+#\trap '' ALRM
 
 \trap cleanup_handler_sighup  SIGHUP
 \trap cleanup_handler_sigint  SIGINT
@@ -131,7 +131,7 @@ idle_checker () {
 
     if test -e "$BASE/quit.$ppid" 
     then
-      \rm   -f  "$BASE/quit.$ppid" 
+      \rm   -f  "$BASE/quit.$ppid"
       EXIT_VAL=0
       exit 0
     fi
@@ -139,7 +139,7 @@ idle_checker () {
     if test -e "$BASE/idle.$ppid"
     then
       /bin/kill -s ALRM $ppid >/dev/null 2>&1
-      \rm   -f  "$BASE/idle.$ppid" 
+      \rm   -f  "$BASE/idle.$ppid"
       exit 0
     fi
 
@@ -807,8 +807,8 @@ listen() {
   fi
 
   # make sure we get killed when idle
-  ( idle_checker $$ 1>/dev/null 2>/dev/null 3</dev/null & ) &
-  IDLE=$!
+  #( idle_checker $$ 1>/dev/null 2>/dev/null 3</dev/null & ) &
+  #IDLE=$!
 
   # create fifo to communicate with the monitors
   \rm -f  "$BASE/fifo"


### PR DESCRIPTION
Given that this was not used anyway, and causes problems on BW, there is no
reason not to do this.

Symptoms seen are that the timeout that sends the alarm causes the script to
exit. Which make me think that that my '/bin/sleep' might do something funky
with the SIGALRM handler.

Ultimately it would be good to better understand it, but this is not the time
and place.