### PR TITLE
Disable vnode splitting.

### DIFF
--- a/src/radical/pilot/agent/rm/pbspro.py
+++ b/src/radical/pilot/agent/rm/pbspro.py
@@ -144,7 +144,9 @@ class PBSPro(LRMS):
         node_list = []
         for vnode in vnodes_list:
             # strip the last _0 of the vnodes to get the node name
-            node_list.append(vnode.rsplit('_', 1)[0])
+            # Disabled as ARCHER no longer splits the nodes into multiple vnodes it seems
+            # vnode = vnode.rsplit('_', 1)[0]
+            node_list.append(vnode)
 
         # only unique node names
         node_list = list(set(node_list))


### PR DESCRIPTION
Fix for changed ARCHER vnode format. Neither the original nor the new is perfect, but currently this is the only PBS Pro installation we have and its pretty non-parseable.