### PR TITLE
Fix/state ordering

### DIFF
--- a/src/radical/pilot/states.py
+++ b/src/radical/pilot/states.py
@@ -96,3 +96,4 @@ AGENT_STAGING_OUTPUT_PENDING = 'AgentStagingOutputPending'
 AGENT_STAGING_OUTPUT         = 'AgentStagingOutput'
 PENDING_OUTPUT_STAGING       = 'PendingOutputStaging'
 STAGING_OUTPUT               = 'StagingOutput'
+

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -412,16 +412,15 @@ def drop_units(cfg, units, name, mode, prof=None, logger=None):
         return units
 
     if not units:
-        # nothing to drop
-        if logger:
-            logger.debug('no units - no dropping')
+      # if logger:
+      #     logger.debug('no units - no dropping')
         return units
 
     drop = cfg.get('drop', {}).get(name, {}).get(mode, 1)
 
     if drop == 0:
-        if logger:
-            logger.debug('dropped nothing')
+      # if logger:
+      #     logger.debug('dropped nothing')
         return units
 
     return_list = True
@@ -432,6 +431,8 @@ def drop_units(cfg, units, name, mode, prof=None, logger=None):
     if drop == 2:
         if logger:
             logger.debug('dropped everything')
+            for unit in units:
+                logger.debug('dropped %s', unit['_id'])
         if return_list: return []
         else          : return None
 
@@ -443,19 +444,17 @@ def drop_units(cfg, units, name, mode, prof=None, logger=None):
     for unit in units :
         if '.clone_' not in unit['_id']:
             ret.append(unit)
-            if logger:
-                logger.debug('dropped not %s', unit['_id'])
+          # if logger:
+          #     logger.debug('dropped not %s', unit['_id'])
         else:
             if logger:
-                logger.debug('dropped     %s', unit['_id'])
+                logger.debug('dropped %s', unit['_id'])
 
     if return_list: 
         return ret
     else: 
-        if ret:
-            return ret[0]
-        else:
-            return None
+        if ret: return ret[0]
+        else  : return None
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## enforce unit state ordering before pushing db updates
This removes the sleep-based 'ordering'.  Also in this commit:

  - subscriber threads are now watched by the component, and failures propagate
  - logging noise decreases for non-blowup scenarios
  - rename: component._threads -> component._subscribers

This needs thorough testing.  The code also needs to kept in sync with state
model evolution, and should be moved to the module side after refactoring.
Until that happens, there can only be one instance of an UpdateWorker per agent
instance.