### PR TITLE
added agent_variables in example config

### DIFF
--- a/docs/source/machconf.rst
+++ b/docs/source/machconf.rst
@@ -140,6 +140,9 @@ A configuration file has to be valid JSON. The structure is as follows:
                                              "source /home/hpc/pr87be/di29sut/pilotve/bin/activate"
                                             ],
             "valid_roots"                 : ["/home", "/gpfs/work", "/gpfs/scratch"],
+            "agent_type"                  : "multicore",
+            "agent_scheduler"             : "CONTINUOUS",
+            "agent_spawner"               : "POPEN",
             "pilot_agent"                 : "radical-pilot-agent-multicore.py"
         },
         "ANOTHER_KEY_NAME": 


### PR DESCRIPTION
I don't fully know what these variables are supposed to do, but it doesn't work without them.