### PR TITLE
Feature/stampede2

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -120,6 +120,20 @@
         "cores"    : 96
     },
 
+    "xede.stampede2_ssh"  : {
+        "project"  : "TG-MCB090174",
+        "queue"    : "debug",
+        "schema"   : "gsissh",
+        "cores"    : 96
+    },
+
+    "xede.stampede2_srun"  : {
+        "project"  : "TG-MCB090174",
+        "queue"    : "debug",
+        "schema"   : "gsissh",
+        "cores"    : 96
+    },
+
     "ncar.cheyenne": {
 	    "project"  : "URTG0014",
 	    "queue"    : "regular",

--- a/src/radical/pilot/configs/resource_local.json
+++ b/src/radical/pilot/configs/resource_local.json
@@ -20,7 +20,6 @@
         ],
         "default_remote_workdir"      : "$HOME",
         "lrms"                        : "FORK",
-        "agent_config"                : "default_sa",
         "agent_scheduler"             : "CONTINUOUS",
         "agent_spawner"               : "POPEN",
         "agent_launch_method"         : "FORK",
@@ -32,7 +31,7 @@
         "cores_per_node"              : 8,
         "gpus_per_node"               : 1,
         "lfs_path_per_node"           : "/tmp",
-        "lfs_size_per_node"           : 2048,
+        "lfs_size_per_node"           : 1024,
         "memory_per_node"             : 4096
     },
 

--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -213,7 +213,7 @@
         "cu_pre_exec"                 : ["module restore"]
     },
 
-    "stampede2_ssh": {
+    "stampede2_srun": {
         "description"                 : "The XSEDE 'Stampede' cluster at TACC (https://www.tacc.utexas.edu/stampede/).",
         "notes"                       : "Always set the ``project`` attribute in the ComputePilotDescription or the pilot will fail.",
         "schemas"                     : ["gsissh", "ssh"],

--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -213,6 +213,44 @@
         "cu_pre_exec"                 : ["module restore"]
     },
 
+    "stampede2_ssh": {
+        "description"                 : "The XSEDE 'Stampede' cluster at TACC (https://www.tacc.utexas.edu/stampede/).",
+        "notes"                       : "Always set the ``project`` attribute in the ComputePilotDescription or the pilot will fail.",
+        "schemas"                     : ["gsissh", "ssh"],
+        "mandatory_args"              : ["project"],
+        "gsissh"                      :
+        {
+            "job_manager_endpoint"    : "slurm+gsissh://stampede2.tacc.utexas.edu:2222/",
+            "filesystem_endpoint"     : "gsisftp://stampede2.tacc.utexas.edu:2222/"
+        },
+        "ssh"                         :
+        {
+            "job_manager_endpoint"    : "slurm+ssh://stampede2.tacc.utexas.edu/",
+            "filesystem_endpoint"     : "sftp://stampede2.tacc.utexas.edu/"
+        },
+        "default_queue"               : "normal",
+        "lrms"                        : "SLURM",
+        "cores_per_node"              : 68,
+        "agent_scheduler"             : "CONTINUOUS",
+        "agent_spawner"               : "POPEN",
+        "agent_launch_method"         : "SRUN",
+        "task_launch_method"          : "SRUN",
+        "mpi_launch_method"           : "SRUN",
+        "pre_bootstrap_0"             :["module load TACC",
+                                         "module load intel/17.0.4",
+                                         "module load python/2.7.13"
+                                        ],
+        "default_remote_workdir"      : "$WORK",
+        "valid_roots"                 : ["/scratch", "$SCRATCH", "/work", "$WORK"],
+        "rp_version"                  : "local",
+        "virtenv_mode"                : "create",
+        "python_dist"                 : "default",
+        "export_to_cu"                : ["LMOD_CMD",
+                                         "LMOD_SYSTEM_DEFAULT_MODULES",
+                                         "LD_LIBRARY_PATH"],
+        "cu_pre_exec"                 : ["module restore"]
+    },
+
     "comet_ssh": {
         "description"                 : "The Comet HPC resource at SDSC 'HPC for the 99%' (http://www.sdsc.edu/services/hpc/hpc_systems.html#comet).",
         "notes"                       : "Always set the ``project`` attribute in the ComputePilotDescription or the pilot will fail.",


### PR DESCRIPTION
- Adds new config entry for `stampede2` to use srun instead of ssh for `agent|task|mpi_launch_method`. 
- Fixes entry in localhost resource config file
- Adds stampede2 entries in examples config file.

This is probably useful as hotfix before today release.