### PR TITLE
Disable ntp for now.

### DIFF
--- a/src/radical/pilot/bootstrapper/default_bootstrapper.sh
+++ b/src/radical/pilot/bootstrapper/default_bootstrapper.sh
@@ -1305,6 +1305,12 @@ $converted_entry"
 done
 IFS=$OLD_IFS
 
+
+# we can't always lookup the ntp pool on compute nodes -- so do it once here,
+# and communicate the IP to the agent.  The agent may still not be able to
+# connect, but then a sensible timeout will kick in on ntplib.
+RADICAL_PILOT_NTPHOST=`dig +short 0.pool.ntp.org | grep -v "\.$" | head -n 1`
+
 # Before we start the (sub-)agent proper, we'll create a bootstrap_2.sh script
 # to do so.  For a single agent this is not needed -- but in the case where
 # we spawn out additional agent instances later, that script can be reused to
@@ -1338,6 +1344,9 @@ export SAGA_VERBOSE=DEBUG
 export RADICAL_VERBOSE=DEBUG
 export RADICAL_UTIL_VERBOSE=DEBUG
 export RADICAL_PILOT_VERBOSE=DEBUG
+
+# avoid ntphost lookups on compute nodes
+export RADICAL_PILOT_NTPHOST=$RADICAL_PILOT_NTPHOST
 
 # pass environment variables down so that module load becomes effective at
 # the other side too (e.g. sub-agents).

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -114,9 +114,9 @@ class Profiler (object):
         # We first try to contact a network time service for a timestamp, if that
         # fails we use the current system time.
         try:
-            assert True == False
             import ntplib
-            response = ntplib.NTPClient().request('0.pool.ntp.org')
+            ntphost  = os.environ.get('RADICAL_PILOT_NTPHOST', '0.pool.ntp.org')
+            response = ntplib.NTPClient().request(ntphost, timeout=2)
             timestamp_sys  = response.orig_time
             timestamp_abs  = response.tx_time
             return [timestamp_sys, timestamp_abs]

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -114,6 +114,7 @@ class Profiler (object):
         # We first try to contact a network time service for a timestamp, if that
         # fails we use the current system time.
         try:
+            assert True == False
             import ntplib
             response = ntplib.NTPClient().request('0.pool.ntp.org')
             timestamp_sys  = response.orig_time

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -36,7 +36,7 @@ class Profiler (object):
             self._enabled = False
             return
 
-        self._ts_zero, self._ts_abs = self._timestamp_init()
+        self._ts_zero, self._ts_abs, self._ts_mode = self._timestamp_init()
 
         self._name  = name
         self._handle = open("%s.prof"  % self._name, 'a')
@@ -46,8 +46,9 @@ class Profiler (object):
         #       and downstream analysis tools too!
         self._handle.write("#time,name,uid,state,event,msg\n")
         self._handle.write("%.4f,%s:%s,%s,%s,%s,%s\n" % \
-                (0.0, self._name, "", "", "", 'sync abs',
-                "%s:%s:%s" % (time.time(), self._ts_zero, self._ts_abs)))
+                           (0.0, self._name, "", "", "", 'sync abs',
+                            "%s:%s:%s:%s" % (self._ts_mode, time.time(),
+                                             self._ts_zero, self._ts_abs)))
 
 
     # ------------------------------------------------------------------------------
@@ -116,13 +117,13 @@ class Profiler (object):
         try:
             import ntplib
             ntphost  = os.environ.get('RADICAL_PILOT_NTPHOST', '0.pool.ntp.org')
-            response = ntplib.NTPClient().request(ntphost, timeout=2)
+            response = ntplib.NTPClient().request(ntphost, timeout=1)
             timestamp_sys  = response.orig_time
             timestamp_abs  = response.tx_time
-            return [timestamp_sys, timestamp_abs]
+            return [timestamp_sys, timestamp_abs, 'ntp']
         except:
             t = time.time()
-            return [t,t]
+            return [t,t, 'sys']
 
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
The timeout on ntplib.NTPClient().request() is only for the socket call, not for the name lookup.
In practice this comes down to 40 seconds per Profiler() instantiation when there is no outbound network connectivity.

You do the math ...

On the Crays the time of the systems seem to be in sync.