### PR TITLE
doc update for global TOC, in addition, sphinx version changes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -137,7 +137,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.intersphinx',
               'sphinx.ext.todo',
               'sphinx.ext.coverage',
-              'sphinx.ext.pngmath',
+              'sphinx.ext.imgmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode',
               'sphinx.ext.extlinks']
@@ -266,6 +266,7 @@ html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
+html_sidebars = { '**': ['globaltoc.html', 'relations.html', 'searchbox.html'] }
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
global TOC is presented ( radical-cybertools/radical.entk#390) in the navigation bar, 
shinx.ext.pngmath is replaced to sphinx.ext.imgpath after sphinx 1.8, https://github.com/sphinx-doc/sphinx/issues/6182