### PR TITLE
improve static ve creation script

### DIFF
--- a/bin/radicalpilot-create-static-ve
+++ b/bin/radicalpilot-create-static-ve
@@ -89,15 +89,20 @@ esac
 
 if test "$arg" = "bw"
 then
+    # BW wants us to run all things python in its own process group (I assume
+    # a cgroup or something), so we spawn that here and continue the script at
+    # the same place
     echo "invoke BW magic"
     module load bwpy
     exec bwpy-environment -- /bin/sh "$script" "$prefix" bwpy
 
 elif test "$arg" = "bwpy"
 then
+    # this is where we end up after the `exec` call in the branch above
     echo "create bwpy ve [$prefix]"
 
 else
+    # this is not BW.
     echo "create rct ve [$prefix]"
 
 fi
@@ -127,43 +132,10 @@ python_version=`python -c 'import distutils.sysconfig as sc; print sc.get_python
 ve_mod_prefix=` python -c 'import distutils.sysconfig as sc; print sc.get_python_lib()'`
 rp_mod_prefix=`echo $ve_mod_prefix | sed -e "s|$prefix|$prefix/rp_install/|"`
 
-# # we actually stop at this point.  RP has other dependencies nowadays, which are
-# # not always solved by the simple script above, namely ORTE, and
-# # morespecifically (and indirectly) libffi.  radical-pilot-deploy-ompi.sh needs
-# # to run before rp installation has a chance to succeed (usually).
-# exit
-# 
-# 
-# # NOTE: the code below is left in, as it might get reactivated at some point.
-# PYTHONPATH="$rp_mod_prefix:$PYTHONPATH"
-# export PYTHONPATH
-# 
-# PATH="$prefix/rp_install/bin:$PATH"
-# export PATH
-# 
-# # we need to add the radical name __init__.py manually here --
-# # distutil is broken and will not install it.  That file is necessary to have
-# # the 'radical' namespace searchable by python's import.
-# mkdir -p   "$rp_mod_prefix/radical/"
-# ru_ns_init="$rp_mod_prefix/radical/__init__.py"
-# echo                                              >  $ru_ns_init
-# echo 'import pkg_resources'                       >> $ru_ns_init
-# echo 'pkg_resources.declare_namespace (__name__)' >> $ru_ns_init
-# echo                                              >> $ru_ns_init
-# 
-# PIP_INSTALL="pip install --install-option='--prefix=$prefix/rp_install'"
-# $PIP_INSTALL radical.utils || exit 1
-# $PIP_INSTALL saga-python   || exit 1
-# $PIP_INSTALL radical.pilot || exit 1
-# 
-# OLD_SAGA_VERBOSE=$SAGA_VERBOSE
-# OLD_RADICAL_VERBOSE=$RADICAL_VERBOSE
-# OLD_RADICAL_PILOT_VERBOSE=$RADICAL_PILOT_VERBOSE
-# 
-# SAGA_VERBOSE=WARNING
-# RADICAL_VERBOSE=WARNING
-# RADICAL_PILOT_VERBOSE=WARNING
-
+# BW doesn't like us anymore: after loading the bwpy module, we also need to
+# create a new process group to get a  workable Python.  We thus patch the
+# virtualenv to do the necessary actions automatically, by wrapping the python
+# executable in a small script which sets up that environment.
 if test "$arg" = "bwpy"
 then
 
@@ -172,9 +144,8 @@ then
     cd $prefix/bin
     cwd=$(pwd -P)
 
-    # find binary
-    # NOTE: fucking virtualenv seems to pick the bin name randomly or
-    #       whatever...
+    # find binary - fucking virtualenv seems to pick the bin name randomly or
+    # whatever...
     for p in python python2 python2.7
     do
         if ! test -h $p

--- a/bin/radicalpilot-create-static-ve
+++ b/bin/radicalpilot-create-static-ve
@@ -94,7 +94,7 @@ then
     # the same place
     echo "invoke BW magic"
     module load bwpy
-    exec cbwpy-environ -- /bin/sh "$script" "$prefix" bwpy
+    exec bwpy-environ -- /bin/sh "$script" "$prefix" bwpy
 
 elif test "$arg" = "bwpy"
 then
@@ -153,7 +153,7 @@ then
             echo "patch $p"
             mv $p $p-exe
             echo "#!/bin/sh" > $p
-            echo "exec cbwpy-environ -- $cwd/$p-exe \"\$@\"" >> $p
+            echo "exec bwpy-environ -- $cwd/$p-exe \"\$@\"" >> $p
             chmod 0755  $p
         else
             echo "skip  $p"

--- a/bin/radicalpilot-create-static-ve
+++ b/bin/radicalpilot-create-static-ve
@@ -24,7 +24,8 @@ help(){
 
     cat <<EOT
 
-    usage: $0 <target> [-h]
+    usage: $0 -h
+    usage: $0 <target>
 
     This script creates a virtualenv at the given target location.  That
     virtualenv should be suitable to be used as static VE for a radical.pilot
@@ -34,6 +35,17 @@ EOT
     exit $ret
 }
 
+
+# ------------------------------------------------------------------------------
+#
+progress(){
+
+  while read X
+  do
+    echo -n .
+  done
+  echo
+}
 
 # ------------------------------------------------------------------------------
 #
@@ -64,76 +76,25 @@ case $prefix in
         prefix="`pwd`/$prefix"
         ;;
 esac
-echo "using install prefix $prefix"
+
 
 # create the ve, install bare necessities
 mkdir -p "$prefix"
-mkdir -p "$prefix/rp_install"
 
-virtualenv "$prefix"
+echo -n "create  virtualenv"
+stdbuf -oL virtualenv "$prefix" | progress
 .          "$prefix"/bin/activate
-pip install --upgrade $setuptools || exit 1
-pip install --upgrade $pip        || exit 1
-pip install --upgrade $reqs       || exit 1
 
-# install the radical stack (utils, saga, pilot) into a separate tree
-# ($prefix/rp_install(, so that any local install can use the ve *w/o* 
-# the radical stack, by re-routing PYTHONPATH
-python_version=`python -c 'import distutils.sysconfig as sc; print sc.get_python_version()'`
-ve_mod_prefix=` python -c 'import distutils.sysconfig as sc; print sc.get_python_lib()'`
-rp_mod_prefix=`echo $ve_mod_prefix | sed -e "s|$prefix|$prefix/rp_install/|"`
+# echo "--- update  setuptools"
+# pip install --upgrade $setuptools || exit 1
+# echo "--- update  pip"
+# pip install --upgrade $pip        || exit 1
 
-# we actually stop at this point.  RP has other dependencies nowadays, which are
-# not always solved by the simple script above, namely ORTE, and
-# morespecifically (and indirectly) libffi.  radical-pilot-deploy-ompi.sh needs
-# to run before rp installation has a chance to succeed (usually).
-exit
+for req in $reqs
+do
+    echo -n "install $req "
+    stdbuf -oL pip install --upgrade $req | progress   || exit 1
+done
 
-
-# NOTE: the code below is left in, as it might get reactivated at some point.
-PYTHONPATH="$rp_mod_prefix:$PYTHONPATH"
-export PYTHONPATH
-
-PATH="$prefix/rp_install/bin:$PATH"
-export PATH
-
-# we need to add the radical name __init__.py manually here --
-# distutil is broken and will not install it.  That file is necessary to have
-# the 'radical' namespace searchable by python's import.
-mkdir -p   "$rp_mod_prefix/radical/"
-ru_ns_init="$rp_mod_prefix/radical/__init__.py"
-echo                                              >  $ru_ns_init
-echo 'import pkg_resources'                       >> $ru_ns_init
-echo 'pkg_resources.declare_namespace (__name__)' >> $ru_ns_init
-echo                                              >> $ru_ns_init
-
-PIP_INSTALL="pip install --install-option='--prefix=$prefix/rp_install'"
-$PIP_INSTALL radical.utils || exit 1
-$PIP_INSTALL saga-python   || exit 1
-$PIP_INSTALL radical.pilot || exit 1
-
-OLD_SAGA_VERBOSE=$SAGA_VERBOSE
-OLD_RADICAL_VERBOSE=$RADICAL_VERBOSE
-OLD_RADICAL_PILOT_VERBOSE=$RADICAL_PILOT_VERBOSE
-
-SAGA_VERBOSE=WARNING
-RADICAL_VERBOSE=WARNING
-RADICAL_PILOT_VERBOSE=WARNING
-
-# print the ve information and stack versions for verification
 echo
-echo "---------------------------------------------------------------------"
-echo
-echo "PYTHONPATH: $PYTHONPATH"
-echo "python: `which python` (`python --version`)"
-python -c 'print "utils :",; import radical.utils as ru; print ru.version_detail,; print ru.__file__'
-python -c 'print "saga  :",; import saga          as rs; print rs.version_detail,; print rs.__file__'
-python -c 'print "pilot :",; import radical.pilot as rp; print rp.version_detail,; print rp.__file__'
-echo
-echo "---------------------------------------------------------------------"
-echo
-
-SAGA_VERBOSE=$OLD_SAGA_VERBOSE
-RADICAL_VERBOSE=$OLD_RADICAL_VERBOSE
-RADICAL_PILOT_VERBOSE=$OLD_RADICAL_PILOT_VERBOSE
 

--- a/bin/radicalpilot-create-static-ve
+++ b/bin/radicalpilot-create-static-ve
@@ -1,13 +1,24 @@
 #!/bin/sh
 
-scriptname="radical-pilot-create-static-ve"
+script="$0"
+prefix="$1"
+arg="$2"
+
+echo 
+echo "script : $script"
+echo "prefix : $prefix"
+echo "arg    : $arg"
+echo
 
 reqs="pymongo==2.8 python-hostlist netifaces==0.10.4 setproctitle ntplib pyzmq"
 reqs="$reqs apache-libcloud colorama backports.ssl-match-hostname msgpack-python"
 reqs="$reqs future"
 
-setuptools="setuptools==0.6c11"
-pip="pip==1.4.1"
+# setuptools="setuptools==0.6c11"
+# pip="pip==1.4.1"
+
+setuptools="setuptools"
+pip="pip"
 
 # ------------------------------------------------------------------------------
 #
@@ -24,8 +35,7 @@ help(){
 
     cat <<EOT
 
-    usage: $0 -h
-    usage: $0 <target>
+    usage: $0 <target> [-h]
 
     This script creates a virtualenv at the given target location.  That
     virtualenv should be suitable to be used as static VE for a radical.pilot
@@ -49,7 +59,6 @@ progress(){
 
 # ------------------------------------------------------------------------------
 #
-prefix=$1
 
 if test "$prefix" = "-h"
 then
@@ -78,17 +87,32 @@ case $prefix in
 esac
 
 
+if test "$arg" = "bw"
+then
+    echo "invoke BW magic"
+    module load bwpy
+    exec bwpy-environment -- /bin/sh "$script" "$prefix" bwpy
+
+elif test "$arg" = "bwpy"
+then
+    echo "create bwpy ve [$prefix]"
+
+else
+    echo "create rct ve [$prefix]"
+
+fi
+
 # create the ve, install bare necessities
 mkdir -p "$prefix"
 
-echo -n "create  virtualenv"
+echo -n "create  virtualenv "
 stdbuf -oL virtualenv "$prefix" | progress
 .          "$prefix"/bin/activate
 
-# echo "--- update  setuptools"
-# pip install --upgrade $setuptools || exit 1
-# echo "--- update  pip"
-# pip install --upgrade $pip        || exit 1
+echo -n "update  setuptools "
+pip install --upgrade $setuptools | progress || exit 1
+echo -n "update  pip "
+pip install --upgrade $pip        | progress || exit 1
 
 for req in $reqs
 do
@@ -96,5 +120,83 @@ do
     stdbuf -oL pip install --upgrade $req | progress   || exit 1
 done
 
+# install the radical stack (utils, saga, pilot) into a separate tree
+# ($prefix/rp_install(, so that any local install can use the ve *w/o* 
+# the radical stack, by re-routing PYTHONPATH
+python_version=`python -c 'import distutils.sysconfig as sc; print sc.get_python_version()'`
+ve_mod_prefix=` python -c 'import distutils.sysconfig as sc; print sc.get_python_lib()'`
+rp_mod_prefix=`echo $ve_mod_prefix | sed -e "s|$prefix|$prefix/rp_install/|"`
+
+# # we actually stop at this point.  RP has other dependencies nowadays, which are
+# # not always solved by the simple script above, namely ORTE, and
+# # morespecifically (and indirectly) libffi.  radical-pilot-deploy-ompi.sh needs
+# # to run before rp installation has a chance to succeed (usually).
+# exit
+# 
+# 
+# # NOTE: the code below is left in, as it might get reactivated at some point.
+# PYTHONPATH="$rp_mod_prefix:$PYTHONPATH"
+# export PYTHONPATH
+# 
+# PATH="$prefix/rp_install/bin:$PATH"
+# export PATH
+# 
+# # we need to add the radical name __init__.py manually here --
+# # distutil is broken and will not install it.  That file is necessary to have
+# # the 'radical' namespace searchable by python's import.
+# mkdir -p   "$rp_mod_prefix/radical/"
+# ru_ns_init="$rp_mod_prefix/radical/__init__.py"
+# echo                                              >  $ru_ns_init
+# echo 'import pkg_resources'                       >> $ru_ns_init
+# echo 'pkg_resources.declare_namespace (__name__)' >> $ru_ns_init
+# echo                                              >> $ru_ns_init
+# 
+# PIP_INSTALL="pip install --install-option='--prefix=$prefix/rp_install'"
+# $PIP_INSTALL radical.utils || exit 1
+# $PIP_INSTALL saga-python   || exit 1
+# $PIP_INSTALL radical.pilot || exit 1
+# 
+# OLD_SAGA_VERBOSE=$SAGA_VERBOSE
+# OLD_RADICAL_VERBOSE=$RADICAL_VERBOSE
+# OLD_RADICAL_PILOT_VERBOSE=$RADICAL_PILOT_VERBOSE
+# 
+# SAGA_VERBOSE=WARNING
+# RADICAL_VERBOSE=WARNING
+# RADICAL_PILOT_VERBOSE=WARNING
+
+if test "$arg" = "bwpy"
+then
+
+    echo "fix bwpy ve"
+    old_cwd=$(pwd)
+    cd $prefix/bin
+    cwd=$(pwd -P)
+
+    # find binary
+    # NOTE: fucking virtualenv seems to pick the bin name randomly or
+    #       whatever...
+    for p in python python2 python2.7
+    do
+        if ! test -h $p
+        then
+            echo "patch $p"
+            mv $p $p-exe
+            echo "#!/bin/sh" > $p
+            echo "exec bwpy-environment -- $cwd/$p-exe \"\$@\"" >> $p
+            chmod 0755  $p
+        else
+            echo "skip  $p"
+        fi
+    done
+fi
+
+# print the ve information and stack versions for verification
+echo
+echo "---------------------------------------------------------------------"
+echo
+echo "PYTHONPATH: $PYTHONPATH"
+echo "python: `which python` (`python --version`)"
+echo
+echo "---------------------------------------------------------------------"
 echo
 

--- a/bin/radicalpilot-create-static-ve
+++ b/bin/radicalpilot-create-static-ve
@@ -94,7 +94,7 @@ then
     # the same place
     echo "invoke BW magic"
     module load bwpy
-    exec bwpy-environment -- /bin/sh "$script" "$prefix" bwpy
+    exec cbwpy-environ -- /bin/sh "$script" "$prefix" bwpy
 
 elif test "$arg" = "bwpy"
 then
@@ -153,7 +153,7 @@ then
             echo "patch $p"
             mv $p $p-exe
             echo "#!/bin/sh" > $p
-            echo "exec bwpy-environment -- $cwd/$p-exe \"\$@\"" >> $p
+            echo "exec cbwpy-environ -- $cwd/$p-exe \"\$@\"" >> $p
             chmod 0755  $p
         else
             echo "skip  $p"


### PR DESCRIPTION
This improves the RP script for creating a static resource VE.  

Srinivas, can you please give this a try in the context of #1546?  Basically, please purge the VE in `radical.pilot.sandbox` on BW, and create a new one with

```
radicalpilot-create-static-ve ve.bw
``` 

The exact name of the VE may vary, depending on the RP version you used.  After that VE got creeated, please run your application again, to check if the resulting VE is viable.

On bw, you probably need to `module load bwpy` before running the script.