### PR TITLE
use high water mark for ZMQ to avoid message drops on high loads

### DIFF
--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -24,7 +24,7 @@ PUBSUB_TYPES  = [PUBSUB_ZMQ]
 _USE_MULTIPART   =  False  # send [topic, data] as multipart message
 _BRIDGE_TIMEOUT  =      1  # how long to wait for bridge startup
 _LINGER_TIMEOUT  =    250  # ms to linger after close
-_HIGH_WATER_MARK = 100000  # number of messages to buffer before dropping
+_HIGH_WATER_MARK =      0  # number of bytes to buffer before dropping
 
 
 # --------------------------------------------------------------------------

--- a/src/radical/pilot/utils/queue.py
+++ b/src/radical/pilot/utils/queue.py
@@ -25,7 +25,7 @@ QUEUE_TYPES   = [QUEUE_THREAD, QUEUE_PROCESS, QUEUE_ZMQ]
 
 _BRIDGE_TIMEOUT  =      1  # how long to wait for bridge startup
 _LINGER_TIMEOUT  =    250  # ms to linger after close
-_HIGH_WATER_MARK = 100000  # number of messages to buffer before dropping
+_HIGH_WATER_MARK =      0  # number of bytes to buffer before dropping
 
 # --------------------------------------------------------------------------
 #

--- a/src/radical/pilot/utils/queue.py
+++ b/src/radical/pilot/utils/queue.py
@@ -23,7 +23,9 @@ QUEUE_PROCESS = 'process'
 QUEUE_ZMQ     = 'zmq'
 QUEUE_TYPES   = [QUEUE_THREAD, QUEUE_PROCESS, QUEUE_ZMQ]
 
-_BRIDGE_TIMEOUT = 5.0  # how long to wait for bridge startup
+_BRIDGE_TIMEOUT  =      1  # how long to wait for bridge startup
+_LINGER_TIMEOUT  =    250  # ms to linger after close
+_HIGH_WATER_MARK = 100000  # number of messages to buffer before dropping
 
 # --------------------------------------------------------------------------
 #
@@ -46,7 +48,6 @@ def _uninterruptible(f, *args, **kwargs):
                 if cnt > 10:
                     raise
                 # interrupted, try again
-                print 'interrupted! [%s] [%s] [%s]' % (f, args, kwargs)
                 continue
             else:
                 # real error, raise it
@@ -366,6 +367,8 @@ class QueueZMQ(Queue):
         if self._role == QUEUE_INPUT:
             ctx = zmq.Context()
             self._q = ctx.socket(zmq.PUSH)
+            self._q.linger = _LINGER_TIMEOUT
+            self._q.hwm    = _HIGH_WATER_MARK
             self._q.connect(self._addr)
 
 
@@ -401,9 +404,13 @@ class QueueZMQ(Queue):
 
                     ctx = zmq.Context()
                     _in = ctx.socket(zmq.PULL)
+                    _in.linger = _LINGER_TIMEOUT
+                    _in.hwm    = _HIGH_WATER_MARK
                     _in.bind(addr)
 
                     _out = ctx.socket(zmq.REP)
+                    _out.linger = _LINGER_TIMEOUT
+                    _out.hwm    = _HIGH_WATER_MARK
                     _out.bind(addr)
 
                     # communicate the bridge ports to the parent process
@@ -443,6 +450,8 @@ class QueueZMQ(Queue):
         elif self._role == QUEUE_OUTPUT:
             ctx = zmq.Context()
             self._q = ctx.socket(zmq.REQ)
+            self._q.linger = _LINGER_TIMEOUT
+            self._q.hwm    = _HIGH_WATER_MARK
             self._q.connect(self._addr)
 
         # ----------------------------------------------------------------------


### PR DESCRIPTION
the 'linger' timeout make sure the sockets don't stay around after shutdown.  that was the default in earlier versions of pyzmq, but isn't anymore...