### PR TITLE
Update 09_mpi_units.py

### DIFF
--- a/examples/09_mpi_units.py
+++ b/examples/09_mpi_units.py
@@ -36,10 +36,8 @@ if __name__ == '__main__':
     if   len(sys.argv)  > 2: report.exit('Usage:\t%s [resource]\n\n' % sys.argv[0])
     elif len(sys.argv) == 2: 
         resource = sys.argv[1]
-        cu_arg = ['09_mpi_units.sh']
     else: 
         resource = 'local.localhost'
-        cu_arg = ['%s/09_mpi_units.sh' % PWD]
 
     # Create a new session. No need to try/except this: if session creation
     # fails, there is not much we can do anyways...
@@ -97,7 +95,7 @@ if __name__ == '__main__':
             # Here we don't use dict initialization.
             cud = rp.ComputeUnitDescription()
             cud.executable     = '/bin/sh'
-            cud.arguments      = cu_arg
+            cud.arguments      = ['09_mpi_units.sh']
             cud.input_staging  = ['%s/09_mpi_units.sh' % PWD]
             cud.cores          = 3
             cud.mpi            = True

--- a/examples/09_mpi_units.py
+++ b/examples/09_mpi_units.py
@@ -34,8 +34,12 @@ if __name__ == '__main__':
 
     # use the resource specified as argument, fall back to localhost
     if   len(sys.argv)  > 2: report.exit('Usage:\t%s [resource]\n\n' % sys.argv[0])
-    elif len(sys.argv) == 2: resource = sys.argv[1]
-    else                   : resource = 'local.localhost'
+    elif len(sys.argv) == 2: 
+        resource = sys.argv[1]
+        cu_arg = ['09_mpi_units.sh']
+    else: 
+        resource = 'local.localhost'
+        cu_arg = ['%s/09_mpi_units.sh' % PWD]
 
     # Create a new session. No need to try/except this: if session creation
     # fails, there is not much we can do anyways...
@@ -93,7 +97,7 @@ if __name__ == '__main__':
             # Here we don't use dict initialization.
             cud = rp.ComputeUnitDescription()
             cud.executable     = '/bin/sh'
-            cud.arguments      = ['%s/09_mpi_units.sh' % PWD]
+            cud.arguments      = cu_arg
             cud.input_staging  = ['%s/09_mpi_units.sh' % PWD]
             cud.cores          = 3
             cud.mpi            = True


### PR DESCRIPTION
The example sets the CU argument with the path that is on the client side. As a result the example fails on remote with a message:
```
[paraskev@br006 unit.000000]$ cat STDERR
touch: missing file operand
Try 'touch --help' for more information.
/bin/sh: /home/iparask/Git/radical.pilot/examples/09_mpi_units.sh: No such file or directory
```

I propose the path of the argument to be configurable and based on whether the agent is local or remote.
