### PR TITLE
Expand env variables in LFS path

### DIFF
--- a/src/radical/pilot/agent/rm/ccm.py
+++ b/src/radical/pilot/agent/rm/ccm.py
@@ -55,9 +55,8 @@ class CCM(LRMS):
         self.cores_per_node = ccm_nodes_length / ccm_node_list_length
         self.gpus_per_node  = self._cfg.get('gpus_per_node', 0) # FIXME GPU
 
-        lfs_path = self._cfg.get('lfs_path_per_node', None)
-        if '$' in path:
-            lfs_path = os.path.expandvars(path)
+        lfs_path = self._cfg.get('lfs_path_per_node', '')
+        lfs_path = os.path.expandvars(lfs_path)
 
         self.lfs_per_node   = {'path' : lfs_path,
                                'size' : self._cfg.get('lfs_size_per_node', 0)

--- a/src/radical/pilot/agent/rm/ccm.py
+++ b/src/radical/pilot/agent/rm/ccm.py
@@ -54,7 +54,12 @@ class CCM(LRMS):
         # Some simple arithmetic
         self.cores_per_node = ccm_nodes_length / ccm_node_list_length
         self.gpus_per_node  = self._cfg.get('gpus_per_node', 0) # FIXME GPU
-        self.lfs_per_node   = {'path' : self._cfg.get('lfs_path_per_node', None),
+
+        lfs_path = self._cfg.get('lfs_path_per_node', None)
+        if '$' in path:
+            lfs_path = os.path.expandvars(path)
+
+        self.lfs_per_node   = {'path' : lfs_path,
                                'size' : self._cfg.get('lfs_size_per_node', 0)
                               }
 

--- a/src/radical/pilot/agent/rm/fork.py
+++ b/src/radical/pilot/agent/rm/fork.py
@@ -39,11 +39,7 @@ class Fork(LRMS):
         self.cores_per_node = self._cfg.get('cores_per_node', self.requested_cores)
         self.gpus_per_node  = self._cfg.get('gpus_per_node', 0)  # FIXME GPU
 
-        lfs_path = self._cfg.get('lfs_path_per_node', None)
-        if '$' in path:
-            lfs_path = os.path.expandvars(path)
-
-        self.lfs_per_node   = {'path' : lfs_path,
+        self.lfs_per_node   = {'path' :  self._cfg.get('lfs_path_per_node', ''),
                                'size' : self._cfg.get('lfs_size_per_node', 0)
                               }
 

--- a/src/radical/pilot/agent/rm/fork.py
+++ b/src/radical/pilot/agent/rm/fork.py
@@ -38,7 +38,12 @@ class Fork(LRMS):
         # to preserve the previous behavior (1 node).
         self.cores_per_node = self._cfg.get('cores_per_node', self.requested_cores)
         self.gpus_per_node  = self._cfg.get('gpus_per_node', 0)  # FIXME GPU
-        self.lfs_per_node   = {'path' : self._cfg.get('lfs_path_per_node', None),
+
+        lfs_path = self._cfg.get('lfs_path_per_node', None)
+        if '$' in path:
+            lfs_path = os.path.expandvars(path)
+
+        self.lfs_per_node   = {'path' : lfs_path,
                                'size' : self._cfg.get('lfs_size_per_node', 0)
                               }
 

--- a/src/radical/pilot/agent/rm/lsf.py
+++ b/src/radical/pilot/agent/rm/lsf.py
@@ -58,9 +58,8 @@ class LSF(LRMS):
         lsf_cores_per_node   = min(lsf_core_counts)
         lsf_gpus_per_node    = self._cfg.get('gpus_per_node', 0) # FIXME GPU
 
-        lfs_path = self._cfg.get('lfs_path_per_node', None)
-        if '$' in path:
-            lfs_path = os.path.expandvars(path)
+        lfs_path = self._cfg.get('lfs_path_per_node', '')
+        lfs_path = os.path.expandvars(lfs_path)
 
         lfs_lfs_per_node     = {'path' : lfs_path,
                                 'size' : self._cfg.get('lfs_size_per_node', 0)

--- a/src/radical/pilot/agent/rm/lsf.py
+++ b/src/radical/pilot/agent/rm/lsf.py
@@ -57,7 +57,12 @@ class LSF(LRMS):
         lsf_core_counts      = list(set(lsf_cores_count_list))
         lsf_cores_per_node   = min(lsf_core_counts)
         lsf_gpus_per_node    = self._cfg.get('gpus_per_node', 0) # FIXME GPU
-        lfs_lfs_per_node     = {'path' : self._cfg.get('lfs_path_per_node', None),
+
+        lfs_path = self._cfg.get('lfs_path_per_node', None)
+        if '$' in path:
+            lfs_path = os.path.expandvars(path)
+
+        lfs_lfs_per_node     = {'path' : lfs_path,
                                 'size' : self._cfg.get('lfs_size_per_node', 0)
                                }
 

--- a/src/radical/pilot/agent/rm/pbspro.py
+++ b/src/radical/pilot/agent/rm/pbspro.py
@@ -75,7 +75,12 @@ class PBSPro(LRMS):
         self.node_list      = [[node, node] for node in pbspro_vnodes]
         self.cores_per_node = pbspro_num_ppn
         self.gpus_per_node  = self._cfg.get('gpus_per_node', 0) # FIXME GPU
-        self.lfs_per_node   = {'path' : self._cfg.get('lfs_path_per_node', None),
+
+        lfs_path = self._cfg.get('lfs_path_per_node', None)
+        if '$' in path:
+            lfs_path = os.path.expandvars(path)
+
+        self.lfs_per_node   = {'path' : lfs_path,
                                'size' : self._cfg.get('lfs_size_per_node', 0)
                               }
 

--- a/src/radical/pilot/agent/rm/pbspro.py
+++ b/src/radical/pilot/agent/rm/pbspro.py
@@ -76,9 +76,8 @@ class PBSPro(LRMS):
         self.cores_per_node = pbspro_num_ppn
         self.gpus_per_node  = self._cfg.get('gpus_per_node', 0) # FIXME GPU
 
-        lfs_path = self._cfg.get('lfs_path_per_node', None)
-        if '$' in path:
-            lfs_path = os.path.expandvars(path)
+        lfs_path = self._cfg.get('lfs_path_per_node', '')
+        lfs_path = os.path.expandvars(lfs_path)
 
         self.lfs_per_node   = {'path' : lfs_path,
                                'size' : self._cfg.get('lfs_size_per_node', 0)

--- a/src/radical/pilot/agent/rm/sge.py
+++ b/src/radical/pilot/agent/rm/sge.py
@@ -56,7 +56,12 @@ class SGE(LRMS):
         sge_cores_count_list = [int(line.split()[1]) for line in open(sge_hostfile)]
         sge_core_counts      = list(set(sge_cores_count_list))
         sge_gpus_per_node    = self._cfg.get('gpus_per_node', 0) # FIXME GPU
-        sge_lfs_per_node     = {'path' : self._cfg.get('lfs_path_per_node', None),
+
+        lfs_path = self._cfg.get('lfs_path_per_node', None)
+        if '$' in path:
+            lfs_path = os.path.expandvars(path)
+
+        sge_lfs_per_node     = {'path' : lfs_path,
                                 'size' : self._cfg.get('lfs_size_per_node', 0)
                                }
 

--- a/src/radical/pilot/agent/rm/sge.py
+++ b/src/radical/pilot/agent/rm/sge.py
@@ -57,9 +57,8 @@ class SGE(LRMS):
         sge_core_counts      = list(set(sge_cores_count_list))
         sge_gpus_per_node    = self._cfg.get('gpus_per_node', 0) # FIXME GPU
 
-        lfs_path = self._cfg.get('lfs_path_per_node', None)
-        if '$' in path:
-            lfs_path = os.path.expandvars(path)
+        lfs_path = self._cfg.get('lfs_path_per_node', '')
+        lfs_path = os.path.expandvars(lfs_path)
 
         sge_lfs_per_node     = {'path' : lfs_path,
                                 'size' : self._cfg.get('lfs_size_per_node', 0)

--- a/src/radical/pilot/agent/rm/slurm.py
+++ b/src/radical/pilot/agent/rm/slurm.py
@@ -75,7 +75,12 @@ class Slurm(LRMS):
         # in case of a single partial node allocation.
         self.cores_per_node = self._cfg.get('cores_per_node', 0)
         self.gpus_per_node  = self._cfg.get('gpus_per_node',  0)  # FIXME GPU
-        self.lfs_per_node   = {'path' : self._cfg.get('lfs_path_per_node', None),
+
+        lfs_path = self._cfg.get('lfs_path_per_node', None)
+        if '$' in path:
+            lfs_path = os.path.expandvars(path)
+
+        self.lfs_per_node   = {'path' : lfs_path,
                                'size' : self._cfg.get('lfs_size_per_node', 0)
                               }
 

--- a/src/radical/pilot/agent/rm/slurm.py
+++ b/src/radical/pilot/agent/rm/slurm.py
@@ -76,9 +76,8 @@ class Slurm(LRMS):
         self.cores_per_node = self._cfg.get('cores_per_node', 0)
         self.gpus_per_node  = self._cfg.get('gpus_per_node',  0)  # FIXME GPU
 
-        lfs_path = self._cfg.get('lfs_path_per_node', None)
-        if '$' in path:
-            lfs_path = os.path.expandvars(path)
+        lfs_path = self._cfg.get('lfs_path_per_node', '')
+        lfs_path = os.path.expandvars(lfs_path)
 
         self.lfs_per_node   = {'path' : lfs_path,
                                'size' : self._cfg.get('lfs_size_per_node', 0)

--- a/src/radical/pilot/agent/rm/torque.py
+++ b/src/radical/pilot/agent/rm/torque.py
@@ -54,9 +54,9 @@ class Torque(LRMS):
             self._log.warning(msg)
 
         torque_gpus_per_node  = self._cfg.get('gpus_per_node', 0) # FIXME GPU
-        lfs_path = self._cfg.get('lfs_path_per_node', None)
-        if '$' in path:
-            lfs_path = os.path.expandvars(path)
+
+        lfs_path = self._cfg.get('lfs_path_per_node', '')
+        lfs_path = os.path.expandvars(lfs_path)
 
         torque_lfs_per_node   = {'path' : lfs_path,
                                  'size' : self._cfg.get('lfs_size_per_node', 0)

--- a/src/radical/pilot/agent/rm/torque.py
+++ b/src/radical/pilot/agent/rm/torque.py
@@ -54,7 +54,11 @@ class Torque(LRMS):
             self._log.warning(msg)
 
         torque_gpus_per_node  = self._cfg.get('gpus_per_node', 0) # FIXME GPU
-        torque_lfs_per_node   = {'path' : self._cfg.get('lfs_path_per_node', None),
+        lfs_path = self._cfg.get('lfs_path_per_node', None)
+        if '$' in path:
+            lfs_path = os.path.expandvars(path)
+
+        torque_lfs_per_node   = {'path' : lfs_path,
                                  'size' : self._cfg.get('lfs_size_per_node', 0)
                                 }
 


### PR DESCRIPTION
Fixes #1775 

In the case where the LFS path has environment variables in it, it gets expanded in the resource manager. As a result the scheduler and the unit description just get an absolute path.