### PR TITLE
Add config `.json` file for FU Berlin allegro cluster

### DIFF
--- a/src/radical/pilot/agent/lm/aprun.py
+++ b/src/radical/pilot/agent/lm/aprun.py
@@ -3,6 +3,8 @@ __copyright__ = "Copyright 2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
 
+import radical.utils as ru
+
 from .base import LaunchMethod
 
 
@@ -21,7 +23,7 @@ class APRun(LaunchMethod):
     #
     def _configure(self):
         # aprun: job launcher for Cray systems
-        self.launch_command= self._which('aprun')
+        self.launch_command= ru.which('aprun')
 
         # TODO: ensure that only one concurrent aprun per node is executed!
 

--- a/src/radical/pilot/agent/lm/base.py
+++ b/src/radical/pilot/agent/lm/base.py
@@ -209,42 +209,20 @@ class LaunchMethod(object):
     #
     @classmethod
     def _find_executable(cls, names):
-        """Takes a (list of) name(s) and looks for an executable in the path.
+        """
+        Takes a (list of) name(s) and looks for an executable in the path.  It
+        will return the first match found, or `None` if none of the given names
+        is found.
         """
 
         if not isinstance(names, list):
             names = [names]
 
         for name in names:
-            ret = cls._which(name)
-            if ret is not None:
+            ret = ru.which(name)
+            if ret:
                 return ret
 
-        return None
-
-
-    # --------------------------------------------------------------------------
-    #
-    @classmethod
-    def _which(cls, program):
-        """Finds the location of an executable.
-        Taken from:
-        http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
-        """
-        # ----------------------------------------------------------------------
-        #
-        def is_exe(fpath):
-            return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-        fpath, _ = os.path.split(program)
-        if fpath:
-            if is_exe(program):
-                return program
-        else:
-            for path in os.environ["PATH"].split(os.pathsep):
-                exe_file = os.path.join(path, program)
-                if is_exe(exe_file):
-                    return exe_file
         return None
 
 

--- a/src/radical/pilot/agent/lm/base.py
+++ b/src/radical/pilot/agent/lm/base.py
@@ -8,6 +8,8 @@ import fractions
 import tempfile
 import collections
 
+import radical.utils as ru
+
 
 # 'enum' for launch method types
 LM_NAME_APRUN         = 'APRUN'
@@ -23,6 +25,7 @@ LM_NAME_MPIRUN_RSH    = 'MPIRUN_RSH'
 LM_NAME_ORTE          = 'ORTE'
 LM_NAME_POE           = 'POE'
 LM_NAME_RUNJOB        = 'RUNJOB'
+LM_NAME_RSH           = 'RSH'
 LM_NAME_SSH           = 'SSH'
 LM_NAME_YARN          = 'YARN'
 LM_NAME_SPARK         = 'SPARK'
@@ -90,6 +93,7 @@ class LaunchMethod(object):
         from .orte           import ORTE
         from .poe            import POE
         from .runjob         import Runjob
+        from .rsh            import RSH
         from .ssh            import SSH
         from .yarn           import Yarn
         from .spark          import Spark
@@ -109,6 +113,7 @@ class LaunchMethod(object):
                 LM_NAME_ORTE          : ORTE,
                 LM_NAME_POE           : POE,
                 LM_NAME_RUNJOB        : Runjob,
+                LM_NAME_RSH           : RSH,
                 LM_NAME_SSH           : SSH,
                 LM_NAME_YARN          : Yarn,
                 LM_NAME_SPARK         : Spark

--- a/src/radical/pilot/agent/lm/ccmrun.py
+++ b/src/radical/pilot/agent/lm/ccmrun.py
@@ -3,7 +3,10 @@ __copyright__ = "Copyright 2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
 
+import radical.utils as ru
+
 from .base import LaunchMethod
+
 
 # ==============================================================================
 #
@@ -20,7 +23,7 @@ class CCMRun(LaunchMethod):
     #
     def _configure(self):
         # ccmrun: Cluster Compatibility Mode (CCM) job launcher for Cray systems
-        self.launch_command= self._which('ccmrun')
+        self.launch_command= ru.which('ccmrun')
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/lm/dplace.py
+++ b/src/radical/pilot/agent/lm/dplace.py
@@ -3,6 +3,8 @@ __copyright__ = "Copyright 2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
 
+import radical.utils as ru
+
 from .base import LaunchMethod
 
 
@@ -21,7 +23,7 @@ class DPlace(LaunchMethod):
     #
     def _configure(self):
         # dplace: job launcher for SGI systems (e.g. on Blacklight)
-        self.launch_command = self._which('dplace')
+        self.launch_command = ru.which('dplace')
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/lm/ibrun.py
+++ b/src/radical/pilot/agent/lm/ibrun.py
@@ -4,6 +4,8 @@ __copyright__ = "Copyright 2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
 
+import radical.utils as ru
+
 from .base import LaunchMethod
 
 
@@ -24,7 +26,7 @@ class IBRun(LaunchMethod):
     #
     def _configure(self):
         # ibrun: wrapper for mpirun at TACC
-        self.launch_command = self._which('ibrun')
+        self.launch_command = ru.which('ibrun')
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/lm/mpirun_ccmrun.py
+++ b/src/radical/pilot/agent/lm/mpirun_ccmrun.py
@@ -4,6 +4,7 @@ __license__   = "MIT"
 
 
 import os
+import radical.utils as ru
 
 from .base import LaunchMethod
 
@@ -24,9 +25,9 @@ class MPIRunCCMRun(LaunchMethod):
     #
     def _configure(self):
         # ccmrun: Cluster Compatibility Mode job launcher for Cray systems
-        self.launch_command= self._which('ccmrun')
+        self.launch_command= ru.which('ccmrun')
 
-        self.mpirun_command = self._which('mpirun')
+        self.mpirun_command = ru.which('mpirun')
         if not self.mpirun_command:
             raise RuntimeError("mpirun not found!")
 

--- a/src/radical/pilot/agent/lm/mpirun_dplace.py
+++ b/src/radical/pilot/agent/lm/mpirun_dplace.py
@@ -3,6 +3,8 @@ __copyright__ = "Copyright 2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
 
+import radical.utils as ru
+
 from .base import LaunchMethod
 
 
@@ -22,8 +24,8 @@ class MPIRunDPlace(LaunchMethod):
     #
     def _configure(self):
         # dplace: job launcher for SGI systems (e.g. on Blacklight)
-        self.launch_command = self._which('dplace')
-        self.mpirun_command = self._which('mpirun')
+        self.launch_command = ru.which('dplace')
+        self.mpirun_command = ru.which('mpirun')
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/lm/mpirun_rsh.py
+++ b/src/radical/pilot/agent/lm/mpirun_rsh.py
@@ -4,6 +4,7 @@ __license__   = "MIT"
 
 
 import os
+import radical.utils as ru
 
 from .base import LaunchMethod
 
@@ -23,7 +24,7 @@ class MPIRunRSH(LaunchMethod):
     def _configure(self):
 
         # mpirun_rsh (e.g. on Gordon@SDSC, Stampede@TACC)
-        if not self._which('mpirun_rsh'):
+        if not ru.which('mpirun_rsh'):
             raise Exception("mpirun_rsh could not be found")
 
         # We don't use the full pathname as the user might load a different

--- a/src/radical/pilot/agent/lm/orte.py
+++ b/src/radical/pilot/agent/lm/orte.py
@@ -7,6 +7,7 @@ import os
 import time
 import threading
 import subprocess
+import radical.utils as ru
 
 from .base import LaunchMethod
 
@@ -175,7 +176,7 @@ class ORTE(LaunchMethod):
     #
     def _configure(self):
 
-        self.launch_command = self._which('orterun')
+        self.launch_command = ru.which('orterun')
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/lm/orte.py
+++ b/src/radical/pilot/agent/lm/orte.py
@@ -7,6 +7,7 @@ import os
 import time
 import threading
 import subprocess
+
 import radical.utils as ru
 
 from .base import LaunchMethod
@@ -42,7 +43,7 @@ class ORTE(LaunchMethod):
                the DVM.
         """
 
-        dvm_command = cls._which('orte-dvm')
+        dvm_command = ru.which('orte-dvm')
         if not dvm_command:
             raise Exception("Couldn't find orte-dvm")
 
@@ -164,7 +165,7 @@ class ORTE(LaunchMethod):
         if 'dvm_uri' in lm_info:
             try:
                 logger.info('terminating dvm')
-                orterun = cls._which('orterun')
+                orterun = ru.which('orterun')
                 if not orterun:
                     raise Exception("Couldn't find orterun")
                 subprocess.Popen([orterun, "--hnp", lm_info['dvm_uri'], "--terminate"])

--- a/src/radical/pilot/agent/lm/poe.py
+++ b/src/radical/pilot/agent/lm/poe.py
@@ -3,6 +3,8 @@ __copyright__ = "Copyright 2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
 
+import radical.utils as ru
+
 from .base import LaunchMethod
 
 
@@ -21,7 +23,7 @@ class POE(LaunchMethod):
     #
     def _configure(self):
         # poe: LSF specific wrapper for MPI (e.g. yellowstone)
-        self.launch_command = self._which('poe')
+        self.launch_command = ru.which('poe')
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/lm/runjob.py
+++ b/src/radical/pilot/agent/lm/runjob.py
@@ -4,6 +4,7 @@ __license__   = "MIT"
 
 
 import os
+import radical.utils as ru
 
 from .base import LaunchMethod
 
@@ -23,7 +24,7 @@ class Runjob(LaunchMethod):
     #
     def _configure(self):
         # runjob: job launcher for IBM BG/Q systems, e.g. Joule
-        self.launch_command= self._which('runjob')
+        self.launch_command= ru.which('runjob')
 
         raise NotImplementedError('RUNJOB LM needs to be decoupled from the scheduler/LRMS')
 

--- a/src/radical/pilot/agent/lm/spark.py
+++ b/src/radical/pilot/agent/lm/spark.py
@@ -9,8 +9,9 @@ import sys
 import socket
 import random
 
-from .base import LaunchMethod
+import radical.utils as ru
 
+from .base import LaunchMethod
 
 
 # ==============================================================================

--- a/src/radical/pilot/agent/lm/yarn.py
+++ b/src/radical/pilot/agent/lm/yarn.py
@@ -6,6 +6,8 @@ __license__   = "MIT"
 import os
 import subprocess
 
+import radical.utils as ru
+
 from .base import LaunchMethod
 
 

--- a/src/radical/pilot/configs/fub_allegro.json
+++ b/src/radical/pilot/configs/fub_allegro.json
@@ -1,0 +1,37 @@
+{
+  "allegro": {
+    "description": "The FU Berlin 'Allegro' cluster at IMP (http://www.allegro.imp.fu-berlin.de).",
+    "notes": "This one uses experimental RSH support to execute tasks.",
+    "schemas": [
+      "ssh"
+    ],
+    "mandatory_args": [],
+    "ssh": {
+      "job_manager_endpoint": "slurm+ssh://allegro.imp.fu-berlin.de/",
+      "filesystem_endpoint": "sftp://allegro.imp.fu-berlin.de/"
+    },
+    "default_queue": "micro",
+    "lrms": "SLURM",
+    "agent_type": "multicore",
+    "agent_scheduler": "CONTINUOUS",
+    "agent_spawner": "POPEN",
+    "agent_launch_method": "SSH",
+    "task_launch_method": "RSH",
+    "mpi_launch_method": "MPIEXEC",
+    "pre_bootstrap_1": [],
+    "default_remote_workdir": "$HOME/NO_BACKUP",
+    "valid_roots": [
+      "$HOME",
+      "/data/scratch"
+    ],
+    "rp_version": "local",
+    "virtenv": "%(global_sandbox)s/ve_allegro",
+    "virtenv_mode": "create",
+    "python_dist": "default",
+    "export_to_cu": [
+    ],
+    "cu_pre_exec": [
+      "module restore"
+    ]
+  }
+}


### PR DESCRIPTION
This was tested from inside the IMP subdomain of the FU Berlin. The necessary mongodb server needs to reside within a subdomain accessible from the allegro cluster nodes. 

The cluster connects to nodes using `rsh` and not `ssh` and hence requires the still experimental rsh support in branch `lm_rsh` #1172 . 