### PR TITLE
Feature/local cpn

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -3483,10 +3483,17 @@ class ForkLRMS(LRMS):
                 self._log.warn("more cores available: using requested %d instead of available %d.",
                         selected_cpus, detected_cpus)
 
-        self.node_list = list()
-        for i in range(selected_cpus):
+        # if cores_per_node is set in the agent config, we slice the number of
+        # cores into that many virtual nodes.  cpn defaults to selected_cpus,
+        # to preserve the previous behavior.
+        self.cores_per_node = self._cfg.get('cores_per_node', selected_cpus)
+        requested_nodes = int(math.ceil(float(selected_cpus) / float(self.cores_per_node)))
+        self.node_list  = list()
+        for i in range(requested_nodes):
             self.node_list.append("localhost")
-        self.cores_per_node = 1
+
+        self._log.debug('configure localhost to have %s nodes a %s cores',
+                len(self.node_list), self.cores_per_node)
 
 
 

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -3495,7 +3495,7 @@ class ForkLRMS(LRMS):
         for i in range(requested_nodes):
             self.node_list.append("localhost")
 
-        self._log.debug('configure localhost to have %s nodes a %s cores',
+        self._log.debug('configure localhost to behave as %s nodes with %s cores each.',
                 len(self.node_list), self.cores_per_node)
 
 

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -3486,7 +3486,10 @@ class ForkLRMS(LRMS):
         # if cores_per_node is set in the agent config, we slice the number of
         # cores into that many virtual nodes.  cpn defaults to selected_cpus,
         # to preserve the previous behavior.
-        self.cores_per_node = self._cfg.get('cores_per_node', selected_cpus)
+        self.cores_per_node = self._cfg.get('cores_per_node')
+        if not self.cores_per_node:
+            self.cores_per_node = selected_cpus
+
         requested_nodes = int(math.ceil(float(selected_cpus) / float(self.cores_per_node)))
         self.node_list  = list()
         for i in range(requested_nodes):

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -3483,8 +3483,10 @@ class ForkLRMS(LRMS):
                 self._log.warn("more cores available: using requested %d instead of available %d.",
                         selected_cpus, detected_cpus)
 
-        self.node_list = ["localhost"]
-        self.cores_per_node = selected_cpus
+        self.node_list = list()
+        for i in range(selected_cpus):
+            self.node_list.append("localhost")
+        self.cores_per_node = 1
 
 
 

--- a/src/radical/pilot/controller/pilot_launcher_worker.py
+++ b/src/radical/pilot/controller/pilot_launcher_worker.py
@@ -615,8 +615,7 @@ class PilotLauncherWorker(threading.Thread):
 
                         # set some agent configuration
                         agent_cfg_dict['cores']              = number_cores
-                        agent_cfg_dict['cores_per_node']     = cores_per_node
-                        agent_cfg_dict['debug']              = logger.getEffectiveLevel() 
+                        agent_cfg_dict['debug']              = logger.getEffectiveLevel()
                         agent_cfg_dict['mongodb_url']        = str(agent_dburl)
                         agent_cfg_dict['lrms']               = lrms
                         agent_cfg_dict['spawner']            = agent_spawner
@@ -627,6 +626,8 @@ class PilotLauncherWorker(threading.Thread):
                         agent_cfg_dict['agent_launch_method']= agent_launch_method
                         agent_cfg_dict['task_launch_method'] = task_launch_method
                         agent_cfg_dict['mpi_launch_method']  = mpi_launch_method
+                        if cores_per_node:
+                            agent_cfg_dict['cores_per_node'] = cores_per_node
 
                         # ------------------------------------------------------
                         # Write agent config dict to a json file in pilot sandbox.

--- a/src/radical/pilot/controller/pilot_launcher_worker.py
+++ b/src/radical/pilot/controller/pilot_launcher_worker.py
@@ -615,6 +615,7 @@ class PilotLauncherWorker(threading.Thread):
 
                         # set some agent configuration
                         agent_cfg_dict['cores']              = number_cores
+                        agent_cfg_dict['cores_per_node']     = cores_per_node
                         agent_cfg_dict['debug']              = logger.getEffectiveLevel() 
                         agent_cfg_dict['mongodb_url']        = str(agent_dburl)
                         agent_cfg_dict['lrms']               = lrms


### PR DESCRIPTION
setting `cores_pre_node=2` in the localhost config now results in

```
agent.0.bootstrap_3.log:2015-09-15 15:27:05,983: agent.0.bootstrap_3 : MainProcess : MainThread : \
DEBUG   : configure localhost to have 4 nodes a 2 cores
```