### PR TITLE
let units fail on pre/post exec errors

### DIFF
--- a/src/radical/pilot/agent/executing/orte.py
+++ b/src/radical/pilot/agent/executing/orte.py
@@ -358,35 +358,31 @@ class ORTE(AgentExecutingComponent):
         # TODO: pre_exec
         #     # Before the Big Bang there was nothing
         #     if cu['description']['pre_exec']:
-        #         pre_exec_string = ''
-        #         if isinstance(cu['description']['pre_exec'], list):
-        #             for elem in cu['description']['pre_exec']:
-        #                 pre_exec_string += "%s\n" % elem
-        #         else:
-        #             pre_exec_string += "%s\n" % cu['description']['pre_exec']
+        #         fail = ' (echo "pre_exec failed"; false) || exit'
+        #         pre  = ''
+        #         for elem in cu['description']['pre_exec']:
+        #             pre += "%s || %s\n" % (elem, fail)
         #         # Note: extra spaces below are for visual alignment
         #         launch_script.write("# Pre-exec commands\n")
         #         if 'RADICAL_PILOT_PROFILE' in os.environ:
         #             launch_script.write("echo pre  start `%s` >> %s/PROF\n" % (cu['gtod'], cu_tmpdir))
-        #         launch_script.write(pre_exec_string)
+        #         launch_script.write(pre)
         #         if 'RADICAL_PILOT_PROFILE' in os.environ:
         #             launch_script.write("echo pre  stop `%s` >> %s/PROF\n" % (cu['gtod'], cu_tmpdir))
 
         # TODO: post_exec
-        # # After the universe dies the infrared death, there will be nothing
-        # if cu['description']['post_exec']:
-        #     post_exec_string = ''
-        #     if isinstance(cu['description']['post_exec'], list):
+        #     # After the universe dies the infrared death, there will be nothing
+        #     if cu['description']['post_exec']:
+        #         fail = ' (echo "post_exec failed"; false) || exit'
+        #         post = ''
         #         for elem in cu['description']['post_exec']:
-        #             post_exec_string += "%s\n" % elem
-        #     else:
-        #         post_exec_string += "%s\n" % cu['description']['post_exec']
-        #     launch_script.write("# Post-exec commands\n")
-        #     if 'RADICAL_PILOT_PROFILE' in os.environ:
-        #         launch_script.write("echo post start `%s` >> %s/PROF\n" % (cu['gtod'], cu_tmpdir))
-        #     launch_script.write('%s\n' % post_exec_string)
-        #     if 'RADICAL_PILOT_PROFILE' in os.environ:
-        #         launch_script.write("echo post stop  `%s` >> %s/PROF\n" % (cu['gtod'], cu_tmpdir))
+        #             post += "%s || %s\n" % (elem, fail)
+        #         launch_script.write("# Post-exec commands\n")
+        #         if 'RADICAL_PILOT_PROFILE' in os.environ:
+        #             launch_script.write("echo post start `%s` >> %s/PROF\n" % (cu['gtod'], cu_tmpdir))
+        #         launch_script.write('%s\n' % post)
+        #         if 'RADICAL_PILOT_PROFILE' in os.environ:
+        #             launch_script.write("echo post stop  `%s` >> %s/PROF\n" % (cu['gtod'], cu_tmpdir))
 
 
 

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -247,9 +247,11 @@ class Popen(AgentExecutingComponent) :
             for k,v in self._env_cu_export.iteritems():
                 env_string += "export %s=%s\n" % (k,v)
 
+            descr = cu['description']
+
             # also add any env vars requested in the unit description
-            if cu['description']['environment']:
-                for key,val in cu['description']['environment'].iteritems():
+            if descr['environment']:
+                for key,val in descr['environment'].iteritems():
                     env_string += 'export "%s=%s"\n' % (key, val)
 
             launch_script.write('\n# Environment variables\n%s\n' % env_string)
@@ -269,19 +271,17 @@ class Popen(AgentExecutingComponent) :
                 for val in self._cfg['cu_pre_exec']:
                     launch_script.write("%s\n"  % val)
 
-            if cu['description']['pre_exec']:
-                pre_exec_string = ''
-                if isinstance(cu['description']['pre_exec'], list):
-                    for elem in cu['description']['pre_exec']:
-                        pre_exec_string += "%s\n" % elem
-                else:
-                    pre_exec_string += "%s\n" % cu['description']['pre_exec']
+            if descr['pre_exec']:
+                fail = ' (echo "pre_exec failed"; false) || exit'
+                pre  = ''
+                for elem in descr['pre_exec']:
+                    pre += "%s || %s\n" % (elem, fail)
                 # Note: extra spaces below are for visual alignment
                 launch_script.write("\n# Pre-exec commands\n")
                 if 'RADICAL_PILOT_PROFILE' in os.environ:
                     launch_script.write('echo "`$RP_GTOD`,unit_script,%s,%s,pre_start," >> $RP_PROF\n' %  \
                                         (cu['uid'], rps.AGENT_EXECUTING))
-                launch_script.write(pre_exec_string)
+                launch_script.write(pre)
                 if 'RADICAL_PILOT_PROFILE' in os.environ:
                     launch_script.write('echo "`$RP_GTOD`,unit_script,%s,%s,pre_stop," >> $RP_PROF\n' %  \
                                         (cu['uid'], rps.AGENT_EXECUTING))
@@ -306,18 +306,16 @@ class Popen(AgentExecutingComponent) :
                                     (cu['uid'], rps.AGENT_EXECUTING))
 
             # After the universe dies the infrared death, there will be nothing
-            if cu['description']['post_exec']:
-                post_exec_string = ''
-                if isinstance(cu['description']['post_exec'], list):
-                    for elem in cu['description']['post_exec']:
-                        post_exec_string += "%s\n" % elem
-                else:
-                    post_exec_string += "%s\n" % cu['description']['post_exec']
+            if descr['post_exec']:
+                fail = ' (echo "post_exec failed"; false) || exit'
+                post = ''
+                for elem in descr['post_exec']:
+                    post += "%s || %s\n" % (elem, fail)
                 launch_script.write("\n# Post-exec commands\n")
                 if 'RADICAL_PILOT_PROFILE' in os.environ:
                     launch_script.write('echo "`$RP_GTOD`,unit_script,%s,%s,post_start," >> $RP_PROF\n' %  \
                                         (cu['uid'], rps.AGENT_EXECUTING))
-                launch_script.write('%s\n' % post_exec_string)
+                launch_script.write('%s\n' % post)
                 if 'RADICAL_PILOT_PROFILE' in os.environ:
                     launch_script.write('echo "`$RP_GTOD`,unit_script,%s,%s,post_stop," >> $RP_PROF\n' %  \
                                         (cu['uid'], rps.AGENT_EXECUTING))
@@ -331,8 +329,8 @@ class Popen(AgentExecutingComponent) :
         self._prof.prof('command', msg='launch script constructed', uid=cu['uid'])
 
         # prepare stdout/stderr
-        stdout_file = cu['description'].get('stdout') or 'STDOUT'
-        stderr_file = cu['description'].get('stderr') or 'STDERR'
+        stdout_file = descr.get('stdout') or 'STDOUT'
+        stderr_file = descr.get('stderr') or 'STDERR'
 
         cu['stdout_file'] = os.path.join(sandbox, stdout_file)
         cu['stderr_file'] = os.path.join(sandbox, stderr_file)

--- a/src/radical/pilot/agent/executing/shell.py
+++ b/src/radical/pilot/agent/executing/shell.py
@@ -361,11 +361,14 @@ class Shell(AgentExecutingComponent):
         env  += "\n"
 
         if  descr['pre_exec'] :
+            fail  = ' (echo "pre_exec failed"; false) || exit'
             pre  += "\n# CU pre-exec\n"
             if 'RADICAL_PILOT_PROFILE' in os.environ:
                 pre += 'echo "`$GTOD`,unit_script,%s,%s,pre_start," >> $RP_PROF\n' %  \
                        (cu['uid'], rps.AGENT_EXECUTING)
-            pre  += '\n'.join(descr['pre_exec' ])
+            pre = ''
+            for elem in descr['pre_exec']:
+                pre += "%s || %s\n" % (elem, fail)
             pre  += "\n"
             if 'RADICAL_PILOT_PROFILE' in os.environ:
                 pre += 'echo "`$GTOD`,unit_script,%s,%s,pre_stop," >> $RP_PROF\n' %  \
@@ -373,11 +376,13 @@ class Shell(AgentExecutingComponent):
             pre  += "\n"
 
         if  descr['post_exec'] :
+            fail  = ' (echo "post_exec failed"; false) || exit'
             post += "\n# CU post-exec\n"
             if 'RADICAL_PILOT_PROFILE' in os.environ:
                 post += 'echo "`$GTOD`,unit_script,%s,%s,post_start," >> $RP_PROF\n' %  \
                        (cu['uid'], rps.AGENT_EXECUTING)
-            post += '\n'.join(descr['post_exec' ])
+            for elem in descr['post_exec']:
+                post += "%s || %s\n" % (elem, fail)
             post += "\n"
             if 'RADICAL_PILOT_PROFILE' in os.environ:
                 post += 'echo "`$GTOD`,unit_script,%s,%s,post_stop," >> $RP_PROF\n' %  \

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -608,10 +608,6 @@ class Default(PMGRLaunchingComponent):
         candidate_hosts = pilot['description']['candidate_hosts']
 
         # make sure that mandatory args are known
-        print 'mas: %s' % mandatory_args
-        import sys
-        sys.stdout.write('mas: %s\n' % mandatory_args)
-        sys.stdout.flush()
         for ma in mandatory_args:
             if pilot['description'].get(ma) is None:
                 raise  ValueError('attribute "%s" is required for "%s"' \


### PR DESCRIPTION
fixes #1240, in that it makes the CU execution fail on pre- and post-exec errors.  This PR implements this for the popen and shell spawners, and documents it for orte.  Yarn and ABDS should be checked fro consistency - I'll reassign the ticket to Iannis once this PR is merged.

In general: we are sharing lots of code for the script generation between the launch methods, and probably should move parts of it into RP-utils, to simplify maintenance and increase consistency.  At this point, ORTE-LIB is the only LM which really looks fundamentally different I think.