### PR TITLE
Fix/issue 1538

### DIFF
--- a/src/radical/pilot/agent/agent_0.py
+++ b/src/radical/pilot/agent/agent_0.py
@@ -55,7 +55,7 @@ class Agent_0(rpu.Worker):
 
         self._uid         = agent_name
         self._pid         = cfg['pilot_id']
-        self._session_id  = cfg['session_id']
+        self._sid         = cfg['session_id']
         self._runtime     = cfg['runtime']
         self._starttime   = time.time()
         self._final_cause = None
@@ -94,7 +94,7 @@ class Agent_0(rpu.Worker):
         # from the config copy.
         session_cfg = copy.deepcopy(cfg)
         session_cfg['components'] = dict()
-        session = rp_Session(cfg=session_cfg)
+        session = rp_Session(cfg=session_cfg, uid=self._sid)
 
         # we still want the bridge addresses known though, so make sure they are
         # merged into our own copy, along with any other additions done by the

--- a/src/radical/pilot/agent/agent_n.py
+++ b/src/radical/pilot/agent/agent_n.py
@@ -43,8 +43,8 @@ class Agent_n(rpu.Worker):
         cfg        = ru.read_json_str(agent_cfg)
 
         self._uid         = agent_name
-        self._pilot_id    = cfg['pilot_id']
-        self._session_id  = cfg['session_id']
+        self._pid         = cfg['pilot_id']
+        self._sid         = cfg['session_id']
         self._final_cause = None
 
         # Create a session.  
@@ -57,7 +57,7 @@ class Agent_n(rpu.Worker):
         session_cfg = copy.deepcopy(cfg)
         session_cfg['owner']      = self._uid
         session_cfg['components'] = dict()
-        session = rp_Session(cfg=session_cfg, _connect=False)
+        session = rp_Session(cfg=session_cfg, _connect=False, uid=self._sid)
 
         # we still want the bridge addresses known though, so make sure they are
         # merged into our own copy, along with any other additions done by the

--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -76,7 +76,7 @@
             "module swap PrgEnv-pgi PrgEnv-gnu",
             "module load python",
             "module use --append /lustre/atlas/world-shared/csc230/openmpi/modules/",
-            "module load openmpi/2017_05_04_539f71d",
+            "module load openmpi/2018_01_16_539f71d",
             # Workaround for ZMQ runtime failure
             "export LD_PRELOAD=/lib64/librt.so.1"
         ],
@@ -122,7 +122,7 @@
             "module swap PrgEnv-pgi PrgEnv-gnu",
             "module load python",
             "module use --append /lustre/atlas/world-shared/csc230/openmpi/modules/",
-            "module load openmpi/2017_05_04_539f71d",
+            "module load openmpi/2018_01_16_539f71d",
             # Workaround for ZMQ runtime failure
             "export LD_PRELOAD=/lib64/librt.so.1"
         ],

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -144,9 +144,6 @@ class Session(rs.Session):
         # The resource configuration dictionary associated with the session.
         self._resource_configs = {}
 
-        # initialize the base class (saga session)
-        rs.Session.__init__(self)
-
         # if a config is given, us its values:
         if cfg:
             self._cfg = copy.deepcopy(cfg)
@@ -199,6 +196,10 @@ class Session(rs.Session):
 
         self._dburl = ru.Url(dburl)
         self._cfg['dburl'] = str(self._dburl)
+
+        # now we have config and uid - initialize base class (saga session)
+        rs.Session.__init__(self, uid=self._uid)
+
 
         # ----------------------------------------------------------------------
         # create new session


### PR DESCRIPTION
This requires a simultaneous merge in RS.  The patch allows to share the RP session ID with the inherited SAGA session, which in turn avoids that the RP agent  creates its own session ID, which in turn would require `$HOME/.radical` for  state management, which is not available on some clusters (titan).  Sharing the ID for the inherited session is semantically the right thing to do anyway.  I'll open a ticket to clean up session ID management, which should not be shared between the layers anyway.