### PR TITLE
fix #1327

### DIFF
--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -542,16 +542,6 @@ class Default(PMGRLaunchingComponent):
         database_url  = self._session.dburl
 
         # ------------------------------------------------------------------
-        # pilot description and resource configuration
-        number_cores    = pilot['description']['cores']
-        runtime         = pilot['description']['runtime']
-        queue           = pilot['description']['queue']
-        project         = pilot['description']['project']
-        cleanup         = pilot['description']['cleanup']
-        memory          = pilot['description']['memory']
-        candidate_hosts = pilot['description']['candidate_hosts']
-
-        # ------------------------------------------------------------------
         # get parameters from resource cfg, set defaults where needed
         agent_launch_method     = rcfg.get('agent_launch_method')
         agent_dburl             = rcfg.get('agent_mongodb_endpoint', database_url)
@@ -580,8 +570,27 @@ class Default(PMGRLaunchingComponent):
         cu_pre_exec             = rcfg.get('cu_pre_exec')
         cu_post_exec            = rcfg.get('cu_post_exec')
         export_to_cu            = rcfg.get('export_to_cu')
+        mandatory_args          = rcfg.get('mandatory_args', [])
 
+        # ------------------------------------------------------------------
+        # get parameters from the pilot description
+        number_cores    = pilot['description']['cores']
+        runtime         = pilot['description']['runtime']
+        queue           = pilot['description']['queue']
+        project         = pilot['description']['project']
+        cleanup         = pilot['description']['cleanup']
+        memory          = pilot['description']['memory']
+        candidate_hosts = pilot['description']['candidate_hosts']
 
+        # make sure that mandatory args are known
+        print 'mas: %s' % mandatory_args
+        import sys
+        sys.stdout.write('mas: %s\n' % mandatory_args)
+        sys.stdout.flush()
+        for ma in mandatory_args:
+            if pilot['description'].get(ma) is None:
+                raise  ValueError('attribute "%s" is required for "%s"' \
+                                 % (ma, resource))
 
         # get pilot and global sandbox
         global_sandbox   = self._session._get_global_sandbox (pilot).path


### PR DESCRIPTION
re-add mandatory arg check.

I am not perfectly happy with the fix, as it conflicts with the semantics of user-local config files.  For example, `queue` might be a required attribute for pilots on a certain target resource.  If the user specifies a default queue in his local resource config, then the launcher will still complain when the pilot description does not explicitly specify a queue.  Oh well - at least this recovers the old semantics.  Since local configs are not yet widely used, we'll let it slide I guess...