### PR TITLE
make orte-submit aware of non-mpi CUs

### DIFF
--- a/src/radical/pilot/agent/lm/orte.py
+++ b/src/radical/pilot/agent/lm/orte.py
@@ -186,6 +186,7 @@ class ORTE(LaunchMethod):
         cud          = cu['description']
         task_exec    = cud['executable']
         task_cores   = cud['cores']
+        task_mpi     = cud.get('mpi')       or False
         task_args    = cud.get('arguments') or []
         task_argstr  = self._create_arg_string(task_args)
 
@@ -230,8 +231,13 @@ class ORTE(LaunchMethod):
             #'--mca oob_base_verbose 100',
             #'--mca rml_base_verbose 100'
         ]
-        orte_command = '%s %s --hnp "%s" %s -np %s -host %s %s' % (
-            self.launch_command, ' '.join(debug_strings), dvm_uri, export_vars, task_cores, hosts_string, task_command)
+
+        if task_mpi: np_flag = '-np %s' % task_cores
+        else       : np_flag = '-np 1'
+
+        orte_command = '%s %s --hnp "%s" %s %s -host %s %s' % (self.launch_command, 
+                ' '.join(debug_strings), dvm_uri, export_vars, np_flag, 
+                hosts_string, task_command)
 
         return orte_command, None
 


### PR DESCRIPTION
it now allocates the same set of cores to the CU, but only creates one
application instance when cud['mpi'] == False