### PR TITLE
ZOMBIE PR!

### DIFF
--- a/examples/getting_started_remote.py
+++ b/examples/getting_started_remote.py
@@ -10,7 +10,7 @@ import radical.utils as ru
 dh = ru.DebugHelper ()
 
 CNT      =     0
-RUNTIME  =    10
+RUNTIME  =    20
 SLEEP    =     0
 CORES    =    64
 UNITS    =   128

--- a/src/radical/pilot/bootstrapper/default_bootstrapper.sh
+++ b/src/radical/pilot/bootstrapper/default_bootstrapper.sh
@@ -1309,7 +1309,7 @@ IFS=$OLD_IFS
 # we can't always lookup the ntp pool on compute nodes -- so do it once here,
 # and communicate the IP to the agent.  The agent may still not be able to
 # connect, but then a sensible timeout will kick in on ntplib.
-RADICAL_PILOT_NTPHOST=`dig +short 0.pool.ntp.org | grep -v "\.$" | head -n 1`
+RADICAL_PILOT_NTPHOST=`dig +short 0.pool.ntp.org | grep -v -e ";;" -e "\.$" | head -n 1`
 
 # Before we start the (sub-)agent proper, we'll create a bootstrap_2.sh script
 # to do so.  For a single agent this is not needed -- but in the case where

--- a/src/radical/pilot/configs/resource_epsrc.json
+++ b/src/radical/pilot/configs/resource_epsrc.json
@@ -59,7 +59,7 @@
         ],
         "default_remote_workdir"      : "/work/`id -gn`/`id -gn`/$USER",
         "valid_roots"                 : ["/work"],
-        "virtenv"                     : "/work/e290/shared/shared_pilot_ve_20150916/",
+        "virtenv"                     : "/work/e290/shared/shared_pilot_ve_20150924/",
         "virtenv_mode"                : "use",
         "rp_version"                  : "debug"
     }

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -114,7 +114,7 @@ class Profiler (object):
         # We first try to contact a network time service for a timestamp, if that
         # fails we use the current system time.
         try:
-            ntphost = os.environ.get('RADICAL_PILOT_NTPHOST', '0.pool.ntp.org').strip()
+            ntphost = os.environ.get('RADICAL_PILOT_NTPHOST', '').strip()
 
             if ntphost:
                 import ntplib

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -114,13 +114,13 @@ class Profiler (object):
         # We first try to contact a network time service for a timestamp, if that
         # fails we use the current system time.
         try:
-            ntphost = os.environ.get('RADICAL_PILOT_NTPHOST', '').strip()
+            ntphost = os.environ.get('RADICAL_PILOT_NTPHOST').strip()
 
             if ntphost:
                 import ntplib
                 response = ntplib.NTPClient().request(ntphost, timeout=1)
-                timestamp_sys  = response.orig_time
-                timestamp_abs  = response.tx_time
+                timestamp_sys = response.orig_time
+                timestamp_abs = response.tx_time
                 return [timestamp_sys, timestamp_abs, 'ntp']
         except:
             pass

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -100,7 +100,6 @@ class Profiler (object):
         #       and downstream analysis tools too!
         self._handle.write("%.4f,%s:%s,%s,%s,%s,%s\n" \
                 % (timestamp, self._name, tid, uid, state, event, msg))
-        self.flush()
 
 
     # --------------------------------------------------------------------------
@@ -115,15 +114,19 @@ class Profiler (object):
         # We first try to contact a network time service for a timestamp, if that
         # fails we use the current system time.
         try:
-            import ntplib
-            ntphost  = os.environ.get('RADICAL_PILOT_NTPHOST', '0.pool.ntp.org')
-            response = ntplib.NTPClient().request(ntphost, timeout=1)
-            timestamp_sys  = response.orig_time
-            timestamp_abs  = response.tx_time
-            return [timestamp_sys, timestamp_abs, 'ntp']
+            ntphost = os.environ.get('RADICAL_PILOT_NTPHOST', '0.pool.ntp.org').strip()
+
+            if ntphost:
+                import ntplib
+                response = ntplib.NTPClient().request(ntphost, timeout=1)
+                timestamp_sys  = response.orig_time
+                timestamp_abs  = response.tx_time
+                return [timestamp_sys, timestamp_abs, 'ntp']
         except:
-            t = time.time()
-            return [t,t, 'sys']
+            pass
+
+        t = time.time()
+        return [t,t, 'sys']
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -114,7 +114,7 @@ class Profiler (object):
         # We first try to contact a network time service for a timestamp, if that
         # fails we use the current system time.
         try:
-            ntphost = os.environ.get('RADICAL_PILOT_NTPHOST').strip()
+            ntphost = os.environ.get('RADICAL_PILOT_NTPHOST', '').strip()
 
             if ntphost:
                 import ntplib


### PR DESCRIPTION
Make ntp fully optional.
It is now only used when the ntp host resolves in the bootstrapper.
This commit also sneakily removes a prof.flush.