### PR TITLE
Add 'br0' to list of preferred interface names.

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -2364,7 +2364,11 @@ class LRMS(object):
         black_list = ['lo', 'sit0']
 
         # Known intefaces in preferred order
-        sorted_preferred = ['ipogif0', 'eth0']
+        sorted_preferred = [
+            'ipogif0', # Cray's
+            'br0', # SuperMIC
+            'eth0'
+        ]
         
         # Get a list of all network interfaces
         all = netifaces.interfaces()


### PR DESCRIPTION
Fixes #789 and possibly some more.