### PR TITLE
use POPEN for localhost

### DIFF
--- a/src/radical/pilot/configs/local.json
+++ b/src/radical/pilot/configs/local.json
@@ -18,7 +18,7 @@
         "lrms"                        : "FORK",
         "agent_type"                  : "multicore",
         "agent_scheduler"             : "CONTINUOUS",
-        "agent_spawner"               : "SHELL",
+        "agent_spawner"               : "POPEN",
         "task_launch_method"          : "FORK",
         "mpi_launch_method"           : "MPIEXEC",
         "rp_version"                  : "debug",


### PR DESCRIPTION
There is a lingering issue in the shell spawner which makes SHELL
unstable on localhost.  The fix is in devel, but instead of starting
to cherry-pick, it seems easier to switch to POPEN for the time being.

This relates to #747.