### PR TITLE
Build sdist in bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ def get_version (mod_root):
         sdist_name = sdist_name.replace ('@', '-')
         sdist_name = sdist_name.replace ('#', '-')
         sdist_name = sdist_name.replace ('_', '-')
-        if '--record'  in sys.argv or 'bdist_egg' in sys.argv:
+        if '--record'  in sys.argv or 'bdist_egg' in sys.argv or 'bdist_wheel' in sys.argv:
            # pip install stage 2      easy_install stage 1
            # NOTE: pip install will untar the sdist in a tmp tree.  In that tmp
            # tree, we won't be able to derive git version tags -- so we pack the


### PR DESCRIPTION
With this change, the sdist is included in the wheel when I build radical.pilot using `pip wheel`. I suspect that a similar change would work for radical.utils and saga-python.