### PR TITLE
Hotfix/conda ve

### DIFF
--- a/bin/radical-pilot-create-static-ve
+++ b/bin/radical-pilot-create-static-ve
@@ -4,7 +4,7 @@ script="$0"
 prefix="$1"
 arg="$2"
 
-echo 
+echo
 echo "script : $script"
 echo "prefix : $prefix"
 echo "arg    : $arg"
@@ -26,7 +26,7 @@ help(){
 
     err="$1"
     ret=0
-    
+
     if ! test -z "$err"
     then
         ret=1
@@ -62,7 +62,7 @@ progress(){
 
 if test "$prefix" = "-h"
 then
-    help 
+    help
 fi
 
 if test -z "$prefix"
@@ -111,6 +111,12 @@ fi
 mkdir -p "$prefix"
 cd $prefix
 
+# for conda environments, install virtualenv in the env
+if ! test -z "$CONDA_DEFAULT_ENV"
+then
+    conda install -y virtualenv | progress 2>&1
+fi
+
 echo -n "install virtualenv "
 
 VIRTENV_CMD="$(which virtualenv 2>/dev/null)"
@@ -139,7 +145,7 @@ do
 done
 
 # install the radical stack (utils, saga, pilot) into a separate tree
-# ($prefix/rp_install(, so that any local install can use the ve *w/o* 
+# ($prefix/rp_install(, so that any local install can use the ve *w/o*
 # the radical stack, by re-routing PYTHONPATH
 python_version=`$PYTHON -c 'import distutils.sysconfig as sc; print sc.get_python_version()'`
 ve_mod_prefix=` $PYTHON -c 'import distutils.sysconfig as sc; print sc.get_python_lib()'`

--- a/bin/radical-pilot-create-static-ve
+++ b/bin/radical-pilot-create-static-ve
@@ -131,7 +131,7 @@ fi
 VIRTENV_CMD="$(which virtualenv 2>/dev/null)"
 if test -z "$VIRTENV_CMD"
 then
-    echo -n "install fallback virtualenv "
+    echo -n "install private virtualenv "
     VIRTENV_TGZ="virtualenv-1.9.tar.gz"
     VIRTENV_TGZ_URL="https://pypi.python.org/packages/source/v/virtualenv/$VIRTENV_TGZ"
     curl -k -L -O "$VIRTENV_TGZ_URL" 2>&1 | progress

--- a/bin/radical-pilot-create-static-ve
+++ b/bin/radical-pilot-create-static-ve
@@ -116,8 +116,8 @@ if ! test -z "$CONDA_DEFAULT_ENV"
 then
     # conda developers did not think this through... :-(
     CONDA="$(which conda 2>/dev/null | head -n 1)"
-    test -z "$CONDA$_CONDA_EXE" || CONDA="$_CONDA_EXE"
-    test -z "$CONDA$CONDA_EXE"  || CONDA="$CONDA_EXE"
+    test -z "$CONDA" && CONDA="$_CONDA_EXE"
+    test -z "$CONDA" && CONDA="$CONDA_EXE"
     if test -z "$CONDA"
     then
         echo "conda is not functional"

--- a/bin/radical-pilot-create-static-ve
+++ b/bin/radical-pilot-create-static-ve
@@ -124,7 +124,7 @@ then
         exit 1
     fi
     echo -n "install conda virtualenv "
-    test -z "$CONDA" || "$CONDA" install -y virtualenv 2>&1 | progress
+    "$CONDA" install -y virtualenv 2>&1 | progress || exit 1
 fi
 
 

--- a/bin/radical-pilot-create-static-ve
+++ b/bin/radical-pilot-create-static-ve
@@ -114,14 +114,24 @@ cd $prefix
 # for conda environments, install virtualenv in the env
 if ! test -z "$CONDA_DEFAULT_ENV"
 then
-    conda install -y virtualenv | progress 2>&1
+    # conda developers did not think this through... :-(
+    CONDA="$(which conda 2>/dev/null | head -n 1)"
+    test -z "$CONDA$_CONDA_EXE" || CONDA="$_CONDA_EXE"
+    test -z "$CONDA$CONDA_EXE"  || CONDA="$CONDA_EXE"
+    if test -z "$CONDA"
+    then
+        echo "conda is not functional"
+        exit 1
+    fi
+    echo -n "install conda virtualenv "
+    test -z "$CONDA" || "$CONDA" install -y virtualenv 2>&1 | progress
 fi
 
-echo -n "install virtualenv "
 
 VIRTENV_CMD="$(which virtualenv 2>/dev/null)"
 if test -z "$VIRTENV_CMD"
 then
+    echo -n "install fallback virtualenv "
     VIRTENV_TGZ="virtualenv-1.9.tar.gz"
     VIRTENV_TGZ_URL="https://pypi.python.org/packages/source/v/virtualenv/$VIRTENV_TGZ"
     curl -k -L -O "$VIRTENV_TGZ_URL" 2>&1 | progress


### PR DESCRIPTION
Unfortunately, tiger needs another hotfix: our users use Anaconda, but that does not play well with our static ve creations script: it does not like the way we install virtualenv.  Alas, the fix is a little more involved than calling `conda install -y virtualenv`, since (a) the conda command was recently moved to a shell function which is not available in scripts (this was a really stupid decision IMHO), and (b) different versions of conda use different env variables to point to the conda executable (*sigh*).  Either way: this patch makes sure that virtualenv is installed in the used conda env, and then uses that to create our static ve.