### PR TITLE
moving 5 lines of code, for the benefit of mankind

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -3403,13 +3403,6 @@ class ExecWorker_POPEN (ExecWorker) :
                  schedule_queue, pilot_id, session_id)
 
 
-        # run watcher thread
-        watcher_name  = self.name.replace ('ExecWorker', 'ExecWatcher')
-        self._watcher = threading.Thread(target = self._watch,
-                                         name   = watcher_name)
-        self._watcher.start ()
-
-
     # --------------------------------------------------------------------------
     #
     def close(self):
@@ -3417,8 +3410,6 @@ class ExecWorker_POPEN (ExecWorker) :
         # shut down the watcher thread
         rpu.prof ('stop request')
         rpu.flush_prof()
-        self._terminate.set()
-        self._watcher.join()
 
 
     # --------------------------------------------------------------------------
@@ -3452,6 +3443,13 @@ class ExecWorker_POPEN (ExecWorker) :
     # --------------------------------------------------------------------------
     #
     def run(self):
+
+        # run watcher thread
+        watcher_name  = self.name.replace ('ExecWorker', 'ExecWatcher')
+        self._watcher = threading.Thread(target = self._watch,
+                                         name   = watcher_name)
+        self._watcher.start ()
+
 
         rpu.prof('run')
         try:
@@ -3524,6 +3522,8 @@ class ExecWorker_POPEN (ExecWorker) :
 
         except Exception as e:
             self._log.exception("Error in ExecWorker loop (%s)" % e)
+            self._terminate.set()
+            self._watcher.join()
 
         rpu.prof ('stop')
 


### PR DESCRIPTION
don't ask me why, but this fixes the popen/process issue.  Well, I actually may
venture a guess why: because pickle thinks its too clever, and because somebody
did not write unit tests -- and with somebody, I mean python.

It seems that pickle can `pickle()` `subprocess.Popen` classes all right, and
specifically can *`unpickle()`* them into functional classes as long as they remain
in the process tree *beneath* the process which spawned the `Popen` proc.  But, as
you may have guessed, moving sidewards in the process tree does not work.  Well,
it works, but not as expected: the `Popen` instance looks valid, inspects valid,
has the correct PID - and is disconnected from the process it is supposed to
own, and *kaboom!*.

By moving the watcher thread beneath the class which spawns the `Popen` instances,
the sideway move is avoided, and *huzza!*.

Oh, and just for the amusement of the interested (or bored) reader: I hit a very
'nice' race condition which did cost me about 4 hours of my live: removing some
lines of uninteresting (because logging) code made a certain code section
exactly so much faster that it then won a race when pulling from a queue.  ARGH!