### PR TITLE
Move env safekeeping until after the pre bootstrap.

### DIFF
--- a/src/radical/pilot/bootstrapper/bootstrap_1.sh
+++ b/src/radical/pilot/bootstrapper/bootstrap_1.sh
@@ -60,18 +60,6 @@ VIRTENV_TGZ="virtualenv-1.9.tar.gz"
 VIRTENV_IS_ACTIVATED=FALSE
 VIRTENV_RADICAL_DEPS="pymongo==2.8 apache-libcloud colorama python-hostlist ntplib pyzmq netifaces==0.10.4 setproctitle"
 
-# before we change anything else in the pilot environment, we safe a couple of
-# env vars to later re-create a close-to-pristine env for unit execution.
-_OLD_VIRTUAL_PYTHONPATH="$PYTHONPATH"
-_OLD_VIRTUAL_PYTHONHOME="$PYTHONHOME"
-_OLD_VIRTUAL_PATH="$PATH"
-_OLD_VIRTUAL_PS1="$PS1"
-
-export _OLD_VIRTUAL_PYTHONPATH
-export _OLD_VIRTUAL_PYTHONHOME
-export _OLD_VIRTUAL_PATH
-export _OLD_VIRTUAL_PS1
-
 
 # ------------------------------------------------------------------------------
 #
@@ -1232,6 +1220,18 @@ while getopts "a:b:cd:e:f:h:i:m:p:r:s:t:v:w:x" OPTION; do
         *)  usage "Unknown option: '$OPTION'='$OPTARG'"  ;;
     esac
 done
+
+# before we change anything else in the pilot environment, we safe a couple of
+# env vars to later re-create a close-to-pristine env for unit execution.
+_OLD_VIRTUAL_PYTHONPATH="$PYTHONPATH"
+_OLD_VIRTUAL_PYTHONHOME="$PYTHONHOME"
+_OLD_VIRTUAL_PATH="$PATH"
+_OLD_VIRTUAL_PS1="$PS1"
+
+export _OLD_VIRTUAL_PYTHONPATH
+export _OLD_VIRTUAL_PYTHONHOME
+export _OLD_VIRTUAL_PATH
+export _OLD_VIRTUAL_PS1
 
 # TODO: Move earlier, because if pre_bootstrap fails, this is not yet set
 LOGFILES_TARBALL="$PILOTID.log.tgz"


### PR DESCRIPTION
Without this, anything added to PATH during prebootstrap1 is not persistent
after ve activation.
This was triggered by the installation of orte_cffi where ompi_info could not
be found on the path.