### PR TITLE
Hotfix/zmq autoport

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -145,7 +145,6 @@ import Queue
 import pprint
 import signal
 import shutil
-import socket
 import hostlist
 import tempfile
 import netifaces

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -2388,7 +2388,7 @@ class LRMS(object):
 
         # If there were no potentials, see if we can find one in the blacklist
         if not pref:
-            for iface in blacklist:
+            for iface in black_list:
                 if iface in all:
                     pref = iface
 

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -3907,7 +3907,8 @@ class AgentExecutingComponent_POPEN (AgentExecutingComponent) :
             self._log.exception("Error in ExecWorker watch loop (%s)" % e)
             # FIXME: this should signal the ExecWorker for shutdown...
 
-        self._prof.prof ('stop')
+        self._prof.prof('stop')
+        self._prof.flush()
 
 
     # --------------------------------------------------------------------------
@@ -4514,7 +4515,8 @@ class AgentExecutingComponent_SHELL(AgentExecutingComponent):
             self._log.exception("Exception in job monitoring thread: %s", e)
             self._terminate.set()
 
-        self._prof.prof ('stop')
+        self._prof.prof('stop')
+        self._prof.flush()
 
 
     # --------------------------------------------------------------------------
@@ -6044,6 +6046,7 @@ def bootstrap_3():
     finally:
         log.info('stop')
         prof.prof('stop', msg='finally clause agent')
+        prof.flush()
 
 
 

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -1991,6 +1991,7 @@ class LaunchMethodORTE(LaunchMethod):
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
 
+        dvm_uri = None
         while True:
 
             line = dvm_process.stdout.readline().strip()

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -385,8 +385,8 @@ class Component(mp.Process):
         if not isinstance(states, list):
             states = [states]
 
-        # check if a remote address is configured for the queue
-        addr = self._addr_map.get (input)
+        # get address for the queue
+        addr = self._addr_map[input]['source']
         self._log.debug("using addr %s for input %s" % (addr, input))
 
         q = rpu_Queue.create(rpu_QUEUE_ZMQ, input, rpu_QUEUE_OUTPUT, addr)
@@ -428,8 +428,8 @@ class Component(mp.Process):
                 # this indicates a final state
                 self._outputs[state] = None
             else:
-                # check if a remote address is configured for the queue
-                addr = self._addr_map.get (output)
+                # get address for the queue
+                addr = self._addr_map[output]['sink']
                 self._log.debug("using addr %s for output %s" % (addr, output))
 
                 # non-final state, ie. we want a queue to push to
@@ -503,8 +503,8 @@ class Component(mp.Process):
         if topic not in self._publishers:
             self._publishers[topic] = list()
 
-        # check if a remote address is configured for the queue
-        addr = self._addr_map.get (pubsub)
+        # get address for pubsub
+        addr = self._addr_map[pubsub]['sink']
         self._log.debug("using addr %s for pubsub %s" % (addr, pubsub))
 
         q = rpu_Pubsub.create(rpu_PUBSUB_ZMQ, pubsub, rpu_PUBSUB_PUB, addr)
@@ -550,8 +550,8 @@ class Component(mp.Process):
                     raise
         # ----------------------------------------------------------------------
 
-        # check if a remote address is configured for the queue
-        addr = self._addr_map.get (pubsub)
+        # get address for pubsub
+        addr = self._addr_map[pubsub]['source']
         self._log.debug("using addr %s for pubsub %s" % (addr, pubsub))
 
         # create a pubsub subscriber, and subscribe to the given topic

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import time
-import pprint
 import signal
 
 import threading       as mt

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -223,6 +223,7 @@ class Component(mp.Process):
         tear down component state after units have been processed.
         """
         self._log.debug('base finalize (NOOP)')
+        self._prof.flush()
 
 
     # --------------------------------------------------------------------------
@@ -327,6 +328,7 @@ class Component(mp.Process):
                 self._finalized = True
                 self.finalize()
                 self._prof.prof("finalized")
+                self._prof.flush()
             self.terminate()
 
         else:
@@ -335,6 +337,7 @@ class Component(mp.Process):
                 self._prof.prof("finalize")
                 self.finalize_child()
                 self._prof.prof("finalized")
+                self._prof.flush()
             sys.exit()
 
 
@@ -348,6 +351,7 @@ class Component(mp.Process):
             sys.exit()
 
         self._prof.prof("stopped")
+        self._prof.flush()
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -6,9 +6,7 @@ import time
 import errno
 import pprint
 import Queue           as pyq
-import threading       as mt
 import multiprocessing as mp
-import radical.utils   as ru
 
 # --------------------------------------------------------------------------
 # defines for pubsub roles

--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -74,7 +74,7 @@ class Pubsub(object):
         self._channel    = channel
         self._role       = role
         self._addr       = address
-        self._debug      = True
+        self._debug      = False
         self._logfd      = None
         self._name       = "pubsub.%s.%s" % (self._channel, self._role)
         self._bridge_in  = None           # bridge input  addr

--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -5,6 +5,7 @@ import json
 import time
 import errno
 import pprint
+import Queue           as pyq
 import threading       as mt
 import multiprocessing as mp
 import radical.utils   as ru
@@ -20,16 +21,8 @@ PUBSUB_ROLES  = [PUBSUB_PUB, PUBSUB_SUB, PUBSUB_BRIDGE]
 PUBSUB_ZMQ    = 'zmq'
 PUBSUB_TYPES  = [PUBSUB_ZMQ]
 
-# some predefined port numbers
-_PUBSUB_PORTS     = {
-        'client_command_pubsub'   : 'tcp://*:11000',
-        'agent_command_pubsub'    : 'tcp://*:11002',
-        'agent_unschedule_pubsub' : 'tcp://*:11004',
-        'agent_reschedule_pubsub' : 'tcp://*:11006',
-        'agent_state_pubsub'      : 'tcp://*:11008',
-    }
-
-_USE_MULTIPART = False
+_USE_MULTIPART  = False # send [topic, data] as multipart message
+_BRIDGE_TIMEOUT = 5.0   # how long to wait for bridge startup
 
 
 # --------------------------------------------------------------------------
@@ -59,39 +52,6 @@ def _uninterruptible(f, *args, **kwargs):
                 # real error, raise it
                 raise
 
-# --------------------------------------------------------------------------
-#
-# the pub-to-bridge end of the pubsub uses a different port than the
-# bridge-to-sub end...
-#
-def _port_inc(addr):
-
-    u = ru.Url(addr)
-    u.port += 1
-    return str(u)
-
-
-# --------------------------------------------------------------------------
-#
-# bridges by default bind to all interfaces on a given port, inputs and outputs
-# connect to localhost (127.0.0.1)
-# bridge-output end...
-#
-def _get_addr(name, role):
-
-    addr = _PUBSUB_PORTS.get(name)
-
-    if not addr:
-        raise LookupError("no addr for pubsub type '%s'" % name)
-
-    if role != PUBSUB_BRIDGE:
-        u = ru.Url(addr)
-        u.host = '127.0.0.1'
-        addr = str(u)
-
-    return addr
-
-
 # ==============================================================================
 #
 # Notifications between components are based on pubsub channels.  Those channels
@@ -104,29 +64,27 @@ class Pubsub(object):
     """
 
     def __init__(self, flavor, channel, role, address=None):
+        """
+        Addresses are of the form 'tcp://host:port'.  Both 'host' and 'port' can
+        be wildcards for BRIDGE roles -- the bridge will report the in and out
+        addresses as obj.bridge_in and obj.bridge_out.
+        """
 
-        self._flavor  = flavor
-        self._channel = channel
-        self._role    = role
-        self._addr    = ru.Url(address)
-        self._debug   = False
-        self._logfd   = None
-        self._name    = "pubsub.%s.%s" % (self._channel, self._role)
+        self._flavor     = flavor
+        self._channel    = channel
+        self._role       = role
+        self._addr       = address
+        self._debug      = True
+        self._logfd      = None
+        self._name       = "pubsub.%s.%s" % (self._channel, self._role)
+        self._bridge_in  = None           # bridge input  addr
+        self._bridge_out = None           # bridge output addr
 
         if 'msg' in os.environ.get('RADICAL_DEBUG', '').lower():
             self._debug = True
 
-        # sanity check on address
-        default_addr = ru.Url(_get_addr(self._channel, self._role))
-
-        # we replace only empty parts of the addr with default values
-        if not self._addr       : self._addr        = default_addr
-        if not self._addr.schema: self._addr.schema = default_addr.schema
-        if not self._addr.host  : self._addr.host   = default_addr.host
-        if not self._addr.port  : self._addr.port   = default_addr.port
-
         if not self._addr:
-            raise RuntimeError("no default address found for '%s'" % self._channel)
+            self._addr = 'tcp://*:*'
 
         self._log ("create %s - %s - %s" % (self._channel, self._role, self._addr))
 
@@ -177,6 +135,24 @@ class Pubsub(object):
             return impl(flavor, channel, role, address)
         except KeyError:
             raise RuntimeError("Pubsub type '%s' unknown!" % flavor)
+
+
+    # --------------------------------------------------------------------------
+    #
+    @property
+    def bridge_in(self):
+        if self._role != PUBSUB_BRIDGE:
+            raise TypeError('bridge_in is only defined on a bridge')
+        return self._bridge_in
+
+
+    # --------------------------------------------------------------------------
+    #
+    @property
+    def bridge_out(self):
+        if self._role != PUBSUB_BRIDGE:
+            raise TypeError('bridge_out is only defined on a bridge')
+        return self._bridge_out
 
 
     # --------------------------------------------------------------------------
@@ -239,22 +215,7 @@ class PubsubZMQ(Pubsub):
 
         Pubsub.__init__(self, flavor, channel, role, address)
 
-        self._p   = None           # the bridge process
-
-        # zmq checks on address
-        if  self._addr.path   != ''    or \
-            self._addr.schema != 'tcp' :
-            raise ValueError("url '%s' cannot be used for zmq pubsubs" % self._addr)
-
-        if self._addr.port:
-            if (self._addr.port % 2):
-                raise ValueError("port numbers must be even, not '%d'" % self._addr.port)
-
-        if self._role != PUBSUB_BRIDGE:
-            if self._addr.host == '*':
-                self._addr.host = '127.0.0.1'
-
-        self._log('%s/%s uses addr %s' % (self._channel, self._role, self._addr))
+        self._p = None  # the bridge process
 
 
         # ----------------------------------------------------------------------
@@ -269,8 +230,15 @@ class PubsubZMQ(Pubsub):
         # ----------------------------------------------------------------------
         elif self._role == PUBSUB_BRIDGE:
 
+            # we expect bridges to always use a port wildcard. Make sure
+            # that's the case
+            elems = self._addr.split(':')
+            if len(elems) > 2 and elems[2] and elems[2] != '*':
+                raise RuntimeError('wildcard port (*) required for bridge addresses (%s)' \
+                                % self._addr)
+
             # ------------------------------------------------------------------
-            def _bridge(addr_in, addr_out):
+            def _bridge(addr, pqueue):
 
                 try:
                     import setproctitle as spt
@@ -278,53 +246,72 @@ class PubsubZMQ(Pubsub):
                 except Exception as e:
                     pass
 
-              # self._log ('_bridge: %s %s' % (addr_in, addr_out))
-                ctx = zmq.Context()
-                _in = ctx.socket(zmq.XSUB)
-                _in.bind(addr_in)
+                try:
 
-                _out = ctx.socket(zmq.XPUB)
-                _out.bind(addr_out)
+                    self._log('start bridge %s on %s' % (self._name, addr))
 
-                _poll = zmq.Poller()
-                _poll.register(_in,  zmq.POLLIN)
-                _poll.register(_out, zmq.POLLIN)
+                    ctx = zmq.Context()
+                    _in = ctx.socket(zmq.XSUB)
+                    _in.bind(addr)
 
-                while True:
+                    _out = ctx.socket(zmq.XPUB)
+                    _out.bind(addr)
 
-                    _socks = dict(_uninterruptible(_poll.poll, timeout=1000)) # timeout in ms
+                    # communicate the bridge ports to the parent process
+                    _in_port  =  _in.getsockopt(zmq.LAST_ENDPOINT)
+                    _out_port = _out.getsockopt(zmq.LAST_ENDPOINT)
+                    self._log('bound bridge %s to %s : %s' % (self._name, _in_port, _out_port))
 
-                    if _in in _socks:
-                        if _USE_MULTIPART:
-                            msg = _uninterruptible(_in.recv_multipart, flags=zmq.NOBLOCK)
-                            _uninterruptible(_out.send_multipart, msg)
-                        else:
-                            msg = _uninterruptible(_in.recv, flags=zmq.NOBLOCK)
-                            _uninterruptible(_out.send, msg)
-                      # self._log("-> %s" % msg)
+                    pqueue.put([_in_port, _out_port])
+                    self._log('BOUND bridge %s to %s : %s' % (self._name, _in_port, _out_port))
+
+                    # start polling for messages
+                    _poll = zmq.Poller()
+                    _poll.register(_in,  zmq.POLLIN)
+                    _poll.register(_out, zmq.POLLIN)
+
+                    while True:
+
+                        _socks = dict(_uninterruptible(_poll.poll, timeout=1000)) # timeout in ms
+
+                        if _in in _socks:
+                            if _USE_MULTIPART:
+                                msg = _uninterruptible(_in.recv_multipart, flags=zmq.NOBLOCK)
+                                _uninterruptible(_out.send_multipart, msg)
+                            else:
+                                msg = _uninterruptible(_in.recv, flags=zmq.NOBLOCK)
+                                _uninterruptible(_out.send, msg)
+                          # self._log("-> %s" % msg)
 
 
-                    if _out in _socks:
-                        if _USE_MULTIPART:
-                            msg = _uninterruptible(_out.recv_multipart)
-                            _uninterruptible(_in.send_multipart, msg)
-                        else:
-                            msg = _uninterruptible(_out.recv)
-                            _uninterruptible(_in.send, msg)
-                      # self._log("<- %s" % msg)
+                        if _out in _socks:
+                            if _USE_MULTIPART:
+                                msg = _uninterruptible(_out.recv_multipart)
+                                _uninterruptible(_in.send_multipart, msg)
+                            else:
+                                msg = _uninterruptible(_out.recv)
+                                _uninterruptible(_in.send, msg)
+                          # self._log("<- %s" % msg)
+
+                except Exception as e:
+                    self._log('bridge error: %s' % e)
             # ------------------------------------------------------------------
 
-            addr_in  = str(self._addr)
-            addr_out = str(_port_inc(self._addr))
-            self._p  = mp.Process(target=_bridge, args=[addr_in, addr_out])
+            pqueue   = mp.Queue()
+            self._p  = mp.Process(target=_bridge, args=[self._addr, pqueue])
             self._p.start()
+
+            try:
+                self._bridge_in, self._bridge_out = pqueue.get(True, _BRIDGE_TIMEOUT)
+            except pyq.Empty as e:
+                raise RuntimeError ("bridge did not come up! (%s)" % e)
 
         # ----------------------------------------------------------------------
         elif self._role == PUBSUB_SUB:
 
             ctx = zmq.Context()
             self._q = ctx.socket(zmq.SUB)
-            self._q.connect(str(_port_inc(self._addr)))
+            self._q.connect(self._addr)
 
         # ----------------------------------------------------------------------
         else:

--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -315,7 +315,7 @@ class PubsubZMQ(Pubsub):
 
         # ----------------------------------------------------------------------
         else:
-            raise RuntimeError ("unsupported pubsub role '%s' (%s)" % (self._role, _PUBSUB_ROLES))
+            raise RuntimeError ("unsupported pubsub role '%s' (%s)" % (self._role, PUBSUB_ROLES))
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/utils/queue.py
+++ b/src/radical/pilot/utils/queue.py
@@ -149,7 +149,7 @@ class Queue(object):
         self._qname  = qname
         self._role   = role
         self._addr   = address
-        self._debug  = True
+        self._debug  = False
         self._logfd  = None
         self._name   = "queue.%s.%s" % (self._qname, self._role)
 

--- a/src/radical/pilot/utils/queue.py
+++ b/src/radical/pilot/utils/queue.py
@@ -22,19 +22,7 @@ QUEUE_PROCESS = 'process'
 QUEUE_ZMQ     = 'zmq'
 QUEUE_TYPES   = [QUEUE_THREAD, QUEUE_PROCESS, QUEUE_ZMQ]
 
-# some predefined port numbers
-_QUEUE_PORTS  = {
-        'pilot_launching_queue'      : 'tcp://*:10002',
-        'umgr_scheduling_queue'      : 'tcp://*:10004',
-        'umgr_staging_input_queue'   : 'tcp://*:10006',
-        'agent_staging_input_queue'  : 'tcp://*:10008',
-        'agent_scheduling_queue'     : 'tcp://*:10010',
-        'agent_executing_queue'      : 'tcp://*:10012',
-        'agent_staging_output_queue' : 'tcp://*:10014',
-        'umgr_staging_output_queue'  : 'tcp://*:10016',
-        'ping_queue'                 : 'tcp://*:20000',
-        'pong_queue'                 : 'tcp://*:20002',
-    }
+_BRIDGE_TIMEOUT = 5.0  # how long to wait for bridge startup
 
 # --------------------------------------------------------------------------
 #
@@ -62,39 +50,6 @@ def _uninterruptible(f, *args, **kwargs):
             else:
                 # real error, raise it
                 raise
-
-
-# --------------------------------------------------------------------------
-#
-# the input-to-bridge end of the queue uses a different port than the
-# bridge-to-output end...
-#
-def _port_inc(addr):
-
-    u = ru.Url(addr)
-    u.port += 1
-    return str(u)
-
-
-# --------------------------------------------------------------------------
-#
-# bridges by default bind to all interfaces on a given port, inputs and outputs
-# connect to localhost (127.0.0.1)
-# bridge-output end...
-#
-def _get_addr(name, role):
-
-    addr = _QUEUE_PORTS.get(name)
-
-    if not addr:
-        raise LookupError("no addr for queue type '%s'" % name)
-
-    if role != QUEUE_BRIDGE:
-        u = ru.Url(addr)
-        u.host = '127.0.0.1'
-        addr = str(u)
-
-    return addr
 
 
 # ==============================================================================
@@ -193,25 +148,16 @@ class Queue(object):
         self._flavor = flavor
         self._qname  = qname
         self._role   = role
-        self._addr   = ru.Url(address)
-        self._debug  = False
+        self._addr   = address
+        self._debug  = True
         self._logfd  = None
         self._name   = "queue.%s.%s" % (self._qname, self._role)
 
         if 'msg' in os.environ.get('RADICAL_DEBUG', '').lower():
             self._debug = True
 
-        # sanity check on address
-        default_addr = ru.Url(_get_addr(qname, role))
-
-        # we replace only empty parts of the addr with default values
-        if not self._addr       : self._addr        = default_addr
-        if not self._addr.schema: self._addr.schema = default_addr.schema
-        if not self._addr.host  : self._addr.host   = default_addr.host
-        if not self._addr.port  : self._addr.port   = default_addr.port
-
         if not self._addr:
-            raise RuntimeError("no default address found for '%s'" % self._qname)
+            self._addr = 'tcp://*:*'
 
         if role in [QUEUE_INPUT, QUEUE_OUTPUT]:
             self._log ("create %s - %s - %s - %s" % (flavor, qname, role, address))
@@ -345,7 +291,7 @@ class QueueThread(Queue):
 
         try:
             return self._q.get_nowait()
-        except Queue.Empty:
+        except pyq.Empty:
             return None
 
 
@@ -388,7 +334,7 @@ class QueueProcess(Queue):
 
         try:
             return self._q.get_nowait()
-        except Queue.Empty:
+        except pyq.Empty:
             return None
 
 
@@ -413,39 +359,18 @@ class QueueZMQ(Queue):
         and output type endpoints 'connect()' to it.  It is the callees
         responsibility to ensure that only one bridge of a given type exists.
 
-        All component will specify the same address.  Addresses are of the form
-        'tcp://ip-number:port'.  
-
-        Note that the address is both used for binding and connecting -- so if
-        any component lives on a remote host, all components need to use
-        a publicly visible ip number, ie. not '127.0.0.1/localhost'.  The
-        bridge-to-output communication needs to use a different port number than
-        the input-to-bridge communication.  To simplify setup, we expect
-        a single address to be used for all components, and will auto-increase
-        the bridge-output port by one.  All given port numbers should be *even*.
-
+        Addresses are of the form 'tcp://host:port'.  Both 'host' and 'port' can
+        be wildcards for BRIDGE roles -- the bridge will report the in and out
+        addresses as obj.bridge_in and obj.bridge_out.
         """
         Queue.__init__(self, flavor, name, role, address)
 
-        self._p         = None           # the bridge process
-        self._q         = None           # the zmq queue
-        self._lock      = mt.RLock()     # for _requested
-        self._requested = False          # send/recv sync
-
-        # zmq checks on address
-        if  self._addr.path   != ''    or \
-            self._addr.schema != 'tcp' :
-            raise ValueError("url '%s' cannot be used for zmq queues" % self._addr)
-
-        if self._addr.port:
-            if (self._addr.port % 2):
-                raise ValueError("port numbers must be even, not '%d'" % self._addr.port)
-
-        if self._role != QUEUE_BRIDGE:
-            if self._addr.host == '*':
-                self._addr.host = '127.0.0.1'
-
-        self._log('%s/%s uses addr %s' % (self._qname, self._role, self._addr))
+        self._p          = None           # the bridge process
+        self._q          = None           # the zmq queue
+        self._lock       = mt.RLock()     # for _requested
+        self._requested  = False          # send/recv sync
+        self._bridge_in  = None           # bridge input  addr
+        self._bridge_out = None           # bridge output addr
 
 
         # ----------------------------------------------------------------------
@@ -453,14 +378,21 @@ class QueueZMQ(Queue):
         if self._role == QUEUE_INPUT:
             ctx = zmq.Context()
             self._q = ctx.socket(zmq.PUSH)
-            self._q.connect(str(self._addr))
+            self._q.connect(self._addr)
 
 
         # ----------------------------------------------------------------------
         elif self._role == QUEUE_BRIDGE:
 
+            # we expect bridges to always use a port wildcard. Make sure
+            # that's the case
+            elems = self._addr.split(':')
+            if len(elems) > 2 and elems[2] and elems[2] != '*':
+                raise RuntimeError('wildcard port (*) required for bridge addresses (%s)' \
+                                % self._addr)
+
             # ------------------------------------------------------------------
-            def _bridge(addr_in, addr_out):
+            def _bridge(addr, pqueue):
 
                 try:
                     import setproctitle as spt
@@ -468,43 +400,57 @@ class QueueZMQ(Queue):
                 except Exception as e:
                     pass
 
+                try:
+                    self._log('start bridge %s on %s' % (self._name, addr))
 
-                # FIXME: should we cache messages coming in at the pull/push 
-                #        side, so as not to block the push end?
+                    # FIXME: should we cache messages coming in at the pull/push 
+                    #        side, so as not to block the push end?
 
-              # self._log ('in  _bridge: %s %s' % (addr_in, addr_out))
-                ctx = zmq.Context()
-                _in = ctx.socket(zmq.PULL)
-                _in.bind(addr_in)
+                    ctx = zmq.Context()
+                    _in = ctx.socket(zmq.PULL)
+                    _in.bind(addr)
 
-              # self._log ('out _bridge: %s %s' % (addr_in, addr_out))
-                _out = ctx.socket(zmq.REP)
-                _out.bind(addr_out)
+                    _out = ctx.socket(zmq.REP)
+                    _out.bind(addr)
 
-                _poll = zmq.Poller()
-                _poll.register(_out, zmq.POLLIN)
+                    # communicate the bridge ports to the parent process
+                    _in_port  =  _in.getsockopt(zmq.LAST_ENDPOINT)
+                    _out_port = _out.getsockopt(zmq.LAST_ENDPOINT)
+                    self._log('bound bridge %s to %s : %s' % (self._name, _in_port, _out_port))
 
-                while True:
+                    pqueue.put([_in_port, _out_port])
+                    self._log('BOUND bridge %s to %s : %s' % (self._name, _in_port, _out_port))
 
-                  # self._log ('run _bridge: %s %s' % (addr_in, addr_out))
+                    # start polling for messages
+                    _poll = zmq.Poller()
+                    _poll.register(_out, zmq.POLLIN)
 
-                    events = dict(_uninterruptible(_poll.poll, 1000)) # timeout in ms
+                    while True:
 
-                    if _out in events:
-                        req = _uninterruptible(_out.recv)
-                        _uninterruptible(_out.send_json, _uninterruptible(_in.recv_json))
+                        events = dict(_uninterruptible(_poll.poll, 1000)) # timeout in ms
+
+                        if _out in events:
+                            req = _uninterruptible(_out.recv)
+                            _uninterruptible(_out.send_json, _uninterruptible(_in.recv_json))
+
+                except Exception as e:
+                    self._log('bridge error: %s' % e)
             # ------------------------------------------------------------------
 
-            addr_in  = str(self._addr)
-            addr_out = str(_port_inc(self._addr))
-            self._p  = mp.Process(target=_bridge, args=[addr_in, addr_out])
+            pqueue   = mp.Queue()
+            self._p  = mp.Process(target=_bridge, args=[self._addr, pqueue])
             self._p.start()
+
+            try:
+                self._bridge_in, self._bridge_out = pqueue.get(True, _BRIDGE_TIMEOUT)
+            except pyq.Empty as e:
+                raise RuntimeError ("bridge did not come up! (%s)" % e)
 
         # ----------------------------------------------------------------------
         elif self._role == QUEUE_OUTPUT:
             ctx = zmq.Context()
             self._q = ctx.socket(zmq.REQ)
-            self._q.connect(str(_port_inc(self._addr)))
+            self._q.connect(self._addr)
 
         # ----------------------------------------------------------------------
         else:
@@ -516,6 +462,24 @@ class QueueZMQ(Queue):
     def __del__(self):
 
         self.stop()
+
+
+    # --------------------------------------------------------------------------
+    #
+    @property
+    def bridge_in(self):
+        if self._role != QUEUE_BRIDGE:
+            raise TypeError('bridge_in is only defined on a bridge')
+        return self._bridge_in
+
+
+    # --------------------------------------------------------------------------
+    #
+    @property
+    def bridge_out(self):
+        if self._role != QUEUE_BRIDGE:
+            raise TypeError('bridge_out is only defined on a bridge')
+        return self._bridge_out
 
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
Queue and Pubsub bridges now find free ports on their own

This implies that we need to inspect the bridges for the used addresses afterwards, and that we need to communicate both ends (sink and source) to the agent components individually.

Further, as the addresses are now only known *after* starting the bridges, we need to move the bridge startup (and shutdown) into bootstrap_3, before creating the AgentWorker, as that already tries to connect to the bridges.
