### PR TITLE
Feature/proctitles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,6 +215,9 @@ setup_args = {
 #   }
 }
 
+if 'RADICAL_DEBUG' in os.environ:
+    setup_args['install_requires'].append('setproctitle')
+
 # ------------------------------------------------------------------------------
 
 setup (**setup_args)

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -5645,8 +5645,8 @@ class AgentWorker(rpu.Worker):
                 ccfg['number'] = i
                 comp = cmap[cname].create(ccfg)
                 comp.start()
-                self._components[comp.cname] = {'handle' : comp,
-                                                'alive'  : False}
+                self._components[comp.childname] = {'handle' : comp,
+                                                    'alive'  : False}
                 self._log.info('created component %s (%s): %s', cname, cnum, comp.cname)
 
         # we also create *one* instance of every 'worker' type -- which are the
@@ -5663,8 +5663,8 @@ class AgentWorker(rpu.Worker):
                 wcfg   = copy.deepcopy(self._cfg)
                 worker = wmap[wname].create(wcfg)
                 worker.start()
-                self._workers[worker.cname] = {'handle' : worker,
-                                               'alive'  : False}
+                self._workers[worker.childname] = {'handle' : worker,
+                                                   'alive'  : False}
 
         self._log.debug("start_components done")
 

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -5845,17 +5845,17 @@ def bootstrap_3():
         raise RuntimeError('invalid number of parameters (%s)' % sys.argv)
     agent_name = sys.argv[1]
 
-    try:
-        import setproctitle as spt
-        spt.setproctitle('radical.pilot %s' % agent_name)
-    except Exception as e:
-        self._log.debug('no setproctitle: %s', e)
-
     # set up a logger and profiler
     prof = rpu.Profiler ('%s.bootstrap_3' % agent_name)
     log  = ru.get_logger('%s.bootstrap_3' % agent_name, 
                          '%s.bootstrap_3.log' % agent_name, 'DEBUG')  # FIXME?
     log.info('start')
+
+    try:
+        import setproctitle as spt
+        spt.setproctitle('radical.pilot %s' % agent_name)
+    except Exception as e:
+        log.debug('no setproctitle: %s', e)
 
     # load the agent config, and overload the config dicts
     agent_cfg  = "%s/%s.cfg" % (os.getcwd(), agent_name)

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -5845,6 +5845,12 @@ def bootstrap_3():
         raise RuntimeError('invalid number of parameters (%s)' % sys.argv)
     agent_name = sys.argv[1]
 
+    try:
+        import setproctitle as spt
+        spt.setproctitle('radical.pilot %s' % agent_name)
+    except Exception as e:
+        self._log.debug('no setproctitle: %s', e)
+
     # set up a logger and profiler
     prof = rpu.Profiler ('%s.bootstrap_3' % agent_name)
     log  = ru.get_logger('%s.bootstrap_3' % agent_name, 

--- a/src/radical/pilot/bootstrapper/default_bootstrapper.sh
+++ b/src/radical/pilot/bootstrapper/default_bootstrapper.sh
@@ -1343,7 +1343,7 @@ export RADICAL_PILOT_VERBOSE=DEBUG
 $PREBOOTSTRAP2_EXPANDED
 
 # start agent, forward arguments
-$AGENT_CMD "\$1" 1>"\$1.out" 2>"\$1.err"
+exec $AGENT_CMD "\$1" 1>"\$1.out" 2>"\$1.err"
 
 EOT
 

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -132,6 +132,7 @@ class Component(mp.Process):
         self._debug         = cfg.get('debug', 'DEBUG') # FIXME
         self._agent_name    = cfg['agent_name']
         self._cname         = "%s.%s.%d" % (self._agent_name, type(self).__name__, cfg.get('number', 0))
+        self._childname     = "%s.child" % self._cname
         self._addr_map      = cfg['bridge_addresses']
         self._parent        = os.getpid() # pid of spawning process
         self._inputs        = list()      # queues to get units from
@@ -170,6 +171,13 @@ class Component(mp.Process):
     @property
     def cname(self):
         return self._cname
+
+
+    # --------------------------------------------------------------------------
+    #
+    @property
+    def childname(self):
+        return self._childname
 
 
     # --------------------------------------------------------------------------
@@ -468,7 +476,7 @@ class Component(mp.Process):
 
 
         # set process name
-        self._cname = "%s.child" % self._cname
+        self._cname = self.childname
 
         try:
             import setproctitle as spt

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -467,12 +467,20 @@ class Component(mp.Process):
         signal.signal(signal.SIGTERM, sigterm_handler)
 
 
-        try:
-            dh = ru.DebugHelper()
+        # set process name
+        self._cname = "%s.child" % self._cname
 
+        try:
+            import setproctitle as spt
+            spt.setproctitle('radical.pilot %s' % self._cname)
+        except Exception as e:
+            pass
+
+
+        try:
             # configure the component's logger
-            log_name = self._cname
-            log_tgt  = self._cname + ".log"
+            log_name  = self._cname
+            log_tgt   = self._cname + ".log"
             self._log = ru.get_logger(log_name, log_tgt, self._debug)
             self._log.info('running %s' % self._cname)
 

--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -261,6 +261,12 @@ class PubsubZMQ(Pubsub):
             # ------------------------------------------------------------------
             def _bridge(addr_in, addr_out):
 
+                try:
+                    import setproctitle as spt
+                    spt.setproctitle('radical.pilot %s' % self._name)
+                except Exception as e:
+                    pass
+
               # self._log ('_bridge: %s %s' % (addr_in, addr_out))
                 ctx = zmq.Context()
                 _in = ctx.socket(zmq.XSUB)

--- a/src/radical/pilot/utils/queue.py
+++ b/src/radical/pilot/utils/queue.py
@@ -451,6 +451,13 @@ class QueueZMQ(Queue):
             # ------------------------------------------------------------------
             def _bridge(addr_in, addr_out):
 
+                try:
+                    import setproctitle as spt
+                    spt.setproctitle('radical.pilot %s' % self._name)
+                except Exception as e:
+                    pass
+
+
                 # FIXME: should we cache messages coming in at the pull/push 
                 #        side, so as not to block the push end?
 


### PR DESCRIPTION
This PR implements two (related) things:
  * make processes recognizable in `ps` output, at least in debug mode, but using 'setproctitle'
  * cleaner separate a component's and component's child name