### PR TITLE
Only break out when we can't schedule.

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -592,6 +592,8 @@ class AgentSchedulingComponent(rpu.Component):
                 with self._wait_lock :
                     self._wait_pool.remove(cu)
                     self._prof.prof('unqueue', msg="re-allocation done", uid=cu['_id'])
+            else:
+                # Break out of this loop if we didn't manage to schedule a task
                 break
 
         # Note: The extra space below is for visual alignment


### PR DESCRIPTION
This is a data supported incrmental change to the recent scheduler change.
In the previous incarnation we would gradually reach a lower number of
concurrent cores as we would never allocate more than one new, even if multiple
units had completed.

This is probably not a great change though in the light of mixed size units.