### PR TITLE
Fix/issue 1361

### DIFF
--- a/docs/architecture/zmq/test_zmq.py
+++ b/docs/architecture/zmq/test_zmq.py
@@ -6,18 +6,11 @@ import zmq
 import time
 import multiprocessing as mp
 
-cfg = {
-    'src'     : {
-        'n'   : 1000,
-        't'   : 0.1
-        },
-    'queue'   : {
-        't'   : 0.1
-        },
-    'tgt'     : {
-        't'   : 0.1
-        }
-    }
+cfg = {'src'   : {'n' : 1000,
+                  't' : 0.0 } ,
+       'queue' : {'t' : 0.0 } ,
+       'tgt'   : {'t' : 0.0 } }
+
 
 def src(host):
     context        = zmq.Context()
@@ -31,10 +24,13 @@ def src(host):
     pid = os.getpid()
 
     for num in range(n):
-        msg = {pid:num}
+        msg = {unicode(pid):num}
         socket_src.send_json(msg)
-        print 'sent %s' % msg
+        print 'put %s' % msg
         time.sleep (t)
+    print 'put %s' % msg
+    socket_src.send_json({pid:'stop'})
+    context.destroy()
 
 
 def queue(host):
@@ -50,14 +46,20 @@ def queue(host):
 
     t = cfg['queue']['t']
 
-    while True:
-        req = socket_sink.recv()
-        msg = socket_src.recv_json()
-        print msg
-        socket_sink.send_json(msg)
+    try:
+        while True:
+            req = socket_sink.recv()
+            msg = socket_src.recv_json()
+            print '<-> %s' % msg
+            socket_sink.send_json(msg)
 
-        if t:
-            time.sleep (t)
+            if 'stop' in msg.values():
+                return
+
+            if t:
+                time.sleep (t)
+    finally:
+        context.destroy()
 
 
 def tgt(host):
@@ -67,12 +69,20 @@ def tgt(host):
     socket_sink.connect("tcp://127.0.0.1:5001")
 
     t = cfg['tgt']['t']
-    
-    while True:
-        socket_sink.send('request')
-        msg = socket_sink.recv_json()
-        print 'got %s' % msg
-        time.sleep (t)
+
+    try:
+        while True:
+            socket_sink.send('request')
+            msg = socket_sink.recv_json()
+            print 'get %s' % msg
+            time.sleep (t)
+
+            if 'stop' in msg.values():
+                return
+
+    finally:
+        context.destroy()
+
 
 if len(sys.argv) < 3:
     print """
@@ -102,4 +112,4 @@ for p in procs:
 for p in procs:
     p.join()
 
-        
+

--- a/src/radical/pilot/agent/agent_0.py
+++ b/src/radical/pilot/agent/agent_0.py
@@ -162,6 +162,10 @@ class Agent_0(rpu.Worker):
 
         # tear things down in reverse order
 
+        self.unregister_timed_cb(self._check_units_cb)
+        self.unregister_output(rps.AGENT_STAGING_INPUT_PENDING)
+        self.unregister_timed_cb(self._agent_command_cb)
+
         if self._lrms:
             self._log.debug('stop    lrms %s', self._lrms)
             self._lrms.stop()

--- a/src/radical/pilot/agent/agent_0.py
+++ b/src/radical/pilot/agent/agent_0.py
@@ -33,13 +33,13 @@ class Agent_0(rpu.Worker):
 
     # This is the base agent.  It does not do much apart from starting
     # sub-agents and watching them  If any of the sub-agents die, it will shut
-    # down the other sub-agents and itself.  
+    # down the other sub-agents and itself.
     #
     # This class inherits the rpu.Worker, so that it can use the communication
     # bridges and callback mechanisms.  It will own a session (which creates said
     # communication bridges (or at least some of them); and a controller, which
     # will control the sub-agents.
-    
+
     # --------------------------------------------------------------------------
     #
     def __init__(self, agent_name):
@@ -84,11 +84,11 @@ class Agent_0(rpu.Worker):
             dburl = ru.Url(cfg['dburl'])
             dburl.host, dburl.port = hostport.split(':')
             cfg['dburl'] = str(dburl)
-        
-        # Create a session.  
+
+        # Create a session.
         #
         # This session will connect to MongoDB, and will also create any
-        # communication channels and components/workers specified in the 
+        # communication channels and components/workers specified in the
         # config -- we merge that information into our own config.
         # We don't want the session to start components though, so remove them
         # from the config copy.
@@ -113,7 +113,7 @@ class Agent_0(rpu.Worker):
         # Create LRMS which will give us the set of agent_nodes to use for
         # sub-agent startup.  Add the remaining LRMS information to the
         # config, for the benefit of the scheduler).
-        self._lrms = rpa_rm.RM.create(name=self._cfg['lrms'], cfg=self._cfg, 
+        self._lrms = rpa_rm.RM.create(name=self._cfg['lrms'], cfg=self._cfg,
                                       session=self._session)
 
         # add the resource manager information to our own config
@@ -131,7 +131,7 @@ class Agent_0(rpu.Worker):
         self._start_sub_agents()
 
         # register the command callback which pulls the DB for commands
-        self.register_timed_cb(self._agent_command_cb, 
+        self.register_timed_cb(self._agent_command_cb,
                                timer=self._cfg['db_poll_sleeptime'])
 
         # registers the staging_input_queue as this is what we want to push
@@ -152,7 +152,7 @@ class Agent_0(rpu.Worker):
 
         # register idle callback to pull for units -- which is the only action
         # we have to perform, really
-        self.register_timed_cb(self._check_units_cb, 
+        self.register_timed_cb(self._check_units_cb,
                                timer=self._cfg['db_poll_sleeptime'])
 
 
@@ -167,7 +167,7 @@ class Agent_0(rpu.Worker):
             self._lrms.stop()
             self._log.debug('stopped lrms %s', self._lrms)
 
-        if   self._final_cause == 'timeout'  : state = rps.DONE 
+        if   self._final_cause == 'timeout'  : state = rps.DONE
         elif self._final_cause == 'cancel'   : state = rps.CANCELED
         elif self._final_cause == 'sys.exit' : state = rps.CANCELED
         else                                 : state = rps.FAILED
@@ -193,31 +193,31 @@ class Agent_0(rpu.Worker):
 
         if state == rps.FAILED:
             self._log.info(ru.get_trace())
-    
+
         now = time.time()
         out = None
         err = None
         log = None
-    
+
         try    : out = open('./agent_0.out', 'r').read(1024)
         except Exception: pass
         try    : err = open('./agent_0.err', 'r').read(1024)
         except Exception: pass
         try    : log = open('./agent_0.log', 'r').read(1024)
         except Exception: pass
-    
+
         ret = self._session._dbs._c.update(
-                {'type'   : 'pilot', 
+                {'type'   : 'pilot',
                  "uid"    : self._pid},
                 {"$push"  : {"states"        : state},
-                 "$set"   : {"state"         : state, 
+                 "$set"   : {"state"         : state,
                              "stdout"        : rpu.tail(out),
                              "stderr"        : rpu.tail(err),
                              "logfile"       : rpu.tail(log),
                              "finished"      : now}
                 })
         self._log.debug('update ret: %s', ret)
-    
+
 
     # --------------------------------------------------------------------------
     #
@@ -254,11 +254,11 @@ class Agent_0(rpu.Worker):
         agent instance on the respective node.  We pass it to the seconds
         bootstrap level, there is no need to pass the first one again.
         """
-    
+
         # FIXME: we need a watcher cb to watch sub-agent state
-    
+
         self._log.debug('start_sub_agents')
-    
+
         if not self._cfg.get('agents'):
             self._log.debug('start_sub_agents noop')
             return
@@ -272,22 +272,22 @@ class Agent_0(rpu.Worker):
         # non-local sub_agents.
         agent_lm   = None
         for sa in self._cfg['agents']:
-    
+
             target = self._cfg['agents'][sa]['target']
-    
+
             if target == 'local':
-    
+
                 # start agent locally
                 cmdline = "/bin/sh -l %s/bootstrap_2.sh %s" % (os.getcwd(), sa)
-    
+
             elif target == 'node':
-    
+
                 if not agent_lm:
                     agent_lm = rpa_lm.LaunchMethod.create(
                         name    = self._cfg['agent_launch_method'],
                         cfg     = self._cfg,
                         session = self._session)
-    
+
                 node = self._cfg['lrms_info']['agent_nodes'][sa]
                 # start agent remotely, use launch method
                 # NOTE:  there is some implicit assumption that we can use
@@ -315,7 +315,7 @@ class Agent_0(rpu.Worker):
                         }
                 cmd, hop = agent_lm.construct_command(agent_cmd,
                         launch_script_hop='/usr/bin/env RP_SPAWNER_HOP=TRUE "%s"' % ls_name)
-    
+
                 with open (ls_name, 'w') as ls:
                     # note that 'exec' only makes sense if we don't add any
                     # commands (such as post-processing) after it.
@@ -323,10 +323,10 @@ class Agent_0(rpu.Worker):
                     ls.write("exec %s\n" % cmd)
                     st = os.stat(ls_name)
                     os.chmod(ls_name, st.st_mode | stat.S_IEXEC)
-    
+
                 if hop : cmdline = hop
                 else   : cmdline = ls_name
-    
+
             # spawn the sub-agent
             self._log.info ("create sub-agent %s: %s" % (sa, cmdline))
             class _SA(ru.Process):
@@ -359,10 +359,10 @@ class Agent_0(rpu.Worker):
                         except Exception as e:
                             # we are likely racing on termination...
                             self._log.warn('%s term failed: %s', self._sa, e)
-    
+
             # the agent is up - let the watcher manage it from here
             self.register_watchable(_SA(sa, cmdline, log=self._log))
-    
+
         self._log.debug('start_sub_agents done')
 
 
@@ -375,7 +375,7 @@ class Agent_0(rpu.Worker):
         self._prof.prof('heartbeat', msg='Listen! Listen! Listen to the heartbeat!',
                         uid=self._owner)
 
-        if not self._check_commands(): return False 
+        if not self._check_commands(): return False
         if not self._check_state   (): return False
 
         return True
@@ -412,7 +412,7 @@ class Agent_0(rpu.Worker):
                 self._final_cause = 'cancel'
                 with open('./killme.signal', 'w+') as f:
                     f.write('cancel pilot cmd received\n')
-        
+
               # ru.attach_pudb(logger=self._log)
 
                 self.stop()
@@ -422,7 +422,7 @@ class Agent_0(rpu.Worker):
                 self._log.info('cancel unit cmd')
                 self.publish(rpc.CONTROL_PUBSUB, {'cmd' : 'cancel_unit',
                                                   'arg' : arg})
-            else: 
+            else:
                 self._log.error('could not interpret cmd "%s" - ignore', cmd)
                 return False  # abort
 
@@ -460,7 +460,7 @@ class Agent_0(rpu.Worker):
         # and log that we pulled it.
         #
         # FIXME: Unfortunately, 'find_and_modify' is not bulkable, so we have
-        #        to use 'find'.  To avoid finding the same units over and over 
+        #        to use 'find'.  To avoid finding the same units over and over
         #        again, we update the 'control' field *before* running the next
         #        find -- so we do it right here.
         #        This also blocks us from using multiple ingest threads, or from

--- a/src/radical/pilot/db/database.py
+++ b/src/radical/pilot/db/database.py
@@ -157,7 +157,8 @@ class DBSession(object):
         close the session
         """
         if self.closed:
-            raise RuntimeError('No active session.')
+            return None
+          # raise RuntimeError('No active session.')
 
         self._closed = time.time()
 
@@ -180,7 +181,8 @@ class DBSession(object):
         Adds a pilot managers doc
         """
         if self.closed:
-            raise Exception('No active session.')
+            return None
+          # raise Exception('No active session.')
 
         pmgr_doc['_id']  = pmgr_doc['uid']
         pmgr_doc['type'] = 'pmgr'
@@ -200,7 +202,8 @@ class DBSession(object):
         # FIXME: explicit bulk vs. insert(multi=True)
 
         if self.closed:
-            raise Exception('No active session.')
+            return None
+          # raise Exception('No active session.')
 
         bulk = self._c.initialize_ordered_bulk_op()
 
@@ -230,7 +233,8 @@ class DBSession(object):
         """
 
         if self.closed:
-            raise Exception('session is closed')
+            return None
+          # raise Exception('session is closed')
 
         if not self._c:
             raise Exception('session is disconnected ')
@@ -295,7 +299,8 @@ class DBSession(object):
         return dict {uid:unit}
         """
         if self.closed:
-            raise Exception("No active session.")
+            return None
+          # raise Exception("No active session.")
 
         if not unit_ids:
             cursor = self._c.find({'type' : 'unit', 
@@ -326,7 +331,8 @@ class DBSession(object):
         Adds a unit managers document
         """
         if self.closed:
-            raise Exception('No active session.')
+            return None
+          # raise Exception('No active session.')
 
         umgr_doc['_id']  = umgr_doc['uid']
         umgr_doc['type'] = 'umgr'
@@ -346,7 +352,8 @@ class DBSession(object):
         # FIXME: explicit bulk vs. insert(multi=True)
 
         if self.closed:
-            raise Exception('No active session.')
+            return None
+          # raise Exception('No active session.')
 
         # We can only insert DB bulks up to a certain size, which is hardcoded
         # here.  In principle, the update should go to the update worker anyway

--- a/src/radical/pilot/pilot_manager.py
+++ b/src/radical/pilot/pilot_manager.py
@@ -124,7 +124,7 @@ class PilotManager(rpu.Component):
         # let session know we exist
         self._session._register_pmgr(self)
 
-        self._prof.prof('PMGR setup done', logger=self._log.debug)
+        self._prof.prof('PMGR setup done')
         self._log.report.ok('>>ok\n')
 
 

--- a/src/radical/pilot/pilot_manager.py
+++ b/src/radical/pilot/pilot_manager.py
@@ -172,7 +172,7 @@ class PilotManager(rpu.Component):
 
         if self._closed:
             return
-        self._closed = True
+        self._terminate.set()
 
         self._log.report.info('<<close pilot manager')
 
@@ -188,13 +188,12 @@ class PilotManager(rpu.Component):
             # if this cancel op fails and the pilots are s till alive after
             # timeout, the pmgr.launcher termination will kill them
 
-        self._terminate.set()
         self.stop()
-
 
         self._session.prof.prof('closed pmgr', uid=self._uid)
         self._log.info("Closed PilotManager %s." % self._uid)
 
+        self._closed = True
         self._log.report.ok('>>ok\n')
 
 
@@ -239,6 +238,9 @@ class PilotManager(rpu.Component):
     #
     def _state_pull_cb(self):
 
+        if self._terminate.is_set():
+            return False
+
         # pull all pilot states from the DB, and compare to the states we know
         # about.  If any state changed, update the known pilot instances and 
         # push an update message to the state pubsub.
@@ -259,6 +261,9 @@ class PilotManager(rpu.Component):
     # --------------------------------------------------------------------------
     #
     def _state_sub_cb(self, topic, msg):
+
+        if self._terminate.is_set():
+            return False
 
         cmd = msg.get('cmd')
         arg = msg.get('arg')

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -120,6 +120,21 @@ class Session(rs.Session):
         self._bridges    = list()
         self._components = list()
 
+        # FIXME: we work around some garbage collection issues we don't yet
+        #        understand: instead of relying on the GC to eventually collect
+        #        some stuff, we actively free those on `session.close()`, at
+        #        least for the current process.  Usually, all resources get
+        #        nicely collected on process termination - but not when we
+        #        create many sessions (one after the other) in the same
+        #        application instance (ie. the same process).  This workarounf
+        #        takes care of that use case.
+        #        The clean solution would be to ensure clean termination
+        #        sequence, something which I seem to be unable to implement...
+        #        :/
+        self._to_close   = list()
+        self._to_stop    = list()
+        self._to_destroy = list()
+
         # cache the client sandbox
         # FIXME: this needs to be overwritten if configured differently in the
         #        session config, as should be the case for any agent side
@@ -272,6 +287,9 @@ class Session(rs.Session):
     def _atfork_child(self)  : 
         self._components = list()
         self._bridges    = list()
+        self._to_close   = list()
+        self._to_stop    = list()
+        self._to_destroy = list()
 
     
     # --------------------------------------------------------------------------
@@ -330,7 +348,7 @@ class Session(rs.Session):
                         break
 
         finally:
-            self._valid_iter -= 1
+            pass
 
         if not self._valid and term:
             self._log.warn("session %s is invalid" % self.uid)
@@ -422,7 +440,6 @@ class Session(rs.Session):
         # close only once
         if self._closed:
             return
-        self._closed = True
 
         self._log.report.info('closing session %s' % self._uid)
         self._log.debug("session %s closing" % (str(self._uid)))
@@ -446,6 +463,12 @@ class Session(rs.Session):
             pmgr.close(terminate=terminate)
             self._log.debug("session %s closed pmgr   %s", self._uid, pmgr_uid)
 
+        for comp in self._components:
+            self._log.debug("session %s closes comp   %s", self._uid, comp.uid)
+            comp.stop()
+            comp.join()
+            self._log.debug("session %s closed comp   %s", self._uid, comp.uid)
+
         for bridge in self._bridges:
             self._log.debug("session %s closes bridge %s", self._uid, bridge.uid)
             bridge.stop()
@@ -460,6 +483,20 @@ class Session(rs.Session):
         self.prof.prof("closed", uid=self._uid)
         self.prof.close()
 
+        # support GC
+        for x in self._to_close: 
+            try:    x.close()
+            except: pass
+        for x in self._to_stop:
+            try:    x.stop()
+            except: pass
+        for x in self._to_destroy:
+            try:    x.destroy()
+            except: pass
+
+        self._closed = True
+        self._valid = False
+
         # after all is said and done, we attempt to download the pilot log- and
         # profiles, if so wanted
         if download:
@@ -470,7 +507,6 @@ class Session(rs.Session):
             self.fetch_profiles()
             self.fetch_logfiles()
 
-        self._valid = False
         self._log.report.info('<<session lifetime: %.1fs' % (self.closed - self.created))
         self._log.report.ok('>>ok\n')
 

--- a/src/radical/pilot/umgr/scheduler/base.py
+++ b/src/radical/pilot/umgr/scheduler/base.py
@@ -78,6 +78,22 @@ class UMGRSchedulingComponent(rpu.Component):
 
     # --------------------------------------------------------------------------
     #
+    def finalize_child(self):
+
+        self._log.info(' ====finalize_child')
+
+        self.unregister_subscriber(rpc.CONTROL_PUBSUB, self._base_command_cb)
+        self.unregister_subscriber(rpc.STATE_PUBSUB,   self._base_state_cb)
+        self.unregister_output(rps.UMGR_STAGING_INPUT_PENDING)
+        self.unregister_input (rps.UMGR_SCHEDULING_PENDING,
+                               rpc.UMGR_SCHEDULING_QUEUE, self.work)
+
+
+        self._log.info(' ====finalize_child done')
+
+
+    # --------------------------------------------------------------------------
+    #
     # This class-method creates the appropriate sub-class for the Scheduler.
     #
     @classmethod

--- a/src/radical/pilot/umgr/scheduler/base.py
+++ b/src/radical/pilot/umgr/scheduler/base.py
@@ -195,9 +195,6 @@ class UMGRSchedulingComponent(rpu.Component):
     #
     def _update_unit_states(self, units):
 
-      # if not units:
-      #     print ' === no units to update'
-
         self.update_units(units)
 
 

--- a/src/radical/pilot/unit_manager.py
+++ b/src/radical/pilot/unit_manager.py
@@ -118,6 +118,7 @@ class UnitManager(rpu.Component):
         cfg['owner'] = self.uid
         rpu.Component.__init__(self, cfg, session)
         self.start(spawn=False)
+        self._log.info('started umgr %s', self._uid)
 
         # only now we have a logger... :/
         self._log.report.info('<<create unit manager')
@@ -204,7 +205,6 @@ class UnitManager(rpu.Component):
         self._terminate.set()
         self.stop()
 
-        self._log.debug(" ==== closing umgr %s!\n%s", self.uid, '\n'.join(ru.get_stacktrace()))
         self._log.report.info('<<close unit manager')
 
         # we don't want any callback invokations during shutdown

--- a/src/radical/pilot/unit_manager.py
+++ b/src/radical/pilot/unit_manager.py
@@ -151,7 +151,7 @@ class UnitManager(rpu.Component):
         # let session know we exist
         self._session._register_umgr(self)
 
-        self._prof.prof('UMGR setup done', logger=self._log.debug)
+        self._prof.prof('UMGR setup done')
         self._log.report.ok('>>ok\n')
 
 

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -1043,7 +1043,7 @@ class Component(ru.Process):
             # ------------------------------------------------------------------
             def work_cb(self):
                 self.is_valid()
-                topic, msg = self._q.get_nowait(500) # timout in ms
+                topic, msg = self._q.get_nowait(500)  # timout in ms
                 if topic and msg:
                     if not isinstance(msg,list):
                         msg = [msg]

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -324,11 +324,18 @@ class Component(ru.Process):
         self._log  = self._session._get_logger(self.uid, level=self._debug)
         self._prof = self._session._get_profiler(self.uid)
 
+        self._q    = None
+        self._in   = None
+        self._out  = None
+        self._poll = None
+        self._ctx  = None
+
         # initialize the Process base class for later fork.
         super(Component, self).__init__(name=self._uid, log=self._log)
 
         # make sure we bootstrapped ok
         self.is_valid()
+        self._session._to_stop.append(self)
 
 
     # --------------------------------------------------------------------------
@@ -351,7 +358,9 @@ class Component(ru.Process):
         #       make frequency configurable.
 
         if self._ru_terminating:
-            return True
+            # don't go any further.  Specifically, don't call stop.  Calling
+            # that is up to the thing who inioated termination.
+            return False
 
         valid = True
 
@@ -613,7 +622,7 @@ class Component(ru.Process):
         self.finalize_common()
 
         # reverse order from initialize_common
-      # self.unregister_publisher(rpc.LOG_PUBSUB)
+        self.unregister_publisher(rpc.LOG_PUBSUB)
         self.unregister_publisher(rpc.STATE_PUBSUB)
         self.unregister_publisher(rpc.CONTROL_PUBSUB)
 
@@ -623,6 +632,40 @@ class Component(ru.Process):
             self._prof.close()
         except Exception:
             pass
+
+        with self._cb_lock:
+
+            for bridge in self._bridges:
+                bridge.stop()
+            self._bridges = list()
+
+            for comp in self._components:
+                comp.stop()
+            self._components = list()
+
+          # #  FIXME: the stuff below caters to unsuccessful or buggy termination
+          # #         routines - but for now all those should be served by the
+          # #         respective unregister routines.
+          #
+          # for name in self._inputs:
+          #     self._inputs[name]['queue'].stop()
+          # self._inputs = dict()
+          #
+          # for name in self._workers.keys()[:]:
+          #     del(self._workers[name])
+          #
+          # for name in self._outputs:
+          #     if self._outputs[name]:
+          #         self._outputs[name].stop()
+          # self._outputs = dict()
+          #
+          # for name in self._publishers:
+          #     self._publishers[name].stop()
+          # self._publishers = dict()
+          #
+          # for name in self._threads:
+          #     self._threads[name].stop()
+          # self._threads = dict()
 
     def finalize_common(self):
         pass # can be overloaded
@@ -660,9 +703,6 @@ class Component(ru.Process):
 
         self._log.info('stop %s (%s : %s : %s) [%s]', self.uid, os.getpid(),
                        self.pid, ru.get_thread_name(), ru.get_caller_name())
-
-        for _,t in self._threads.iteritems(): t['term'  ].set()
-        for _,t in self._threads.iteritems(): t['thread'].join()
 
         super(Component, self).stop(timeout)
 
@@ -742,6 +782,7 @@ class Component(ru.Process):
           # raise ValueError('input %s not registered' % name)
             return
 
+        self._inputs[name]['queue'].stop()
         del(self._inputs[name])
         self._log.debug('unregistered input %s', name)
 
@@ -849,57 +890,59 @@ class Component(ru.Process):
             if name in self._threads:
                 raise ValueError('cb %s already registered' % cb.__name__)
 
-        if timer == None: timer = 0.0  # NOTE: busy idle loop
-        else            : timer = float(timer)
+            if timer == None: timer = 0.0  # NOTE: busy idle loop
+            else            : timer = float(timer)
 
-        # create a separate thread per idle cb, and let it be watched by the
-        # ru.Process base class
-        #
-        # ----------------------------------------------------------------------
-        # NOTE: idle timing is a tricky beast: if we sleep for too long, then we
-        #       have to wait that long on stop() for the thread to get active
-        #       again and terminate/join.  So we always sleep just a little, and
-        #       explicitly check if sufficient time has passed to activate the
-        #       callback.
-        class Idler(ru.Thread):
+            # create a separate thread per idle cb, and let it be watched by the
+            # ru.Process base class
+            #
+            # ----------------------------------------------------------------------
+            # NOTE: idle timing is a tricky beast: if we sleep for too long, then we
+            #       have to wait that long on stop() for the thread to get active
+            #       again and terminate/join.  So we always sleep just a little, and
+            #       explicitly check if sufficient time has passed to activate the
+            #       callback.
+            class Idler(ru.Thread):
 
-            # ------------------------------------------------------------------
-            def __init__(self, name, log, timer, cb, cb_data, cb_lock):
-                self._name    = name
-                self._log     = log
-                self._timeout = timer
-                self._cb      = cb
-                self._cb_data = cb_data
-                self._cb_lock = cb_lock
-                self._last    = 0.0
+                # ------------------------------------------------------------------
+                def __init__(self, name, log, timer, cb, cb_data, cb_lock):
+                    self._name    = name
+                    self._log     = log
+                    self._timeout = timer
+                    self._cb      = cb
+                    self._cb_data = cb_data
+                    self._cb_lock = cb_lock
+                    self._last    = 0.0
 
-                super(Idler, self).__init__(name=self._name, log=self._log)
+                    super(Idler, self).__init__(name=self._name, log=self._log)
 
-                # immediately start the thread upon construction
-                self.start()
+                    # immediately start the thread upon construction
+                    self.start()
 
-            # ------------------------------------------------------------------
-            def work_cb(self):
-                self.is_valid()
-                if self._timeout and (time.time()-self._last) < self._timeout:
-                    # not yet
-                    time.sleep(0.1) # FIXME: make configurable
-                    return True
+                # ------------------------------------------------------------------
+                def work_cb(self):
+                    self.is_valid()
+                    if self._timeout and (time.time()-self._last) < self._timeout:
+                        # not yet
+                        time.sleep(0.1) # FIXME: make configurable
+                        return True
 
-                with self._cb_lock:
-                    if self._cb_data != None:
-                        ret = self._cb(cb_data=self._cb_data)
-                    else:
-                        ret = self._cb()
-                if self._timeout:
-                    self._last = time.time()
-                return ret
-        # ----------------------------------------------------------------------
+                    with self._cb_lock:
+                        if self._cb_data != None:
+                            ret = self._cb(cb_data=self._cb_data)
+                        else:
+                            ret = self._cb()
+                    if self._timeout:
+                        self._last = time.time()
+                    return ret
+            # ----------------------------------------------------------------------
 
-        idler = Idler(name=name, timer=timer, log=self._log,
-                      cb=cb, cb_data=cb_data, cb_lock=self._cb_lock)
+            idler = Idler(name=name, timer=timer, log=self._log,
+                          cb=cb, cb_data=cb_data, cb_lock=self._cb_lock)
+            self._threads[name] = idler
 
         self.register_watchable(idler)
+        self._session._to_stop.append(idler)
         self._log.debug('%s registered idler %s' % (self.uid, name))
 
 
@@ -924,9 +967,7 @@ class Component(ru.Process):
               # raise ValueError('%s is not registered' % name)
                 return
 
-            entry = self._threads[name]
-            entry['term'].set()
-            entry['thread'].join()
+            self._threads[name].stop()  # implies join
             del(self._threads[name])
 
         self._log.debug("TERM : %s unregistered idler %s", self.uid, name)
@@ -977,6 +1018,7 @@ class Component(ru.Process):
 
         self._log.debug('TERM : %s unregister publisher %s', self.uid, pubsub)
 
+        self._publishers[pubsub].stop()
         del(self._publishers[pubsub])
         self._log.debug('unregistered publisher %s', pubsub)
 
@@ -1057,6 +1099,8 @@ class Component(ru.Process):
                         if not ret:
                             return False
                 return True
+            def ru_finalize_common(self):
+                self._q.stop()
         # ----------------------------------------------------------------------
         # create a pubsub subscriber (the pubsub name doubles as topic)
         # FIXME: this should be moved into the thread child_init
@@ -1066,7 +1110,11 @@ class Component(ru.Process):
         subscriber = Subscriber(name=name, l=self._log, q=q, 
                                 cb=cb, cb_data=cb_data, cb_lock=self._cb_lock)
 
+        with self._cb_lock:
+            self._threads[name] = subscriber
+
         self.register_watchable(subscriber)
+        self._session._to_stop.append(subscriber)
         self._log.debug('%s registered %s subscriber %s' % (self.uid, pubsub, name))
 
 
@@ -1090,9 +1138,7 @@ class Component(ru.Process):
               # raise ValueError('%s is not subscribed to %s' % (cb.__name__, pubsub))
                 return
 
-            entry = self._threads[name]
-            entry['term'].set()
-            entry['thread'].join()
+            self._threads[name]  # implies join
             del(self._threads[name])
 
         self._log.debug("unregistered subscriber %s", name)
@@ -1110,10 +1156,10 @@ class Component(ru.Process):
 
         self.is_valid()
 
-        for n,t in self._threads.iteritems():
-            if not t['thread'].is_alive():
-                raise RuntimeError('%s thread %s died', 
-                                    self.uid, t['thread'].name)
+        with self._cb_lock:
+            for tname in self._threads:
+                if not self._threads[tname].is_alive():
+                    raise RuntimeError('%s thread %s died', self.uid, tname)
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -110,17 +110,10 @@ class Pubsub(ru.Process):
 
         super(Pubsub, self).__init__(name=self._uid, log=self._log)
 
-        self._fname = None
 
         # ----------------------------------------------------------------------
         # behavior depends on the role...
         if self._role == PUBSUB_PUB:
-
-            self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
-            with open(self._fname, 'a+') as f:
-                f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
-                f.write('\n'.join(ru.get_stacktrace()))
-                f.write('\n\n\n')
 
             self._ctx = zmq.Context()
             self._session._to_destroy.append(self._ctx)
@@ -162,12 +155,6 @@ class Pubsub(ru.Process):
 
         # ----------------------------------------------------------------------
         elif self._role == PUBSUB_SUB:
-
-            self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
-            with open(self._fname, 'a+') as f:
-                f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
-                f.write('\n'.join(ru.get_stacktrace()))
-                f.write('\n\n\n')
 
             self._ctx = zmq.Context()
             self._session._to_destroy.append(self._ctx)
@@ -225,12 +212,6 @@ class Pubsub(ru.Process):
         spt.setproctitle('rp.%s' % self._uid)
         self._log.info('start bridge %s on %s', self._uid, self._addr)
 
-        self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
-        with open(self._fname, 'a+') as f:
-            f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
-            f.write('\n'.join(ru.get_stacktrace()))
-            f.write('\n\n\n')
-
         self._ctx = zmq.Context()
         self._session._to_destroy.append(self._ctx)
 
@@ -261,12 +242,6 @@ class Pubsub(ru.Process):
     # --------------------------------------------------------------------------
     # 
     def ru_finalize_common(self):
-
-        if self._fname:
-            with open(self._fname, 'a+') as f:
-                f.write('stop  pubsub %s @ %s\n' % (self._role, ru.gettid()))
-                f.write('\n'.join(ru.get_stacktrace()))
-                f.write('\n\n\n')
 
         if self._q   : self._q  .close()
         if self._in  : self._in .close()

--- a/src/radical/pilot/utils/pubsub.py
+++ b/src/radical/pilot/utils/pubsub.py
@@ -48,6 +48,8 @@ def _uninterruptible(f, *args, **kwargs):
         cnt += 1
         try:
             return f(*args, **kwargs)
+        except zmq.ContextTerminated as e:
+            return None
         except zmq.ZMQError as e:
             if e.errno == errno.EINTR:
                 if cnt > 10:
@@ -83,6 +85,7 @@ class Pubsub(ru.Process):
         assert(self._role in PUBSUB_ROLES), 'invalid role %s' % self._role
 
         self._uid = "%s.%s" % (self._channel.replace('_', '.'), self._role)
+        self._uid = ru.generate_id(self._uid)
         self._log = self._session._get_logger(self._uid, 
                          level=self._cfg.get('log_level', 'debug'))
 
@@ -92,9 +95,13 @@ class Pubsub(ru.Process):
         else:
             self._debug = False
 
-        self._q         = None           # the zmq queue
-        self._addr_in   = None           # bridge input  addr
-        self._addr_out  = None           # bridge output addr
+        self._addr_in   = None  # bridge input  addr
+        self._addr_out  = None  # bridge output addr
+
+        self._q    = None
+        self._in   = None
+        self._out  = None
+        self._ctx  = None
 
         if not self._addr:
             self._addr = 'tcp://*:*'
@@ -103,16 +110,26 @@ class Pubsub(ru.Process):
 
         super(Pubsub, self).__init__(name=self._uid, log=self._log)
 
+        self._fname = None
 
         # ----------------------------------------------------------------------
         # behavior depends on the role...
         if self._role == PUBSUB_PUB:
 
-            ctx = zmq.Context()
-            self._q = ctx.socket(zmq.PUB)
+            self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
+            with open(self._fname, 'a+') as f:
+                f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
+                f.write('\n'.join(ru.get_stacktrace()))
+                f.write('\n\n\n')
+
+            self._ctx = zmq.Context()
+            self._session._to_destroy.append(self._ctx)
+
+            self._q   = self._ctx.socket(zmq.PUB)
             self._q.linger = _LINGER_TIMEOUT
             self._q.hwm    = _HIGH_WATER_MARK
             self._q.connect(self._addr)
+            self.start(spawn=False)
 
 
         # ----------------------------------------------------------------------
@@ -146,11 +163,20 @@ class Pubsub(ru.Process):
         # ----------------------------------------------------------------------
         elif self._role == PUBSUB_SUB:
 
-            ctx = zmq.Context()
-            self._q = ctx.socket(zmq.SUB)
+            self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
+            with open(self._fname, 'a+') as f:
+                f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
+                f.write('\n'.join(ru.get_stacktrace()))
+                f.write('\n\n\n')
+
+            self._ctx = zmq.Context()
+            self._session._to_destroy.append(self._ctx)
+
+            self._q   = self._ctx.socket(zmq.SUB)
             self._q.linger = _LINGER_TIMEOUT
             self._q.hwm    = _HIGH_WATER_MARK
             self._q.connect(self._addr)
+            self.start(spawn=False)
 
 
     # --------------------------------------------------------------------------
@@ -199,13 +225,21 @@ class Pubsub(ru.Process):
         spt.setproctitle('rp.%s' % self._uid)
         self._log.info('start bridge %s on %s', self._uid, self._addr)
 
-        ctx = zmq.Context()
-        self._in = ctx.socket(zmq.XSUB)
+        self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
+        with open(self._fname, 'a+') as f:
+            f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
+            f.write('\n'.join(ru.get_stacktrace()))
+            f.write('\n\n\n')
+
+        self._ctx = zmq.Context()
+        self._session._to_destroy.append(self._ctx)
+
+        self._in  = self._ctx.socket(zmq.XSUB)
         self._in.linger = _LINGER_TIMEOUT
         self._in.hwm    = _HIGH_WATER_MARK
         self._in.bind(self._addr)
 
-        self._out = ctx.socket(zmq.XPUB)
+        self._out = self._ctx.socket(zmq.XPUB)
         self._out.linger = _LINGER_TIMEOUT
         self._out.hwm    = _HIGH_WATER_MARK
         self._out.bind(self._addr)
@@ -222,6 +256,22 @@ class Pubsub(ru.Process):
         self._poll = zmq.Poller()
         self._poll.register(self._in,  zmq.POLLIN)
         self._poll.register(self._out, zmq.POLLIN)
+
+
+    # --------------------------------------------------------------------------
+    # 
+    def ru_finalize_common(self):
+
+        if self._fname:
+            with open(self._fname, 'a+') as f:
+                f.write('stop  pubsub %s @ %s\n' % (self._role, ru.gettid()))
+                f.write('\n'.join(ru.get_stacktrace()))
+                f.write('\n\n\n')
+
+        if self._q   : self._q  .close()
+        if self._in  : self._in .close()
+        if self._out : self._out.close()
+        if self._ctx : self._ctx.destroy()
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/utils/queue.py
+++ b/src/radical/pilot/utils/queue.py
@@ -178,11 +178,6 @@ class Queue(ru.Process):
             self._q.connect(self._addr)
             self.start(spawn=False)
 
-          # self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
-          # with open(self._fname, 'a+') as f:
-          #     f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
-          #     f.write('\n'.join(ru.get_stacktrace()))
-          #     f.write('\n\n\n')
 
         # ----------------------------------------------------------------------
         elif self._role == QUEUE_BRIDGE:
@@ -223,12 +218,6 @@ class Queue(ru.Process):
             self._q.hwm    = _HIGH_WATER_MARK
             self._q.connect(self._addr)
             self.start(spawn=False)
-
-          # self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
-          # with open(self._fname, 'a+') as f:
-          #     f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
-          #     f.write('\n'.join(ru.get_stacktrace()))
-          #     f.write('\n\n\n')
 
 
     # --------------------------------------------------------------------------
@@ -293,13 +282,6 @@ class Queue(ru.Process):
         self._out.hwm    = _HIGH_WATER_MARK
         self._out.bind(self._addr)
 
-      # self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
-      # with open(self._fname, 'a+') as f:
-      #     f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
-      #     f.write('\n'.join(ru.get_stacktrace()))
-      #     f.write('\n\n\n')
-
-
         # communicate the bridge ports to the parent process
         _addr_in  = self._in.getsockopt( zmq.LAST_ENDPOINT)
         _addr_out = self._out.getsockopt(zmq.LAST_ENDPOINT)
@@ -316,12 +298,6 @@ class Queue(ru.Process):
     # --------------------------------------------------------------------------
     # 
     def ru_finalize_common(self):
-
-      # if self._ctx:
-      #     with open(self._fname, 'a+') as f:
-      #         f.write('stop  pubsub %s @ %s\n' % (self._role, ru.gettid()))
-      #         f.write('\n'.join(ru.get_stacktrace()))
-      #         f.write('\n\n\n')
 
         if self._q   : self._q   .close()
         if self._in  : self._in  .close()

--- a/src/radical/pilot/utils/queue.py
+++ b/src/radical/pilot/utils/queue.py
@@ -48,6 +48,8 @@ def _uninterruptible(f, *args, **kwargs):
         cnt += 1
         try:
             return f(*args, **kwargs)
+        except zmq.ContextTerminated as e:
+            return None
         except zmq.ZMQError as e:
             if e.errno == errno.EINTR:
                 if cnt > 10:
@@ -133,6 +135,7 @@ class Queue(ru.Process):
         self._cfg['log_level'] = 'debug'
 
         self._uid = "%s.%s" % (self._qname.replace('_', '.'), self._role)
+        self._uid = ru.generate_id(self._uid)
         self._log = self._session._get_logger(self._uid, 
                          level=self._cfg.get('log_level', 'debug'))
 
@@ -144,7 +147,6 @@ class Queue(ru.Process):
         else:
             self._debug = False
 
-        self._q          = None           # the zmq queue
         self._lock       = mt.RLock()     # for _requested
         self._requested  = False          # send/recv sync
         self._addr_in    = None           # bridge input  addr
@@ -157,17 +159,30 @@ class Queue(ru.Process):
 
         self._log.info("create %s - %s - %s", self._qname, self._role, self._addr)
 
+        self._q    = None           # the zmq queue
+        self._in   = None
+        self._out  = None
+        self._ctx  = None
+
 
         # ----------------------------------------------------------------------
         # behavior depends on the role...
         if self._role == QUEUE_INPUT:
 
-            ctx = zmq.Context()
-            self._q = ctx.socket(zmq.PUSH)
+            self._ctx = zmq.Context()
+            self._session._to_destroy.append(self._ctx)
+
+            self._q   = self._ctx.socket(zmq.PUSH)
             self._q.linger = _LINGER_TIMEOUT
             self._q.hwm    = _HIGH_WATER_MARK
             self._q.connect(self._addr)
+            self.start(spawn=False)
 
+          # self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
+          # with open(self._fname, 'a+') as f:
+          #     f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
+          #     f.write('\n'.join(ru.get_stacktrace()))
+          #     f.write('\n\n\n')
 
         # ----------------------------------------------------------------------
         elif self._role == QUEUE_BRIDGE:
@@ -200,11 +215,20 @@ class Queue(ru.Process):
         # ----------------------------------------------------------------------
         elif self._role == QUEUE_OUTPUT:
 
-            ctx = zmq.Context()
-            self._q = ctx.socket(zmq.REQ)
+            self._ctx = zmq.Context()
+            self._session._to_destroy.append(self._ctx)
+
+            self._q   = self._ctx.socket(zmq.REQ)
             self._q.linger = _LINGER_TIMEOUT
             self._q.hwm    = _HIGH_WATER_MARK
             self._q.connect(self._addr)
+            self.start(spawn=False)
+
+          # self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
+          # with open(self._fname, 'a+') as f:
+          #     f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
+          #     f.write('\n'.join(ru.get_stacktrace()))
+          #     f.write('\n\n\n')
 
 
     # --------------------------------------------------------------------------
@@ -256,16 +280,25 @@ class Queue(ru.Process):
         # FIXME: should we cache messages coming in at the pull/push 
         #        side, so as not to block the push end?
 
-        ctx = zmq.Context()
-        self._in = ctx.socket(zmq.PULL)
+        self._ctx = zmq.Context()
+        self._session._to_destroy.append(self._ctx)
+
+        self._in = self._ctx.socket(zmq.PULL)
         self._in.linger = _LINGER_TIMEOUT
         self._in.hwm    = _HIGH_WATER_MARK
         self._in.bind(self._addr)
 
-        self._out = ctx.socket(zmq.REP)
+        self._out = self._ctx.socket(zmq.REP)
         self._out.linger = _LINGER_TIMEOUT
         self._out.hwm    = _HIGH_WATER_MARK
         self._out.bind(self._addr)
+
+      # self._fname = '/tmp/r/%s' % ru.generate_id(self._uid, ru.ID_PRIVATE)
+      # with open(self._fname, 'a+') as f:
+      #     f.write('start pubsub %s @ %s\n' % (self._role, ru.gettid()))
+      #     f.write('\n'.join(ru.get_stacktrace()))
+      #     f.write('\n\n\n')
+
 
         # communicate the bridge ports to the parent process
         _addr_in  = self._in.getsockopt( zmq.LAST_ENDPOINT)
@@ -278,6 +311,22 @@ class Queue(ru.Process):
         # start polling for messages
         self._poll = zmq.Poller()
         self._poll.register(self._out, zmq.POLLIN)
+
+
+    # --------------------------------------------------------------------------
+    # 
+    def ru_finalize_common(self):
+
+      # if self._ctx:
+      #     with open(self._fname, 'a+') as f:
+      #         f.write('stop  pubsub %s @ %s\n' % (self._role, ru.gettid()))
+      #         f.write('\n'.join(ru.get_stacktrace()))
+      #         f.write('\n\n\n')
+
+        if self._q   : self._q   .close()
+        if self._in  : self._in  .close()
+        if self._out : self._out .close()
+        if self._ctx : self._ctx.destroy()
 
 
     # --------------------------------------------------------------------------
@@ -321,7 +370,8 @@ class Queue(ru.Process):
                     break
             if not data:
                 if not self.is_alive(strict=False):
-                    raise RuntimeError('not alive anymore?')
+                    self._log.warn('not alive anymore?')
+                    return False
             msg = msgpack.unpackb(data) 
             if isinstance(msg, list): 
                 msgs += msg

--- a/src/radical/pilot/worker/update.py
+++ b/src/radical/pilot/worker/update.py
@@ -4,21 +4,19 @@ __license__   = "MIT"
 
 
 import time
-import pprint
 import threading
 import pymongo
 
 import radical.utils as ru
 
 from .. import utils     as rpu
-from .. import states    as rps
 from .. import constants as rpc
 
 
 # ==============================================================================
 #
-DEFAULT_BULK_COLLECTION_TIME =  1.0 # seconds
-DEFAULT_BULK_COLLECTION_SIZE =  100 # seconds
+DEFAULT_BULK_COLLECTION_TIME =  1.0  # seconds
+DEFAULT_BULK_COLLECTION_SIZE =  100  # seconds
 
 
 # ==============================================================================
@@ -62,9 +60,9 @@ class Update(rpu.Worker):
         self._mongo_db   = db
         self._coll       = self._mongo_db[self._session_id]
         self._bulk       = self._coll.initialize_ordered_bulk_op()
-        self._last       = time.time()       # time of last bulk push
-        self._uids       = list()            # list of collected uids
-        self._lock       = threading.RLock() # protect _bulk
+        self._last       = time.time()        # time of last bulk push
+        self._uids       = list()             # list of collected uids
+        self._lock       = threading.RLock()  # protect _bulk
 
         self._bct        = self._cfg.get('bulk_collection_time',
                                           DEFAULT_BULK_COLLECTION_TIME)
@@ -74,22 +72,17 @@ class Update(rpu.Worker):
         self.register_subscriber(rpc.STATE_PUBSUB, self._state_cb)
         self.register_timed_cb(self._idle_cb, timer=self._bct)
 
-        self._log.info(' ==== init update')
-
 
     # --------------------------------------------------------------------------
     #
     def stop(self):
 
-        self._log.info(' ==== stop update')
         super(Update, self).stop()
 
 
     # --------------------------------------------------------------------------
     #
     def finalize_child(self):
-
-        self._log.info(' ==== final update')
 
         self.unregister_timed_cb(self._idle_cb)
         self.unregister_subscriber(rpc.STATE_PUBSUB, self._state_cb)
@@ -131,10 +124,10 @@ class Update(rpu.Worker):
             ttype = entry[1]
             state = entry[2]
             if state:
-                self._prof.prof('update', msg='%s update pushed (%s)' \
+                self._prof.prof('update', msg='%s update pushed (%s)'
                                 % (ttype, state), uid=uid)
             else:
-                self._prof.prof('update', msg='%s update pushed' % ttype, 
+                self._prof.prof('update', msg='%s update pushed' % ttype,
                                 uid=uid)
 
         # empty bulk, refresh state
@@ -213,23 +206,22 @@ class Update(rpu.Worker):
             things = [things]
 
 
-        # FIXME: we don't have any error recovery -- any failure to update 
+        # FIXME: we don't have any error recovery -- any failure to update
         #        state in the DB will thus result in an exception here and tear
         #        down the module.
         for thing in things:
 
             # got a new request.  Add to bulk (create as needed),
             # and push bulk if time is up.
-            uid       = thing['uid']
-            ttype     = thing['type']
-            state     = thing['state']
-            timestamp = thing.get('state_timestamp', time.time())
+            uid   = thing['uid']
+            ttype = thing['type']
+            state = thing['state']
 
             if 'clone' in uid:
                 # we don't push clone states to DB
                 return True
 
-            self._prof.prof('get', msg="update %s state to %s" % (ttype, state), 
+            self._prof.prof('get', msg="update %s state to %s" % (ttype, state),
                             uid=uid)
 
             if not state:

--- a/src/radical/pilot/worker/update.py
+++ b/src/radical/pilot/worker/update.py
@@ -74,6 +74,26 @@ class Update(rpu.Worker):
         self.register_subscriber(rpc.STATE_PUBSUB, self._state_cb)
         self.register_timed_cb(self._idle_cb, timer=self._bct)
 
+        self._log.info(' ==== init update')
+
+
+    # --------------------------------------------------------------------------
+    #
+    def stop(self):
+
+        self._log.info(' ==== stop update')
+        super(Update, self).stop()
+
+
+    # --------------------------------------------------------------------------
+    #
+    def finalize_child(self):
+
+        self._log.info(' ==== final update')
+
+        self.unregister_timed_cb(self._idle_cb)
+        self.unregister_subscriber(rpc.STATE_PUBSUB, self._state_cb)
+
 
     # --------------------------------------------------------------------------
     #


### PR DESCRIPTION
This is a new attempt to improve resource RP's resource handling.  More specifically, it reduces the reliance on Python's garbage collection to destroy object handles, and indirectly ZMQ message channels.  

Note that this is not a complete fix: repeated creations of RP sessions in the same application (more precisely in the same Python interpreter instance) will still leak resources, and `select()` will complain about too many socket handles after about 60 sessions (default configuration, on Linux).