### PR TITLE
edited docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -58,8 +58,8 @@ properly, run:
 
 .. code-block:: bash
 
-    $ radicalpilot-version
-    0.50.8
+    $ radical-pilot-version
+    0.50.21
 
 The exact output will obviously depend on the exact version of RP which got
 installed.
@@ -151,7 +151,8 @@ follows:
 Now you can login to the machine by using ``ssh mach1``.  Please make also sure
 that your ssh keys are registered on the target resources -- while RP can in
 principle handle password based login, the repeated prompts for passwords makes
-RP applications very difficult to use.
+RP applications very difficult to use. To learn more about accessing remote machine 
+using RP, see the chapter `Using Local and Remote HPC Resources <./machconf.rst>`.
 
 Source: http://nerderati.com/2011/03/17/simplify-your-life-with-an-ssh-config-file/
 

--- a/docs/source/machconf.rst
+++ b/docs/source/machconf.rst
@@ -64,6 +64,23 @@ your user-id on the remote resource, use the following construct:
     login. This can help if you encounter random connection problems with
     RADICAL-Pilot.
 
+
+Configuring GSISSH Access for XSEDE resources
+=============================================
+The XSEDE resources require using gsissh tool to access. 
+Once the gsissh and myproxy are successfully installed, 
+one need to aquire a X509 certificate:
+
+.. code-block:: bash
+
+    $ export MYPROXY_SERVER_PORT=7512 
+    $ export MYPROXY_SERVER=myproxy.xsede.org
+    $ myproxy-logon -l <user_name> -T -b -t 1000
+    $ [Enter MyProxy pass phrase]
+    $ [you should receive a credential in /tmp/x509up_u1000]
+    $ gsissh -p 2222 login1.stampede2.tacc.utexas.edu
+
+
 .. _preconfigured_resources:
 
 Pre-Configured Resources
@@ -96,6 +113,13 @@ Writing a Custom Resource Configuration File
 If you want to use RADICAL-Pilot with a resource that is not in any of the
 provided resource configuration files, you can write your own, and drop it in
 ``$HOME/.radical/pilot/configs/<your_resource_configuration_file_name>.json``.
+
+.. note::
+    The remote resource configuration file name has to start with "resource_"
+    and end with ".json" suffix. Within each resource file, multiple resources
+    could be listed. For example, the `resource_xsede.json
+    <https://radicalpilot.readthedocs.io/en/latest/_downloads/resource_xsede.json>`_
+    file contains many different hpc resources from XSEDE.
 
 .. note::
     Be advised that you may need specific knowledge about the target resource to

--- a/docs/source/user_guide/00_getting_started.rst
+++ b/docs/source/user_guide/00_getting_started.rst
@@ -105,11 +105,12 @@ of the ``ComputePilotDescription`` are
     * `runtime` : the numbers of minutes the pilot is expected to be active, ie.
       the runtime of the pilot.
 
-Depending on the specific target resource and use case, other properties need to
-be specified.  In our user guide examples, we use
-a separate `config.json` file to store a number of properties per resource
-label, to simplify the example code.  The examples themselves then accept one or
-more resource labels, and create the pilots on those resources:
+Depending on the specific target resource and use case, other properties need
+to be specified.  In our user guide examples, we use a separate
+`config.json<../../../examples/config.json>` file to store a number of
+properties per resource label, to simplify the example code.  The examples
+themselves then accept one or more resource labels, and create the pilots on
+those resources:
 
 
 .. code-block:: python


### PR DESCRIPTION
* typo in "installation.rst", should issue radical-pilot-version
* add how to acquire myproxy credential for using gsissh on XSEDE 
* provide a link to the config file in 00_getting_started.rst
* customized resource config file should start with the prefix "resource_". This is hard-coded in the "resource_config.py"