### PR TITLE
Hotfix/pilot term

### DIFF
--- a/src/radical/pilot/compute_pilot.py
+++ b/src/radical/pilot/compute_pilot.py
@@ -3,15 +3,12 @@ __copyright__ = "Copyright 2013-2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
 
-import os
-import sys
 import copy
 import time
 import threading
 
 import radical.utils as ru
 
-from . import utils     as rpu
 from . import states    as rps
 from . import constants as rpc
 
@@ -19,24 +16,25 @@ from . import constants as rpc
 # ------------------------------------------------------------------------------
 #
 class ComputePilot(object):
-    """
+    '''
     A ComputePilot represent a resource overlay on a local or remote resource.
 
     .. note:: A ComputePilot cannot be created directly. The factory method
-              :meth:`radical.pilot.PilotManager.submit_pilots` has to be used instead.
+              :meth:`radical.pilot.PilotManager.submit_pilots` has to be
+              used instead.
 
-                **Example**::
+        **Example**::
 
-                      pm = radical.pilot.PilotManager(session=s)
+              pm = radical.pilot.PilotManager(session=s)
+              pd = radical.pilot.ComputePilotDescription()
 
-                      pd = radical.pilot.ComputePilotDescription()
-                      pd.resource = "local.localhost"
-                      pd.cores    = 2
-                      pd.runtime  = 5 # minutes
+              pd.resource = "local.localhost"
+              pd.cores    = 2
+              pd.runtime  = 5 # minutes
 
-                      pilot = pm.submit_pilots(pd)
-    """
-    
+              pilot = pm.submit_pilots(pd)
+    '''
+
     # --------------------------------------------------------------------------
     # In terms of implementation, a Pilot is not much more than a dict whose
     # content are dynamically updated to reflect the state progression through
@@ -62,16 +60,18 @@ class ComputePilot(object):
                 raise ValueError("ComputePilotDescription needs '%s'" % check)
 
         # initialize state
-        self._pmgr          = pmgr
-        self._session       = self._pmgr.session
-        self._prof          = self._session._prof
-        self._uid           = ru.generate_id('pilot.%(counter)04d', ru.ID_CUSTOM)
-        self._state         = rps.NEW
-        self._log           = pmgr._log
-        self._pilot_dict    = dict()
-        self._callbacks     = dict()
-        self._cache         = dict()    # cache of SAGA dir handles
-        self._cb_lock       = threading.RLock()
+        self._pmgr       = pmgr
+        self._session    = self._pmgr.session
+        self._prof       = self._session._prof
+        self._uid        = ru.generate_id('pilot.%(counter)04d', ru.ID_CUSTOM)
+        self._state      = rps.NEW
+        self._log        = pmgr._log
+        self._pilot_dict = dict()
+        self._callbacks  = dict()
+        self._cache      = dict()    # cache of SAGA dir handles
+        self._cb_lock    = threading.RLock()
+
+        # pilot failures can trigger app termination
         self._exit_on_error = self._descr.get('exit_on_error')
 
 
@@ -80,7 +80,7 @@ class ComputePilot(object):
 
         # we always invoke the default state cb
         self._callbacks[rpc.PILOT_STATE][self._default_state_cb.__name__] = {
-                'cb'      : self._default_state_cb, 
+                'cb'      : self._default_state_cb,
                 'cb_data' : None}
 
         # `as_dict()` needs `pilot_dict` and other attributes.  Those should all
@@ -92,17 +92,13 @@ class ComputePilot(object):
         self._pilot_sandbox    = ru.Url()
         self._client_sandbox   = ru.Url()
 
-        self._log.debug(' ===== 1: %s [%s]', self._pilot_sandbox, type(self._pilot_sandbox))
-
         pilot = self.as_dict()
-        self._log.debug(' ===== 2: %s [%s]', pilot['pilot_sandbox'], type(pilot['pilot_sandbox']))
 
         self._pilot_jsurl, self._pilot_jshop \
                                = self._session._get_jsurl           (pilot)
         self._resource_sandbox = self._session._get_resource_sandbox(pilot)
         self._pilot_sandbox    = self._session._get_pilot_sandbox   (pilot)
         self._client_sandbox   = self._session._get_client_sandbox()
-        self._log.debug(' ===== 3: %s [%s]', self._pilot_sandbox, type(self._pilot_sandbox))
 
 
     # --------------------------------------------------------------------------
@@ -126,44 +122,40 @@ class ComputePilot(object):
         self._log.info("[Callback]: pilot %s state: %s.", self.uid, self.state)
 
         if self.state == rps.FAILED and self._exit_on_error:
-            self._log.error("[Callback]: pilot '%s' failed (exit on error)", self.uid)
-            # FIXME: how to tell main?  Where are we in the first place?
+            self._log.error("[Callback]: pilot '%s' failed - exit", self.uid)
+
+            # There are different ways to tell main...
             ru.cancel_main_thread('int')
-            raise RuntimeError('pilot %s failed - fatal!' % self.uid)
+          # raise RuntimeError('pilot %s failed - fatal!' % self.uid)
+          # import sys
           # sys.exit()
 
 
     # --------------------------------------------------------------------------
     #
     def _update(self, pilot_dict):
-        """
+        '''
         This will update the facade object after state changes etc, and is
         invoked by whatever component receiving that updated information.
 
         Return True if state changed, False otherwise
-        """
+        '''
 
         if pilot_dict['uid'] != self.uid:
-            self._log.error('incorrect uid: %s / %s', pilot_dict['uid'], self.uid)
+            self._log.error('invalid uid: %s / %s', pilot_dict['uid'], self.uid)
+
         assert(pilot_dict['uid'] == self.uid), 'update called on wrong instance'
 
-        # NOTE: this method relies on state updates to arrive in order, and
+        # NOTE: this method relies on state updates to arrive in order and
         #       without gaps.
         current = self.state
         target  = pilot_dict['state']
 
         if target not in [rps.FAILED, rps.CANCELED]:
 
-
-            try:
-                assert(rps._pilot_state_value(target) - rps._pilot_state_value(current)), \
-                            'invalid state transition'
-            except:
-                self._log.error('%s: invalid state transition %s -> %s', 
-                        self.uid, current, target)
-                raise
-
-            # FIXME
+            cur_state_val = rps._pilot_state_value(current)
+            tgt_state_val = rps._pilot_state_value(target)
+            assert(tgt_state_val - cur_state_val), 'invalid state transition'
 
         self._state = target
 
@@ -172,14 +164,13 @@ class ComputePilot(object):
 
         # invoke pilot specific callbacks
         # FIXME: this iteration needs to be thread-locked!
-        for cb_name, cb_val in self._callbacks[rpc.PILOT_STATE].iteritems():
+        for _,cb_val in self._callbacks[rpc.PILOT_STATE].iteritems():
 
             cb      = cb_val['cb']
             cb_data = cb_val['cb_data']
 
-          # print ' ~~~ call pcbs: %s -> %s : %s' % (self.uid, self.state, cb_name)
             self._log.debug('%s calls cb %s', self.uid, cb)
-            
+
             if cb_data: cb(self, self.state, cb_data)
             else      : cb(self, self.state)
 
@@ -190,27 +181,28 @@ class ComputePilot(object):
     # --------------------------------------------------------------------------
     #
     def as_dict(self):
-        """
+        '''
         Returns a Python dictionary representation of the object.
-        """
-        ret = {
-            'session':          self.session.uid,
-            'pmgr':             self.pmgr.uid,
-            'uid':              self.uid,
-            'type':             'pilot',
-            'state':            self.state,
-            'log':              self.log,
-            'stdout':           self.stdout,
-            'stderr':           self.stderr,
-            'resource':         self.resource,
-            'resource_sandbox': str(self._resource_sandbox),
-            'pilot_sandbox':    str(self._pilot_sandbox),
-            'client_sandbox':   str(self._client_sandbox),
-            'js_url':           str(self._pilot_jsurl),
-            'js_hop':           str(self._pilot_jshop),
-            'description':      self.description,  # this is a deep copy
-            'resource_details': self.resource_details
-        }
+        '''
+
+        ret = {'session':          self.session.uid,
+               'pmgr':             self.pmgr.uid,
+               'uid':              self.uid,
+               'type':             'pilot',
+               'state':            self.state,
+               'log':              self.log,
+               'stdout':           self.stdout,
+               'stderr':           self.stderr,
+               'resource':         self.resource,
+               'resource_sandbox': str(self._resource_sandbox),
+               'pilot_sandbox':    str(self._pilot_sandbox),
+               'client_sandbox':   str(self._client_sandbox),
+               'js_url':           str(self._pilot_jsurl),
+               'js_hop':           str(self._pilot_jshop),
+               'description':      self.description,  # this is a deep copy
+               'resource_details': self.resource_details
+              }
+
         return ret
 
 
@@ -218,12 +210,12 @@ class ComputePilot(object):
     #
     @property
     def session(self):
-        """
+        '''
         Returns the pilot's session.
 
         **Returns:**
             * A :class:`Session`.
-        """
+        '''
 
         return self._session
 
@@ -232,12 +224,12 @@ class ComputePilot(object):
     #
     @property
     def pmgr(self):
-        """
+        '''
         Returns the pilot's manager.
 
         **Returns:**
             * A :class:`PilotManager`.
-        """
+        '''
 
         return self._pmgr
 
@@ -246,9 +238,10 @@ class ComputePilot(object):
     #
     @property
     def resource_details(self):
-        """
+        '''
         Returns agent level resource information
-        """
+        '''
+
         return self._pilot_dict.get('resource_details')
 
 
@@ -256,14 +249,15 @@ class ComputePilot(object):
     #
     @property
     def uid(self):
-        """
+        '''
         Returns the pilot's unique identifier.
 
         The uid identifies the pilot within a :class:`PilotManager`.
 
         **Returns:**
             * A unique identifier (string).
-        """
+        '''
+
         return self._uid
 
 
@@ -271,12 +265,12 @@ class ComputePilot(object):
     #
     @property
     def state(self):
-        """
+        '''
         Returns the current state of the pilot.
 
         **Returns:**
             * state (string enum)
-        """
+        '''
 
         return self._state
 
@@ -285,14 +279,14 @@ class ComputePilot(object):
     #
     @property
     def log(self):
-        """
+        '''
         Returns a list of human readable [timestamp, string] tuples describing
         various events during the pilot's lifetime.  Those strings are not
         normative, only informative!
 
         **Returns:**
             * log (list of [timestamp, string] tuples)
-        """
+        '''
 
         return self._pilot_dict.get('log')
 
@@ -301,7 +295,7 @@ class ComputePilot(object):
     #
     @property
     def stdout(self):
-        """
+        '''
         Returns a snapshot of the pilot's STDOUT stream.
 
         If this property is queried before the pilot has reached
@@ -312,7 +306,7 @@ class ComputePilot(object):
 
         **Returns:**
             * stdout (string)
-        """
+        '''
 
         return self._pilot_dict.get('stdout')
 
@@ -321,7 +315,7 @@ class ComputePilot(object):
     #
     @property
     def stderr(self):
-        """
+        '''
         Returns a snapshot of the pilot's STDERR stream.
 
         If this property is queried before the pilot has reached
@@ -332,7 +326,7 @@ class ComputePilot(object):
 
         **Returns:**
             * stderr (string)
-        """
+        '''
 
         return self._pilot_dict.get('stderr')
 
@@ -341,12 +335,12 @@ class ComputePilot(object):
     #
     @property
     def resource(self):
-        """
+        '''
         Returns the resource tag of this pilot.
 
         **Returns:**
             * A resource tag (string)
-        """
+        '''
 
         return self._descr.get('resource')
 
@@ -355,13 +349,13 @@ class ComputePilot(object):
     #
     @property
     def pilot_sandbox(self):
-        """
+        '''
         Returns the full sandbox URL of this pilot, if that is already
         known, or 'None' otherwise.
 
         **Returns:**
             * A string
-        """
+        '''
 
         # NOTE: The pilot has a sandbox property, containing the full sandbox
         #       path, which is used by the pmgr to stage data back and forth.
@@ -369,35 +363,36 @@ class ComputePilot(object):
         #       be what the agent is seeing, specifically in the case of
         #       non-shared filesystems (OSG).  The agent thus uses
         #       `$PWD` as sandbox, with the assumption that this will
-        #       get mapped to whatever is here returned as sandbox URL.  
+        #       get mapped to whatever is here returned as sandbox URL.
         #
         #       There is thus implicit knowledge shared between the RP client
-        #       and the RP agent that `$PWD` *is* the sandbox!  The same 
+        #       and the RP agent that `$PWD` *is* the sandbox!  The same
         #       implicitly also holds for the staging area, which is relative
         #       to the pilot sandbox.
         if self._pilot_sandbox:
             return str(self._pilot_sandbox)
-        else:
-            return None
+
 
     @property
     def resource_sandbox(self):
         return self._resource_sandbox
 
+
     @property
     def client_sandbox(self):
         return self._client_sandbox
+
 
     # --------------------------------------------------------------------------
     #
     @property
     def description(self):
-        """
+        '''
         Returns the description the pilot was started with, as a dictionary.
 
         **Returns:**
             * description (dict)
-        """
+        '''
 
         return copy.deepcopy(self._descr)
 
@@ -405,7 +400,7 @@ class ComputePilot(object):
     # --------------------------------------------------------------------------
     #
     def register_callback(self, cb, metric=rpc.PILOT_STATE, cb_data=None):
-        """
+        '''
         Registers a callback function that is triggered every time the
         pilot's state changes.
 
@@ -415,19 +410,20 @@ class ComputePilot(object):
 
         where ``object`` is a handle to the object that triggered the callback
         and ``state`` is the new state of that object.  If 'cb_data' is given,
-        then the 'cb' signature changes to 
+        then the 'cb' signature changes to
 
             def cb(obj, state, cb_data)
 
         and 'cb_data' are passed along.
 
-        """
+        '''
+
         if metric not in rpc.PMGR_METRICS :
-            raise ValueError ("Metric '%s' is not available on the pilot manager" % metric)
+            raise ValueError ("Metric '%s' not available on pmgr" % metric)
 
         with self._cb_lock:
             cb_name = cb.__name__
-            self._callbacks[metric][cb_name] = {'cb'      : cb, 
+            self._callbacks[metric][cb_name] = {'cb'      : cb,
                                                 'cb_data' : cb_data}
 
 
@@ -436,23 +432,18 @@ class ComputePilot(object):
     def unregister_callback(self, cb, metric=rpc.PILOT_STATE):
 
         if metric and metric not in rpc.UMGR_METRICS :
-            raise ValueError ("Metric '%s' is not available on the pilot manager" % metric)
+            raise ValueError ("Metric '%s' not available on pmgr" % metric)
 
-        if not metric:
-            metrics = rpc.PMGR_METRICS
-        elif isinstance(metric, list):
-            metrics =  metric
-        else:
-            metrics = [metric]
+        if   not metric                  : metrics = rpc.PMGR_METRICS
+        elif not isinstance(metric, list): metrics = [metric]
+        else                             : metrics = metric
 
         with self._cb_lock:
 
             for metric in metrics:
 
-                if cb:
-                    to_delete = [cb.__name__]
-                else:
-                    to_delete = self._callbacks[metric].keys()
+                if cb: to_delete = [cb.__name__]
+                else : to_delete = self._callbacks[metric].keys()
 
                 for cb_name in to_delete:
 
@@ -465,7 +456,7 @@ class ComputePilot(object):
     # --------------------------------------------------------------------------
     #
     def wait(self, state=None, timeout=None):
-        """
+        '''
         Returns when the pilot reaches a specific state or
         when an optional timeout is reached.
 
@@ -485,14 +476,11 @@ class ComputePilot(object):
             * **timeout** [`float`]
               Optional timeout in seconds before the call returns regardless
               whether the pilot has reached the desired state or not.  The
-              default value **None** never times out.  """
+              default value **None** never times out.  '''
 
-        if not state:
-            states = rps.FINAL
-        elif not isinstance(state, list):
-            states = [state]
-        else:
-            states = state
+        if   not state                  : states = rps.FINAL
+        elif not isinstance(state, list): states = [state]
+        else                            : states = state
 
 
         if self.state in rps.FINAL:
@@ -513,8 +501,8 @@ class ComputePilot(object):
             if timeout and (timeout <= (time.time() - start_wait)):
                 break
 
-          # if self._pmgr._terminate.is_set():
-          #     break
+            if self._pmgr._terminate.is_set():
+                break
 
         return self.state
 
@@ -522,19 +510,19 @@ class ComputePilot(object):
     # --------------------------------------------------------------------------
     #
     def cancel(self):
-        """
+        '''
         Cancel the pilot.
-        """
-        
+        '''
+
         # clean connection cache
         try:
             for key in self._cache:
                 self._cache[key].close()
             self._cache = dict()
+
         except:
             pass
 
-      # print 'pilot: cancel'
         self._pmgr.cancel_pilots(self.uid)
 
 

--- a/src/radical/pilot/compute_pilot.py
+++ b/src/radical/pilot/compute_pilot.py
@@ -128,7 +128,7 @@ class ComputePilot(object):
         if self.state == rps.FAILED and self._exit_on_error:
             self._log.error("[Callback]: pilot '%s' failed (exit on error)", self.uid)
             # FIXME: how to tell main?  Where are we in the first place?
-          # ru.cancel_main_thread('int')
+            ru.cancel_main_thread('int')
             raise RuntimeError('pilot %s failed - fatal!' % self.uid)
           # sys.exit()
 


### PR DESCRIPTION
We know 4 different protocols to request termination from a thread in abnormal conditions: exception, `interrupt_main`, signals and `sys.exit()`.  None of them seems to be very reliable.  We used to use an exception to inform the application about pilot errors - but that became unstable over the last weeks, in that the exceptions did not arrive in the main thread anymore.  This PR switches to `interrupt_main()`, which is fairly brutal, but works.  The main problem with it is that the application cannot catch it, really - but since it is only issued when the pilot sets `terminate_on_error` (default: `yes`), this seems acceptable.