### PR TITLE
Updating SuperMIC pre_bootstrap

### DIFF
--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -720,7 +720,7 @@
         "agent_launch_method"         : "SSH",
         "task_launch_method"          : "SSH",
         "mpi_launch_method"           : "MPIEXEC",
-        "pre_bootstrap_1"             : ["module load python"],
+        "pre_bootstrap_1"             : ["module load python/2.7.7/GCC-4.9.0"],
         "default_remote_workdir"      : "/work/$USER",
         "valid_roots"                 : ["/work"],
         "rp_version"                  : "local",


### PR DESCRIPTION
Explicitly specifying the module. Tested successfully using the following stack running `00_getting_started.py`:

```
  python               : 2.7.12
  pythonpath           : 
  virtualenv           : /home/mingtha/rp_testing/supermic_testing

  radical.pilot        : 0.47-v0.46.2-143-g4c99ec74@fix-1478
  radical.utils        : 0.47-v0.46-63-gc1ae8ac@rc-v0.46.3
  saga                 : 0.47-v0.46-20-g8ea2302c@rc-v0.46.3
```

It would be great it someone can confirm this