### PR TITLE
fix agent startup method for ornl.titan_lib

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -169,21 +169,21 @@
         },
 
         "ornl.titan_aprun" : {
-            "project"  : "BIP103",
+            "project"  : "CSC230",
             "queue"    : "debug",
             "schema"   : "local",
             "cores"    : 64
         },
 
         "ornl.titan_lib" : {
-            "project"  : "BIP103",
+            "project"  : "CSC230",
             "queue"    : "debug",
             "schema"   : "local",
             "cores"    : 32
         },
 
         "ornl.titan" : {
-            "project"  : "BIP103",
+            "project"  : "CSC230",
             "queue"    : "debug",
             "schema"   : "local",
             "cores"    : 64

--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -100,8 +100,8 @@
         "agent_type"                  : "multicore",
         "agent_config"                : "cray",
         "agent_scheduler"             : "CONTINUOUS",
-        "agent_spawner"               : "ORTE",
-        "agent_launch_method"         : "ORTE",
+        "agent_spawner"               : "POPEN",
+        "agent_launch_method"         : "FORK",
         "task_launch_method"          : "ORTE_LIB",
         "mpi_launch_method"           : "ORTE_LIB",
         "pre_bootstrap_1"             : [


### PR DESCRIPTION
This addresses #1237.
It also changes the example config to use our default allocation on titan.