### PR TITLE
add PYTHONPATH to the vars we reset for CU envs

### DIFF
--- a/src/radical/pilot/agent/executing/abds.py
+++ b/src/radical/pilot/agent/executing/abds.py
@@ -137,6 +137,10 @@ class ABDS(AgentExecutingComponent):
         if old_path:
             new_env['PATH'] = old_path
 
+        old_ppath = new_env.pop('_OLD_VIRTUAL_PYTHONPATH', None)
+        if old_ppath:
+            new_env['PYTHONPATH'] = old_ppath
+
         old_home = new_env.pop('_OLD_VIRTUAL_PYTHONHOME', None)
         if old_home:
             new_env['PYTHON_HOME'] = old_home

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -129,6 +129,10 @@ class Popen(AgentExecutingComponent) :
         if old_path:
             new_env['PATH'] = old_path
 
+        old_ppath = new_env.pop('_OLD_VIRTUAL_PYTHONPATH', None)
+        if old_ppath:
+            new_env['PYTHONPATH'] = old_ppath
+
         old_home = new_env.pop('_OLD_VIRTUAL_PYTHONHOME', None)
         if old_home:
             new_env['PYTHON_HOME'] = old_home

--- a/src/radical/pilot/agent/executing/shell.py
+++ b/src/radical/pilot/agent/executing/shell.py
@@ -51,22 +51,25 @@ class Shell(AgentExecutingComponent):
         # Mimic what virtualenv's "deactivate" would do
         self._deactivate = "# deactivate pilot virtualenv\n"
 
-        old_path = os.environ.get('_OLD_VIRTUAL_PATH',       None)
-        old_home = os.environ.get('_OLD_VIRTUAL_PYTHONHOME', None)
-        old_ps1  = os.environ.get('_OLD_VIRTUAL_PS1',        None)
+        old_path  = os.environ.get('_OLD_VIRTUAL_PATH',       None)
+        old_ppath = os.environ.get('_OLD_VIRTUAL_PYTHONPATH', None)
+        old_home  = os.environ.get('_OLD_VIRTUAL_PYTHONHOME', None)
+        old_ps1   = os.environ.get('_OLD_VIRTUAL_PS1',        None)
 
-        if old_path: self._deactivate += 'export PATH="%s"\n'        % old_path
-        if old_home: self._deactivate += 'export PYTHON_HOME="%s"\n' % old_home
-        if old_ps1:  self._deactivate += 'export PS1="%s"\n'         % old_ps1
+        if old_ppath: self._deactivate += 'export PATH="%s"\n'        % old_ppath
+        if old_path : self._deactivate += 'export PYTHONPATH="%s"\n'  % old_path
+        if old_home : self._deactivate += 'export PYTHON_HOME="%s"\n' % old_home
+        if old_ps1  : self._deactivate += 'export PS1="%s"\n'         % old_ps1
 
         self._deactivate += 'unset VIRTUAL_ENV\n\n'
 
         # FIXME: we should not alter the environment of the running agent, but
         #        only make sure that the CU finds a pristine env.  That also
         #        holds for the unsetting below -- AM
-        if old_path: os.environ['PATH']        = old_path
-        if old_home: os.environ['PYTHON_HOME'] = old_home
-        if old_ps1:  os.environ['PS1']         = old_ps1
+        if old_path : os.environ['PATH']        = old_path
+        if old_ppath: os.environ['PYTHONPATH']  = old_ppath
+        if old_home : os.environ['PYTHON_HOME'] = old_home
+        if old_ps1  : os.environ['PS1']         = old_ps1
 
         if 'VIRTUAL_ENV' in os.environ :
             del(os.environ['VIRTUAL_ENV'])

--- a/src/radical/pilot/bootstrapper/bootstrap_1.sh
+++ b/src/radical/pilot/bootstrapper/bootstrap_1.sh
@@ -717,6 +717,10 @@ virtenv_activate()
     RP_MOD_PREFIX=`echo $VE_MOD_PREFIX | sed -e "s|$virtenv|$virtenv/rp_install|"`
     VE_PYTHONPATH="$PYTHONPATH"
 
+    # before we change PYTHONPATH, we keep the original for later use in CU
+    # environment settings
+    _OLD_VIRTUAL_PYTHONPATH=$PYTHONPATH
+
     # NOTE: this should not be necessary, but we explicit set PYTHONPATH to
     #       include the VE module tree, because some systems set a PYTHONPATH on
     #       'module load python', and that would supersede the VE module tree,
@@ -1298,6 +1302,7 @@ virtenv_activate "$VIRTENV" "$PYTHON_DIST"
 # Export the variables related to virtualenv,
 # so that we can disable the virtualenv for the cu.
 export _OLD_VIRTUAL_PATH
+export _OLD_VIRTUAL_PYTHONPATH
 export _OLD_VIRTUAL_PYTHONHOME
 export _OLD_VIRTUAL_PS1
 


### PR DESCRIPTION
This fixes the problem that a unit failed to create/use a Python VE with any radical module installed (e.g.  `radical.synapse`), as the `radical` namespace conflicts with the one in `rp_install`, which `PYTHONPATH` still pointed  to.  `PYTHONPATH` is now reset to the value it had before bootstrapping, thus avoiding that problem.