### PR TITLE
Increased default runtime to 30 minutes in getting_started.py

### DIFF
--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
         # Define an [n]-core local pilot that runs for [x] minutes
         # Here we use a dict to initialize the description object
         pd_init = {'resource'      : resource,
-                   'runtime'       : 15,  # pilot runtime (min)
+                   'runtime'       : 30,  # pilot runtime (min)
                    'exit_on_error' : True,
                    'project'       : config[resource]['project'],
                    'queue'         : config[resource]['queue'],


### PR DESCRIPTION
Some resources i.e. stampede2 KNL requires extra time for package compilation e.g. zmq using Intel Compiler and the getting_started.py example may need increased default runtime for initial bootstrapping.