### PR TITLE
Rhea migration to Slurm since September 2019

### DIFF
--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -44,21 +44,21 @@
         "notes"                       : "Requires the use of an RSA SecurID on every connection.",
         "schemas"                     : ["local", "ssh", "go"],
         "ssh"                         : {
-            "job_manager_endpoint"    : "torque+ssh://rhea.ccs.ornl.gov",
+            "job_manager_endpoint"    : "slurm+ssh://rhea.ccs.ornl.gov",
             "filesystem_endpoint"     : "sftp://rhea.ccs.ornl.gov/"
         },
         "local"                       : {
-            "job_manager_endpoint"    : "torque://localhost",
+            "job_manager_endpoint"    : "slurm://localhost",
             "filesystem_endpoint"     : "file://localhost/"
         },
         "go"                          : {
-            "job_manager_endpoint"    : "torque+ssh://rhea.ccs.ornl.gov",
+            "job_manager_endpoint"    : "slurm+ssh://rhea.ccs.ornl.gov",
             "filesystem_endpoint"     : "go://olcf#dtn/"
         },
         "default_queue"               : "batch",
         "cores_per_node"              : "16",
         "gpus_per_node"               : 1,
-        "lrms"                        : "TORQUE",
+        "lrms"                        : "SLURM",
         #"agent_type"                  : "multicore",
         #"agent_config"                : "mpirun",
         "agent_scheduler"             : "CONTINUOUS",


### PR DESCRIPTION
Rhea migrated batch schedulers from Moab to Slurm on September 03, 2019, according to [this](https://www.olcf.ornl.gov/for-users/system-user-guides/rhea/running-jobs/#slurm).