### PR TITLE
Allow Session to function as context manager for `with`

### DIFF
--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -213,6 +213,18 @@ class Session (saga.Session):
 
 
     #---------------------------------------------------------------------------
+    # Allow Session to function as a context manager in a `with` clause
+    def __enter__ (self):
+        return self
+
+
+    #---------------------------------------------------------------------------
+    # Allow Session to function as a context manager in a `with` clause
+    def __exit__ (self, type, value, traceback) :
+        self.close()
+
+
+    #---------------------------------------------------------------------------
     #
     def __del__ (self) :
         pass


### PR DESCRIPTION
defines `Session.__enter__()` and `Session.__exit__()` so that `Session.close()` will be called when exiting a `with` clause. E.g.

    with Session() as session:
        # do stuff with session
    # session.close() has been called 