### PR TITLE
Feature/clone cb

### DIFF
--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -451,9 +451,15 @@ class AgentSchedulingComponent(rpu.Component):
         # all components use the command channel for control messages
         self.declare_publisher ('command', rp.AGENT_COMMAND_PUBSUB)
 
-        # we declare a drop callback, so that cored allocated to clones can be
-        # freed again
-        self.declare_drop_cb(self.drop_cb)
+        # we declare a clone and a drop callback, so that cores can be assigned
+        # to clones, and can also be freed again.
+        self.declare_clone_cb(self.clone_cb)
+        self.declare_drop_cb (self.drop_cb)
+
+        # when cloning, we fake scheduling via round robin over all cores.
+        # These indexes keeps track of the last used core.
+        self._clone_slot_idx = 0
+        self._clone_core_idx = 0
 
         # The scheduler needs the LRMS information which have been collected
         # during agent startup.  We dig them out of the config at this point.
@@ -632,6 +638,48 @@ class AgentSchedulingComponent(rpu.Component):
 
         # Note: The extra space below is for visual alignment
         self._log.info("slot status after  unschedule: %s" % self.slot_status ())
+
+
+    # --------------------------------------------------------------------------
+    #
+    def clone_cb(self, unit, name=None, mode=None, prof=None, logger=None):
+
+        if mode == 'output':
+
+            # so, this is tricky: we want to clone the unit after scheduling,
+            # but at the same time don't want to have all clones end up on the
+            # same core -- so the clones should be scheduled to a different (set
+            # of) core(s).  But also, we don't really want to schedule, that is
+            # why we blow up on output, right?
+            #
+            # So we fake scheduling.  This assumes the 'self.slots' structure as
+            # used by the continuous scheduler, wo will likely only work for
+            # this one (FIXME): we walk our own index into the slot structure,
+            # and simply assign that core, be it busy or not.
+            #
+            # FIXME: This method makes no attempt to set 'task_slots', so will
+            # not work properly for some launch methods.
+            #
+            # This is awful.  I mean, really awful.  Like, nothing good can come
+            # out of this.  Ticket #902 should be implemented, it will solve
+            # this problem much cleaner...
+
+            if prof: prof.prof      ('clone_cb', uid=unit['_id'])
+            else   : self._prof.prof('clone_cb', uid=unit['_id'])
+
+            slot = self.slots[self._clone_slot_idx]
+
+            unit['opaque_slots']['task_slots'][0] = '%s:%d' % (slot['node'], self._clone_core_idx)
+          # self._log.debug(' === clone cb out : %s', unit['opaque_slots'])
+
+            if (self._clone_core_idx +  1) < self._lrms_cores_per_node:
+                self._clone_core_idx += 1
+            else:
+                self._clone_core_idx  = 0
+                self._clone_slot_idx += 1
+
+                if self._clone_slot_idx >= len(self.slots):
+                    self._clone_slot_idx = 0
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/radical-pilot-agent-multicore.py
+++ b/src/radical/pilot/agent/radical-pilot-agent-multicore.py
@@ -677,7 +677,8 @@ class AgentSchedulingComponent(rpu.Component):
 
             slot = self.slots[self._clone_slot_idx]
 
-            unit['opaque_slots']['task_slots'][0] = '%s:%d' % (slot['node'], self._clone_core_idx)
+            unit['opaque_slots']['task_slots'][0] = '%s:%d' \
+                    % (slot['node'], self._clone_core_idx)
           # self._log.debug(' === clone cb out : %s', unit['opaque_slots'])
 
             if (self._clone_core_idx +  1) < self._lrms_cores_per_node:

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -730,7 +730,7 @@ class Component(mp.Process):
                                 uid=uid, msg=input.name)
                         continue
 
-                    units = clone_units(self._cfg, unit, self.ctype, 'input', 
+                    units = clone_units(self._cfg, unit, self.ctype, 'input',
                                         clone_cb=self._clone_cb, logger=self._log)
 
                     for _unit in units:
@@ -877,8 +877,8 @@ class Component(mp.Process):
                 if not unit:
                     self._prof.prof(event='drop', state=state, uid=uid, msg=output.name)
                     continue
-               
-                units = clone_units(self._cfg, unit, self.ctype, 'output', 
+
+                units = clone_units(self._cfg, unit, self.ctype, 'output',
                                     clone_cb=self._clone_cb, logger=self._log)
 
                 for _unit in units:

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -154,6 +154,7 @@ class Component(mp.Process):
         self._is_parent     = None        # guard initialize/initialize_child
         self._exit_on_error = True        # FIXME: make configurable
         self._cb_lock       = mt.Lock()   # guard threaded callback invokations
+        self._clone_cb      = None        # allocate resources on cloning units
         self._drop_cb       = None        # free resources on dropping clones
 
         # use agent_name for one log per agent, cname for one log per agent and component
@@ -593,6 +594,19 @@ class Component(mp.Process):
 
     # --------------------------------------------------------------------------
     #
+    def declare_clone_cb(self, clone_cb):
+        """
+        The clone callback will be invoked whenever a unit is cloned after
+        passing this component.  So, whenever the component allocates some
+        resources for a unit which would conflict when being cloned, this
+        callback allows to perform the required correction (hi scheduler!).
+        """
+        self._log.debug('declare clone_cb %s (%s)', clone_cb, os.getpid())
+        self._clone_cb = clone_cb
+
+
+    # --------------------------------------------------------------------------
+    #
     def declare_drop_cb(self, drop_cb):
         """
         The drop callback will be invoked whenever a unit is dropped after
@@ -715,7 +729,8 @@ class Component(mp.Process):
                                 uid=uid, msg=input.name)
                         continue
 
-                    units = clone_units(self._cfg, unit, self.ctype, 'input', logger=self._log)
+                    units = clone_units(self._cfg, unit, self.ctype, 'input', 
+                                        clone_cb=self._clone_cb, logger=self._log)
 
                     for _unit in units:
 
@@ -856,7 +871,8 @@ class Component(mp.Process):
                     self._prof.prof(event='drop', state=state, uid=uid, msg=output.name)
                     continue
                
-                units = clone_units(self._cfg, unit, self.ctype, 'output', logger=self._log)
+                units = clone_units(self._cfg, unit, self.ctype, 'output', 
+                                    clone_cb=self._clone_cb, logger=self._log)
 
                 for _unit in units:
                     # FIXME: we should assert that the unit is in a PENDING state.

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -469,12 +469,17 @@ def drop_clones(cfg, units, name, mode, drop_cb=None, prof=None, logger=None):
 
 # ------------------------------------------------------------------------------
 #
-def clone_units(cfg, units, name, mode, prof=None, logger=None):
+def clone_units(cfg, units, name, mode, prof=None, clone_cb=None, logger=None):
     """
     For each unit in units, add 'factor' clones just like it, just with
     a different ID (<id>.clone_001).  The factor depends on the context of
     this clone call (ie. the queue name), and on mode (which is 'input' or
     'output').  This methid will always return a list.
+
+    For each cloned unit, we check if 'clone_cb' is defined, and call
+    that callback if that is the case, with the signature:
+
+      clone_cb(unit=unit, name=name, mode=mode, prof=prof, logger=logger)
     """
 
     if units == None:
@@ -523,6 +528,9 @@ def clone_units(cfg, units, name, mode, prof=None, logger=None):
 
             idx += 1
             ret.append(clone)
+
+            if clone_cb:
+               clone_cb(unit=clone, name=name, mode=mode, prof=prof, logger=logger)
 
         # Append the original cu last, to increase the likelyhood that
         # application state only advances once all clone states have also

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -530,7 +530,7 @@ def clone_units(cfg, units, name, mode, prof=None, clone_cb=None, logger=None):
             ret.append(clone)
 
             if clone_cb:
-               clone_cb(unit=clone, name=name, mode=mode, prof=prof, logger=logger)
+                clone_cb(unit=clone, name=name, mode=mode, prof=prof, logger=logger)
 
         # Append the original cu last, to increase the likelyhood that
         # application state only advances once all clone states have also


### PR DESCRIPTION
This PR is symmetric to the recent `feature/drop_cb`: it supports a similar callback on cloning units.  The commit should be semantically void if no blowup is used.  This code has been tested and used in the micro benchmarks -- the `clone_cb` (crudely) avoids the case where cloned units end up on the same target core.