### PR TITLE
use a separate VE for each resource config

### DIFF
--- a/bin/radicalpilot-version
+++ b/bin/radicalpilot-version
@@ -5,9 +5,8 @@ import sys
 import radical.pilot as rp
 
 if len(sys.argv) > 1 and '-v' in sys.argv:
-    print 'version: %s' % rp.version_detail
-    print 'modpath: %s' % os.path.dirname(rp.__file__)
+    print rp.version_detail
 
 else:
-    print rp.version_detail
+    print rp.version
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@
 
 __author__    = 'RADICAL Team'
 __email__     = 'radical@rutgers.edu'
-__copyright__ = 'Copyright 2013/14, RADICAL Research, Rutgers University'
+__copyright__ = 'Copyright 2013-16, RADICAL Research, Rutgers University'
 __license__   = 'MIT'
 
 
-""" Setup script. Used by easy_install and pip. """
+""" Setup script, only usable via pip. """
 
 import re
 import os
@@ -46,17 +46,16 @@ def get_version (mod_root):
 
     try:
 
-        version        = None
+        version_base   = None
         version_detail = None
 
         # get version from './VERSION'
         src_root = os.path.dirname (__file__)
-        if  not src_root :
+        if  not src_root:
             src_root = '.'
 
-        with open (src_root + '/VERSION', 'r') as f :
-            version = f.readline ().strip()
-
+        with open (src_root + '/VERSION', 'r') as f:
+            version_base = f.readline ().strip()
 
         # attempt to get version detail information from git
         # We only do that though if we are in a repo root dir, 
@@ -65,12 +64,12 @@ def get_version (mod_root):
         # and the pip version used uses an install tmp dir in the ve space
         # instead of /tmp (which seems to happen with some pip/setuptools 
         # versions).
-        p   = sp.Popen ('cd %s ; '\
-                        'test -z `git rev-parse --show-prefix` || exit -1; '\
-                        'tag=`git describe --tags --always` 2>/dev/null ; '\
-                        'branch=`git branch | grep -e "^*" | cut -f 2- -d " "` 2>/dev/null ; '\
-                        'echo $tag@$branch'  % src_root,
-                        stdout=sp.PIPE, stderr=sp.STDOUT, shell=True)
+        p = sp.Popen ('cd %s ; '\
+                      'test -z `git rev-parse --show-prefix` || exit -1; '\
+                      'tag=`git describe --tags --always` 2>/dev/null ; '\
+                      'branch=`git branch | grep -e "^*" | cut -f 2- -d " "` 2>/dev/null ; '\
+                      'echo $tag@$branch'  % src_root,
+                      stdout=sp.PIPE, stderr=sp.STDOUT, shell=True)
         version_detail = str(p.communicate()[0].strip())
         version_detail = version_detail.replace('detached from ', 'detached-')
 
@@ -78,30 +77,34 @@ def get_version (mod_root):
         version_detail = re.sub('[/ ]+', '-', version_detail)
         version_detail = re.sub('[^a-zA-Z0-9_+@.-]+', '', version_detail)
 
-
         if  p.returncode   !=  0  or \
             version_detail == '@' or \
             'not-a-git-repo' in version_detail or \
             'not-found'      in version_detail or \
             'fatal'          in version_detail :
-            version_detail =  version
-
-        print('version: %s (%s)' % (version, version_detail))
-
+            version = version_base
+        elif '@' not in version_base:
+            version = '%s-%s' % (version_base, version_detail)
+        else:
+            version = version_base
 
         # make sure the version files exist for the runtime version inspection
         path = '%s/%s' % (src_root, mod_root)
-        print('creating %s/VERSION' % path)
-        with open (path + "/VERSION", "w") as f : f.write (version_detail + "\n")
+        with open (path + "/VERSION", "w") as f:
+            f.write (version + "\n")
 
-        sdist_name = "%s-%s.tar.gz" % (name, version_detail)
+        sdist_name = "%s-%s.tar.gz" % (name, version)
         sdist_name = sdist_name.replace ('/', '-')
         sdist_name = sdist_name.replace ('@', '-')
         sdist_name = sdist_name.replace ('#', '-')
         sdist_name = sdist_name.replace ('_', '-')
-        if '--record'  in sys.argv or 'bdist_egg' in sys.argv or 'bdist_wheel' in sys.argv:
-           # pip install stage 2      easy_install stage 1
-           # NOTE: pip install will untar the sdist in a tmp tree.  In that tmp
+
+        if '--record'    in sys.argv or \
+           'bdist_egg'   in sys.argv or \
+           'bdist_wheel' in sys.argv    :
+           # pip install stage 2 or easy_install stage 1
+           #
+           # pip install will untar the sdist in a tmp tree.  In that tmp
            # tree, we won't be able to derive git version tags -- so we pack the
            # formerly derived version as ./VERSION
             shutil.move ("VERSION", "VERSION.bak")           # backup version
@@ -111,10 +114,10 @@ def get_version (mod_root):
                          '%s/%s'   % (mod_root, sdist_name)) # copy into tree
             shutil.move ("VERSION.bak", "VERSION")           # restore version
 
-        print('creating %s/SDIST' % path)
-        with open (path + "/SDIST", "w") as f : f.write (sdist_name + "\n")
+        with open (path + "/SDIST", "w") as f: 
+            f.write (sdist_name + "\n")
 
-        return version, version_detail, sdist_name
+        return version_base, version_detail, sdist_name
 
     except Exception as e :
         raise RuntimeError ('Could not extract/set version: %s' % e)
@@ -302,7 +305,7 @@ setup_args = {
 #   },
 #   'upload_sphinx'      : {
 #       'upload-dir'     : 'docs/build/html',
-#   }
+#   },
     # This copies the contents of the examples/ dir under
     # sys.prefix/share/$name
     # It needs the MANIFEST.in entries to work.

--- a/src/radical/pilot/__init__.py
+++ b/src/radical/pilot/__init__.py
@@ -35,7 +35,8 @@ from .resource_config           import ResourceConfig
 from .staging_directives        import COPY, LINK, MOVE, TRANSFER
 from .staging_directives        import SKIP_FAILED, CREATE_PARENTS
 
-from .utils                     import version, version_detail, version_branch
+from .utils                     import version, version_short
+from .utils                     import version_detail, version_branch
 from .utils                     import sdist_name, sdist_path
 from .utils                     import logger
 

--- a/src/radical/pilot/configs/resource_das4.json
+++ b/src/radical/pilot/configs/resource_das4.json
@@ -21,7 +21,6 @@
         "pre_bootstrap_1"             : ["module load openmpi/gcc"],
         "valid_roots"                 : ["/home", "/var/scratch"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_fs2",
         "virtenv_mode"                : "update",
         "python_dist"                 : "default"
     }

--- a/src/radical/pilot/configs/resource_das5.json
+++ b/src/radical/pilot/configs/resource_das5.json
@@ -23,7 +23,6 @@
         "default_remote_workdir"      : "/var/scratch/$USER",
         "valid_roots"                 : ["/home", "/var/scratch"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_fs1",
         "virtenv_mode"                : "update",
         "python_dist"                 : "default"
     }

--- a/src/radical/pilot/configs/resource_fub.json
+++ b/src/radical/pilot/configs/resource_fub.json
@@ -20,7 +20,6 @@
         "valid_roots"           : ["$HOME",
                                    "/data/scratch"],
         "rp_version"            : "local",
-        "virtenv"               : "%(global_sandbox)s/ve_allegro",
         "virtenv_mode"          : "create",
         "python_dist"           : "default",
         "export_to_cu"          : [],

--- a/src/radical/pilot/configs/resource_futuregrid.json
+++ b/src/radical/pilot/configs/resource_futuregrid.json
@@ -19,7 +19,6 @@
         "pre_bootstrap_1"             : ["module purge", "module load python", "module load openmpi/1.4.3-gnu"],
         "valid_roots"                 : ["/N"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_india",
         "virtenv_mode"                : "update",
         "python_dist"                 : "default"
     },
@@ -67,7 +66,6 @@
         "default_queue"               : "delta",
         "valid_roots"                 : ["/N"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_delta",
         "virtenv_mode"                : "update",
         "python_dist"                 : "default"
     },
@@ -89,7 +87,6 @@
         "default_queue"               : "echo",
         "valid_roots"                 : ["/N"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_echo",
         "virtenv_mode"                : "update",
         "python_dist"                 : "default"
 

--- a/src/radical/pilot/configs/resource_iu.json
+++ b/src/radical/pilot/configs/resource_iu.json
@@ -18,7 +18,6 @@
         "pre_bootstrap_1"             : ["module load python/2.7.8"],
         "valid_roots"                 : ["/N"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_br2",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -50,7 +49,6 @@
         "default_remote_workdir"      : "/N/dc2/scratch/$USER",
         "valid_roots"                 : ["/N"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_br2",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"

--- a/src/radical/pilot/configs/resource_local.json
+++ b/src/radical/pilot/configs/resource_local.json
@@ -22,7 +22,6 @@
         "task_launch_method"          : "FORK",
         "mpi_launch_method"           : "MPIEXEC",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_localhost",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -49,7 +48,6 @@
         "task_launch_method"          : "YARN",
         "mpi_launch_method"           : "MPIEXEC",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_localhost",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -76,7 +74,6 @@
         "task_launch_method"          : "FORK",
         "mpi_launch_method"           : "MPIEXEC",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_localhost",
         "virtenv_mode"                : "create",
         "python_dist"                 : "anaconda"
     },
@@ -104,7 +101,6 @@
         "task_launch_method"          : "SPARK",
         "mpi_launch_method"           : "MPIEXEC",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_localhost",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -132,7 +128,6 @@
         "task_launch_method"          : "SPARK",
         "mpi_launch_method"           : "MPIEXEC",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_localhost",
         "virtenv_mode"                : "create",
         "python_dist"                 : "anaconda"
     },
@@ -160,7 +155,6 @@
         "task_launch_method"          : "ORTE",
         "mpi_launch_method"           : "ORTE",
         "rp_version"                  : "debug",
-        "virtenv"                     : "%(global_sandbox)s/ve_localhost",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -188,7 +182,6 @@
         "task_launch_method"          : "ORTE_LIB",
         "mpi_launch_method"           : "ORTE_LIB",
         "rp_version"                  : "debug",
-        "virtenv"                     : "%(global_sandbox)s/ve_localhost",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
   }

--- a/src/radical/pilot/configs/resource_lumc.json
+++ b/src/radical/pilot/configs/resource_lumc.json
@@ -31,7 +31,6 @@
             "/home"
         ],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_shark",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -65,7 +64,6 @@
             "/home"
         ],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_gb-ui",
         "virtenv_mode"                : "create",
         "python_dist"                 : "anaconda"
     }

--- a/src/radical/pilot/configs/resource_ncsa.json
+++ b/src/radical/pilot/configs/resource_ncsa.json
@@ -22,7 +22,6 @@
         "default_remote_workdir"      : "/scratch/sciteam/$USER",
         "valid_roots"                 : ["/scratch/sciteam"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_bw",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : "True",
         "python_dist"                 : "default"
@@ -57,7 +56,6 @@
         "default_remote_workdir"      : "/scratch/sciteam/$USER",
         "valid_roots"                 : ["/scratch/sciteam"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_bw",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -91,7 +89,6 @@
         "default_remote_workdir"      : "/scratch/sciteam/$USER",
         "valid_roots"                 : ["/scratch/sciteam"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_bw",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -159,7 +156,6 @@
         "default_remote_workdir"      : "/scratch/sciteam/$USER",
         "valid_roots"                 : ["/scratch/sciteam"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_bw",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : "True",
         "python_dist"                 : "default"

--- a/src/radical/pilot/configs/resource_nersc.json
+++ b/src/radical/pilot/configs/resource_nersc.json
@@ -19,7 +19,6 @@
         "default_remote_workdir"      : "$SCRATCH",
         "valid_roots"                 : ["/global", "/scratch",  "/scratch2"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_hopper",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "cores_per_node"              : "24",
@@ -64,7 +63,6 @@
         "default_remote_workdir"      : "$SCRATCH",
         "valid_roots"                 : ["/global", "/scratch1", "/scratch2"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_hopper",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -96,7 +94,6 @@
         "forward_tunnel_endpoint"     : "BIND_ADDRESS",
         "tunnel_bind_device"          : "ipogif0",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_hopper",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "cores_per_node"              : "24",
@@ -127,7 +124,6 @@
         "default_remote_workdir"      : "$SCRATCH",
         "valid_roots"                 : ["/global", "/scratch1", "/scratch2"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_edison",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -169,7 +165,6 @@
         "default_remote_workdir"      : "$SCRATCH",
         "valid_roots"                 : ["/global", "/scratch1", "/scratch2"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_edison",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -200,7 +195,6 @@
         "forward_tunnel_endpoint"     : "localhost",
         "tunnel_bind_device"          : "ipogif0",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_edison",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"

--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -32,7 +32,6 @@
         "default_remote_workdir"      : "$MEMBERWORK/`groups | cut -d' ' -f2`",
         "valid_roots"                 : ["/lustre/atlas/scratch"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_titan",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -74,7 +73,6 @@
         "default_remote_workdir"      : "$MEMBERWORK/`groups | cut -d' ' -f2`",
         "valid_roots"                 : ["/lustre/atlas/scratch"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_titan",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"
@@ -117,7 +115,6 @@
         "valid_roots"                 : ["/lustre/atlas/scratch"],
         "rp_version"                  : "debug",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_titan",
         "virtenv_mode"                : "create",
         "stage_cacerts"               : true,
         "python_dist"                 : "default"

--- a/src/radical/pilot/configs/resource_rice.json
+++ b/src/radical/pilot/configs/resource_rice.json
@@ -20,7 +20,6 @@
         "valid_roots"                 : ["/dascratch"],
         "default_remote_workdir"      : "$SHARED_SCRATCH/$USER",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_davinci",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -48,7 +47,6 @@
         "valid_roots"                 : ["/gpfs-biou"],
         "default_remote_workdir"      : "$SHARED_SCRATCH/$USER",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_biou",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     }

--- a/src/radical/pilot/configs/resource_stfc.json
+++ b/src/radical/pilot/configs/resource_stfc.json
@@ -31,7 +31,6 @@
         "valid_roots"                 : ["/gpfs/home"],
         "pilot_agent"                 : "radical-pilot-agent-multicore.py",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_joule",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     }

--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -39,7 +39,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/scratch", "$SCRATCH", "/work", "$WORK"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_stampede",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default", 
         "export_to_cu"                : ["LMOD_CMD",
@@ -94,7 +93,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/scratch", "$SCRATCH", "/work", "$WORK"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_stampede",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -145,7 +143,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/scratch", "$SCRATCH", "/work", "$WORK"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_stampede",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -189,7 +186,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/scratch", "$SCRATCH", "/work", "$WORK"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_stampede",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -238,7 +234,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/scratch", "$SCRATCH", "/work", "$WORK"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_stampede",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -280,7 +275,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/work", "$WORK", "/data", "$DATA"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_wrangler",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -322,7 +316,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/work", "$WORK"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_wrangler",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -367,7 +360,6 @@
         "default_remote_workdir"      : "$WORK",
         "valid_roots"                 : ["/work", "$WORK"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_wrangler",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -404,7 +396,6 @@
                                         ],
         "valid_roots"                 : ["/home1", "/scratch", "/work"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_lonestar",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -434,7 +425,6 @@
                                          "module load python pgi mvapich2_ib gnubase"],
         "valid_roots"                 : ["/home"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_trestles",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -464,7 +454,6 @@
                                          "module load python intel mvapich2_ib gnubase"],
         "valid_roots"                 : ["/home"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_gordon",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -498,7 +487,6 @@
         "valid_roots"                 : ["/usr/users", "/brashear"],
         "stage_cacerts"               : "True",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_blacklight",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -533,7 +521,6 @@
         "valid_roots"                 : ["/home", "/crucible", "/arc"],
         "stage_cacerts"               : "True",
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_greenfield",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -566,7 +553,6 @@
        #"valid_roots"                 : ["/oasis/scratch/comet"],
         "valid_roots"                 : ["/home"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_comet",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default",
         "cu_tmp"                      : "/scratch/$USER/$SLURM_JOBID"
@@ -602,7 +588,6 @@
         ],
         "valid_roots"                 : ["/home"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_comet",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -637,7 +622,6 @@
         ],
         "valid_roots"                 : ["/home"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_comet",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -675,7 +659,6 @@
         #"valid_roots"                 : ["/oasis/scratch/comet"],
         "valid_roots"                 : ["/home"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_comet",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -704,7 +687,6 @@
         "default_remote_workdir"      : "/work/$USER",
         "valid_roots"                 : ["/work"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_supermic",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     },
@@ -733,7 +715,6 @@
         "default_remote_workdir"      : "/work/$USER",
         "valid_roots"                 : ["/work"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_supermic",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     }

--- a/src/radical/pilot/configs/resource_yale.json
+++ b/src/radical/pilot/configs/resource_yale.json
@@ -22,7 +22,6 @@
         "pre_bootstrap_2"             : [],
         "valid_roots"                 : ["/"],
         "rp_version"                  : "local",
-        "virtenv"                     : "%(global_sandbox)s/ve_grace",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default"
     }

--- a/src/radical/pilot/utils/__init__.py
+++ b/src/radical/pilot/utils/__init__.py
@@ -1,14 +1,23 @@
+
 # ------------------------------------------------------------------------------
-#
+# we *first* import radical.utils, so that the monkeypatching of the logger has
+# a chance to kick in before the logging module is pulled by any other 3rd party
+# module, and also to monkeypatch `os.fork()` for the `atfork` functionality.
+# we also get the version string at this point.
+import radical.utils as _ru
 import os
-import radical.utils as ru
 
 _pwd   = os.path.dirname (__file__)
 _root  = "%s/.." % _pwd
-version, version_detail, version_branch, sdist_name, sdist_path = ru.get_version([_root])
 
-logger = ru.get_logger('radical.pilot')
+version_short, version_detail, version_base, version_branch, \
+        sdist_name, sdist_path = _ru.get_version([_root])
+version = version_short
+logger  = _ru.get_logger('radical.pilot')
 
+
+# ------------------------------------------------------------------------------
+#
 from .db_utils     import *
 from .prof_utils   import *
 from .misc         import *


### PR DESCRIPTION
This removes the 'virtenv' config entry for most resource configs.  That
is now only really needed for shared, globe VEs, as on archer and
supermuc.  The new default is to use
%(global_sandbox)/ve.%(resource).%(rp_version)
as name for the VE.  This fixes two issues:

  - different resource configs need different requirements.  For example
    (and prominently), orte-cffi needs only to be installed for orte and
    ortelib configs
  - when new dependencies are introduced in a new release, then they
    will automatically be installed in the new VE

The first item is not yet taken adavntage of - for that, we need to move
the list of optional pre-requisites to the resource configs, or need to
be more clever in the bootstrapper to figure out what is actually
needed.  But the second item will apply immediately, as otherwise all
existing VEs would break on updates to 0.46.  This fixes #1363