### PR TITLE
Feature/session recording

### DIFF
--- a/bin/radicalpilot-run-session
+++ b/bin/radicalpilot-run-session
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import glob
+import pprint
+import datetime
+import logging
+import pymongo
+import radical.utils       as ru
+import radical.pilot       as rp
+import radical.pilot.utils as rpu
+
+
+# ------------------------------------------------------------------------------
+#
+def run_record(rec):
+
+    session = None
+
+    try:
+
+        rep = ru.Reporter(title='Session Replay: %s' % rec)
+
+        rep.header('create session')
+        s_dict  = ru.read_json_str("%s/session.json" % rec)
+        dburl   = s_dict.get('dburl')
+        rep.info('session dburl: %s' % dburl)
+
+        session = rp.Session(database_url=dburl)
+        rep.ok('session uid  : %s' % session.uid)
+
+        pmgr    = rp.PilotManager(session=session)
+        rep.ok('pilot manager: %s' % pmgr.uid)
+
+        umgr    = rp.UnitManager(session=session)
+        rep.ok('unit manager : %s' % umgr.uid)
+
+        rep.header('create pilots')
+        pds = list()
+        for pd_json in glob.glob("%s/pilot.*.json % rec"):
+            pd_dict = ru.read_json(pd_json)
+            pd      = rp.ComputePilotDescription()
+            for key, val in pd_dict.iteritems():
+                pd.set_attribute(key, val)
+            pds.append(pd)
+            rep.info('%-15s [%3d cores]' % (pd.resource, pd.cores))
+        pilots = pmgr.submit_pilots(pds)
+        rep.ok('pilots submitted')
+
+        batch = 0
+        while True:
+            ud_json_list = glob.glob("%s/unit.*.batch.%03d.json" % batch)
+
+            if not ud_json_list:
+                rec.header('no more unit batches found')
+                break
+
+            rep.header('submit units [batch %d]' % batch)
+            uds = list()
+            for ud_json in ud_json_list:
+                ud_dict = ru.read_json(ud_json)
+                ud      = rp.ComputeUnitDescription()
+                for key, val in ud_dict.iteritems():
+                    ud.set_attribute(key, val)
+                uds.append(ud)
+                args = ud_dict.get('arguments', [])
+                rep.info('%s  %s [%3d cores]' % (ud.executable, ' '.join(args), ud.cores))
+            units = umgr.submit_units(uds)
+            rep.ok('units submitted  [batch %d]' % batch)
+    
+            rep.info('wait for units [batch %d]' % batch)
+            umgr.wait_units()
+            rep.ok('units all done   [batch %d]' % batch)
+    
+            for u in units:
+                rep.info("%s (@ %s) state %s, exit %s" \
+                    % (u.uid, u.execution_locations, u.state, u.exit_code))
+
+            batch += 1
+
+
+    except Exception as e:
+        logging.exception('error')
+        rep.error("Exception caught: %s" % e)
+
+    finally:
+
+        if session:
+            rep.info('closing session %s' % session.uid)
+            session.close()
+            rep.ok('session closed')
+
+
+
+# ------------------------------------------------------------------------------
+#
+def usage (msg=None, noexit=False) :
+
+    if  msg :
+        print "\n      Error: %s" % msg
+
+    print """
+      usage      : %s [-r rec]
+      example    : %s -r /tmp/recorded_session
+      options :
+        -r <rec> : run the session recorded in the directory 'rec'
+                   if not specified, we use the value of the env variable
+                   RADICAL_PILOT_SESSION_RECORD (if available)
+
+""" % (sys.argv[0], sys.argv[0])
+
+    if  msg :
+        sys.exit (1)
+
+    if  not noexit :
+        sys.exit (0)
+
+
+# ------------------------------------------------------------------------------
+#
+if __name__ == '__main__' :
+
+    import optparse
+    parser = optparse.OptionParser (add_help_option=False)
+
+    parser.add_option('-r', '--record', dest='rec')
+    parser.add_option('-h', '--help',   dest='help', action="store_true")
+
+    options, args = parser.parse_args ()
+
+    if  options.help :
+        usage ()
+
+    if  options.rec :
+        rec = options.rec
+    else:
+        print 'looking for RADICAL_PILOT_SESSION_RECORD'
+        rec = os.environ.get('RADICAL_PILOT_RECORD_SESSION')
+        if not rec:
+            print 'not found'
+
+    if not rec:
+        usage ("No record specified")
+
+    # don't record a recorded session
+    if 'RADICAL_PILOT_RECORD_SESSION' in os.environ:
+        del(os.environ['RADICAL_PILOT_RECORD_SESSION'])
+
+    run_record(rec)
+
+
+# ------------------------------------------------------------------------------
+

--- a/bin/radicalpilot-run-session
+++ b/bin/radicalpilot-run-session
@@ -38,7 +38,7 @@ def run_record(rec):
 
         rep.header('create pilots')
         pds = list()
-        for pd_json in glob.glob("%s/pilot.*.json % rec"):
+        for pd_json in glob.glob("%s/pilot.*.json" % rec):
             pd_dict = ru.read_json(pd_json)
             pd      = rp.ComputePilotDescription()
             for key, val in pd_dict.iteritems():
@@ -48,9 +48,12 @@ def run_record(rec):
         pilots = pmgr.submit_pilots(pds)
         rep.ok('pilots submitted')
 
+        rep.header('using pilots')
+        umgr.add_pilots(pilots)
+
         batch = 0
         while True:
-            ud_json_list = glob.glob("%s/unit.*.batch.%03d.json" % batch)
+            ud_json_list = glob.glob("%s/unit.*.batch.%03d.json" % (rec, batch))
 
             if not ud_json_list:
                 rec.header('no more unit batches found')

--- a/src/radical/pilot/pilot_manager.py
+++ b/src/radical/pilot/pilot_manager.py
@@ -298,27 +298,27 @@ class PilotManager(Object):
         # each one and append it to 'pilot_obj_list'.
         pilot_obj_list = list()
 
-        for pilot_description in pilot_descriptions:
+        for pd in pilot_descriptions:
 
-            if pilot_description.resource is None:
+            if pd.resource is None:
                 error_msg = "ComputePilotDescription does not define mandatory attribute 'resource'."
                 raise BadParameter(error_msg)
 
-            elif pilot_description.runtime is None:
+            elif pd.runtime is None:
                 error_msg = "ComputePilotDescription does not define mandatory attribute 'runtime'."
                 raise BadParameter(error_msg)
 
-            elif pilot_description.cores is None:
+            elif pd.cores is None:
                 error_msg = "ComputePilotDescription does not define mandatory attribute 'cores'."
                 raise BadParameter(error_msg)
 
-            resource_key = pilot_description.resource
+            resource_key = pd.resource
             resource_cfg = self._session.get_resource_config(resource_key)
 
             # Check resource-specific mandatory attributes
             if "mandatory_args" in resource_cfg:
                 for ma in resource_cfg["mandatory_args"]:
-                    if getattr(pilot_description, ma) is None:
+                    if getattr(pd, ma) is None:
                         error_msg = "ComputePilotDescription does not define attribute '{0}' which is required for '{1}'.".format(ma, resource_key)
                         raise BadParameter(error_msg)
 
@@ -327,14 +327,14 @@ class PilotManager(Object):
             # the selected schema so better use a deep copy...
             import copy
             resource_cfg  = copy.deepcopy (resource_cfg)
-            schema        = pilot_description['access_schema']
+            schema        = pd['access_schema']
 
             if  not schema :
                 if 'schemas' in resource_cfg :
                     schema = resource_cfg['schemas'][0]
               # import pprint
               # print "no schema, using %s" % schema
-              # pprint.pprint (pilot_description)
+              # pprint.pprint (pd)
 
             if  not schema in resource_cfg :
               # import pprint
@@ -349,21 +349,23 @@ class PilotManager(Object):
                     resource_cfg[key] = resource_cfg[schema][key]
 
             # If 'default_sandbox' is defined, set it.
-            if pilot_description.sandbox is not None:
+            if pd.sandbox is not None:
                 if "valid_roots" in resource_cfg and resource_cfg["valid_roots"] is not None:
                     is_valid = False
                     for vr in resource_cfg["valid_roots"]:
-                        if pilot_description.sandbox.startswith(vr):
+                        if pd.sandbox.startswith(vr):
                             is_valid = True
                     if is_valid is False:
-                        raise BadParameter("Working directory for resource '%s' defined as '%s' but needs to be rooted in %s " % (resource_key, pilot_description.sandbox, resource_cfg["valid_roots"]))
+                        raise BadParameter("Working directory for resource '%s'" \
+                               " defined as '%s' but needs to be rooted in %s " \
+                                % (resource_key, pd.sandbox, resource_cfg["valid_roots"]))
 
             # After the sanity checks have passed, we can register a pilot
             # startup request with the worker process and create a facade
             # object.
 
             pilot = ComputePilot.create(
-                pilot_description=pilot_description,
+                pilot_description=pd,
                 pilot_manager_obj=self)
 
             pilot_uid = self._worker.register_start_pilot_request(
@@ -373,6 +375,12 @@ class PilotManager(Object):
             pilot._uid = pilot_uid
 
             pilot_obj_list.append(pilot)
+
+            if self._session._rec:
+                import radical.utils as ru
+                ru.write_json(pd.as_dict(), "%s/%s.json" 
+                        % (self._session._rec, pilot_uid))
+
 
         # Implicit return value conversion
         if  return_list_type :

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -229,9 +229,9 @@ class Session (saga.Session, Object):
 
                 _rec = os.environ.get('RADICAL_PILOT_RECORD_SESSION')
                 if _rec:
-                    os.system('mkdir -p %s/%s' % (_rec, self.uid))
-                    ru.write_json({'dburl' : self._database_url}, "%s/session.json" % _rec)
                     self._rec = "%s/%s" % (_rec, self.uid)
+                    os.system('mkdir -p %s' % self._rec)
+                    ru.write_json({'dburl' : self._database_url}, "%s/session.json" % self._rec)
                     logger.info("recording session in %s" % self._rec)
 
 

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -231,7 +231,7 @@ class Session (saga.Session, Object):
                 if _rec:
                     self._rec = "%s/%s" % (_rec, self.uid)
                     os.system('mkdir -p %s' % self._rec)
-                    ru.write_json({'dburl' : self._database_url}, "%s/session.json" % self._rec)
+                    ru.write_json({'dburl' : str(self._database_url)}, "%s/session.json" % self._rec)
                     logger.info("recording session in %s" % self._rec)
                 else:
                     self._rec = None

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -225,7 +225,15 @@ class Session (saga.Session, Object):
                                       db_url  = self._database_url,
                                       db_name = self._database_name)
 
-                logger.info("New Session created%s." % str(self))
+                logger.info("New Session created %s." % str(self))
+
+                _rec = os.environ.get('RADICAL_PILOT_RECORD_SESSION')
+                if _rec:
+                    os.system('mkdir -p %s/%s' % (_rec, self.uid))
+                    ru.write_json({'dburl' : self._database_url}, "%s/session.json" % _rec)
+                    self._rec = "%s/%s" % (_rec, self.uid)
+                    logger.info("recording session in %s" % self._rec)
+
 
             except Exception, ex:
                 logger.exception ('session create failed')

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -233,6 +233,8 @@ class Session (saga.Session, Object):
                     os.system('mkdir -p %s' % self._rec)
                     ru.write_json({'dburl' : self._database_url}, "%s/session.json" % self._rec)
                     logger.info("recording session in %s" % self._rec)
+                else:
+                    self._rec = None
 
 
             except Exception, ex:

--- a/src/radical/pilot/unit_manager.py
+++ b/src/radical/pilot/unit_manager.py
@@ -97,6 +97,7 @@ class UnitManager(object):
         self._session = session
         self._worker  = None 
         self._pilots  = list()
+        self._rec_id  = 0
 
         if not scheduler:
             scheduler = SCHED_DEFAULT
@@ -437,9 +438,18 @@ class UnitManager(object):
         units = list()
         for ud in unit_descriptions :
 
-            units.append (ComputeUnit.create (unit_description=ud,
-                                              unit_manager_obj=self, 
-                                              local_state=SCHEDULING))
+            u = ComputeUnit.create (unit_description=ud,
+                                    unit_manager_obj=self, 
+                                    local_state=SCHEDULING)
+            units.append(u)
+
+            if self._session._rec:
+                import radical.utils as ru
+                ru.write_json(ud.as_dict(), "%s/%s.batch.%03d.json" \
+                        % (self._session._rec, u.uid, self._rec_id))
+
+        if self._session._rec:
+            self._rec_id += 1
 
         self._worker.publish_compute_units (units=units)
 


### PR DESCRIPTION
When debugging RP applications, I would like to see the pilot and unit descriptions as they arrive on the RP layer.  This PR adds some lines of code which capture those and dump json files to a given dir (specified in `RADICAL_PILOT_RECORD_SESSION`).

Once one has that, one can now also read those json files and play them back via RP, like a session-recording and session-playback mechanism.  That has very limited capabilities for sure: time ordering or causal ordering is not captured, and most importantly, data for staging ops are not captured, but its still quite useful to inspect what is happening on the RP layer w/o the need to go through all the kernel configs and ENMD cluster somethings...
