### PR TITLE
Fixing travis to separate test lint form testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 language: python
 sudo: disabled
 
@@ -6,7 +5,7 @@ python:
   - "2.7"
 
 branches:
-  - feature/lm_tests
+  - devel
 
 os:
   - linux
@@ -18,16 +17,26 @@ env:
   global:
     - RADICAL_PILOT_DBURL=mongodb://rct:rct_test@one.radical-project.org/rct_test
     - RADICAL_PILOT_TEST_DBNAME=rct_test
+    - LOG=`git log -n 1 | grep Merge`
+    - OLD=`echo $LOG | cut -d ' ' -f2`
+    - NEW=`echo $LOG | cut -d ' ' -f3`
+    - DIFF=`git diff --name-only --diff-filter=b $OLD...$NEW`
+    - DIFF=$(echo $DIFF | grep -o -e '\b[^ ]*.py\b')
     - LOC=/home/travis/virtualenv/python2.7  # Location where VE is created on travis
-    - CMD1="coverage run -m pytest -vvv tests/;flake8 tests/;pylint tests/"
-    - CMD2="flake8 --config=.flake8 $LOC/lib/python2.7/site-packages/radical/pilot/agent/lm/;flake8 --config=.flake8 $LOC/lib/python2.7/site-packages/radical/pilot/agent/rm/;"
-    - CMD3="pylint $LOC/lib/python2.7/site-packages/radical/pilot/agent/lm/;pylint $LOC/lib/python2.7/site-packages/radical/pilot/agent/rm/"
+    - CMD_PYTEST="coverage run -m pytest -vvv tests/"
+    - CMD_FLAKE8="if ! test -z \"$DIFF\"; then flake8 --config=.flake8 $DIFF;else echo 'Nothing to pep8'; fi"
+    - CMD_PYLINT="if ! test -z \"$DIFF\"; then pylint $DIFF;else echo 'Nothing to lint';fi"
+    - CMD_PYTEST="coverage run -m pytest -vvv tests/;flake8 tests/;pylint tests/"
+    - CMD_FLAKE8_TESTS="flake8 --config=.flake8 tests/"
+    - CMD_PYLINT_TESTS="pylint tests/"
     - COVERAGE=false
     - CODECOV_TOKEN="c7e0d993-d31a-4d39-8ffa-07c30ea73e48"
   matrix:
-    - MAIN_CMD=$CMD1 COVERAGE=true
-    - MAIN_CMD=$CMD2
-    - MAIN_CMD=$CMD3
+    - MAIN_CMD=$CMD_PYTEST COVERAGE=true
+    - MAIN_CMD=$CMD_FLAKE8
+    - MAIN_CMD=$CMD_PYLINT
+    - MAIN_CMD=$CMD_FLAKE8_TESTS
+    - MAIN_CMD=$CMD_PYLINT_TESTS
 
 before_install:
   - uname -a
@@ -55,10 +64,8 @@ after_success:
       coverage report; \
       curl -s https://codecov.io/bash | bash
     fi
-
 notifications:
   email:
     recipients: andre@merzky.net
     on_success: change
     on_failure: always
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
     - CMD_PYTEST="coverage run -m pytest -vvv tests/"
     - CMD_FLAKE8="if ! test -z \"$DIFF\"; then flake8 --config=.flake8 $DIFF;else echo 'Nothing to pep8'; fi"
     - CMD_PYLINT="if ! test -z \"$DIFF\"; then pylint $DIFF;else echo 'Nothing to lint';fi"
-    - CMD_PYTEST="coverage run -m pytest -vvv tests/;flake8 tests/;pylint tests/"
     - CMD_FLAKE8_TESTS="flake8 --config=.flake8 tests/"
     - CMD_PYLINT_TESTS="pylint tests/"
     - COVERAGE=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "2.7"
 
 branches:
-  - devel
+  - *
 
 os:
   - linux


### PR DESCRIPTION
The proposed change does the following three things.

1. Sets up devel as the testing branch
2. Lints only for the changed python files
3. Separates testing from linting tests, which caused travis to succeed when tests fail.