### PR TITLE
Fix/issue 1554

### DIFF
--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -4,7 +4,6 @@
         "notes"                       : "Requires the use of an RSA SecurID on every connection.",
         "schemas"                     : ["local", "ssh", "go"],
         "ssh"                         : {
-            "job_manager_hop"         : "ssh://titan.ccs.ornl.gov/",
             "job_manager_endpoint"    : "torque+ssh://titan.ccs.ornl.gov/",
             "filesystem_endpoint"     : "sftp://titan.ccs.ornl.gov/"
         },
@@ -14,7 +13,6 @@
             "filesystem_endpoint"     : "file://localhost/"
         },
         "go"                          : {
-            "job_manager_hop"         : "ssh://titan.ccs.ornl.gov/",
             "job_manager_endpoint"    : "torque+ssh://titan.ccs.ornl.gov",
             "filesystem_endpoint"     : "go://olcf#dtn/"
         },
@@ -48,7 +46,6 @@
         "notes"                       : "Requires the use of an RSA SecurID on every connection.",
         "schemas"                     : ["ssh", "local", "go"],
         "ssh"                         : {
-            "job_manager_hop"         : "ssh://titan.ccs.ornl.gov/",
             "job_manager_endpoint"    : "torque+ssh://titan.ccs.ornl.gov",
             "filesystem_endpoint"     : "sftp://titan.ccs.ornl.gov/"
         },
@@ -58,7 +55,6 @@
             "filesystem_endpoint"     : "file://localhost/"
         },
         "go"                          : {
-            "job_manager_hop"         : "ssh://titan.ccs.ornl.gov/",
             "job_manager_endpoint"    : "torque+ssh://titan.ccs.ornl.gov",
             "filesystem_endpoint"     : "go://olcf#dtn/"
         },
@@ -95,7 +91,6 @@
         "notes"                       : "Requires the use of an RSA SecurID on every connection.",
         "schemas"                     : ["ssh", "local", "go"],
         "ssh"                         : {
-            "job_manager_hop"         : "ssh://titan.ccs.ornl.gov/",
             "job_manager_endpoint"    : "torque+ssh://titan.ccs.ornl.gov",
             "filesystem_endpoint"     : "sftp://titan.ccs.ornl.gov/"
         },
@@ -105,7 +100,6 @@
             "filesystem_endpoint"     : "file://localhost/"
         },
         "go"                          : {
-            "job_manager_hop"         : "ssh://titan.ccs.ornl.gov/",
             "job_manager_endpoint"    : "torque+ssh://titan.ccs.ornl.gov",
             "filesystem_endpoint"     : "go://olcf#dtn/"
         },

--- a/src/radical/pilot/configs/resource_osg.json
+++ b/src/radical/pilot/configs/resource_osg.json
@@ -7,12 +7,10 @@
         "schemas"            : ["ssh", "gsissh"],
         "mandatory_args"     : ["project"],
         "ssh"                : {
-            "job_manager_hop"     : "ssh://xd-login.opensciencegrid.org",
             "job_manager_endpoint": "condor+ssh://xd-login.opensciencegrid.org",
             "filesystem_endpoint" : "sftp://xd-login.opensciencegrid.org/"
         },
         "gsissh"             : {
-            "job_manager_hop"     : "gsissh://xd-login.opensciencegrid.org",
             "job_manager_endpoint": "condor+gsissh://xd-login.opensciencegrid.org",
             "filesystem_endpoint" : "gsisftp://xd-login.opensciencegrid.org/"
         },
@@ -63,12 +61,10 @@
         "schemas"            : ["ssh", "gsissh"],
         "mandatory_args"     : ["project"],
         "ssh"                : {
-            "job_manager_hop"     : "ssh://login.osgconnect.net",
             "job_manager_endpoint": "condor+ssh://login.osgconnect.net",
             "filesystem_endpoint" : "sftp://login.osgconnect.net/"
         },
         "gsissh"             : {
-            "job_manager_hop"     : "gsissh://login.osgconnect.net",
             "job_manager_endpoint": "condor+gsissh://login.osgconnect.net",
             "filesystem_endpoint" : "gsisftp://login.osgconnect.net/"
         },

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -1046,8 +1046,15 @@ class Session(rs.Session):
         resrc   = pilot['description']['resource']
         schema  = pilot['description']['access_schema']
         rcfg    = self.get_resource_config(resrc, schema)
+
         js_url  = rs.Url(rcfg.get('job_manager_endpoint'))
         js_hop  = rs.Url(rcfg.get('job_manager_hop', js_url))
+
+        # make sure the js_hop url points to an interactive access
+        if '+gsissh' in js_hop.schema or \
+           'gsissh+' in js_hop.schema    : js_hop.schema = 'gsissh'
+        if '+ssh'    in js_hop.schema or \
+           'ssh+'    in js_hop.schema    : js_hop.schema = 'ssh'
 
         return js_url, js_hop
 


### PR DESCRIPTION
This fix ensures that shell commands (like `untar`) are not submitted to the batch queue, but instead run interactively on the login nodes.

This is urgent to merge.