### PR TITLE
Bridges dependencies fixed

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -80,9 +80,9 @@
 
     "xsede.bridges" : {
         "project"  : null,
-        "queue"    : "RM",
+        "queue"    : "RM-small",
         "schema"   : "gsissh",
-        "cores"    : 64
+        "cores"    : 24
     },
 
     "xsede.wrangler" : {

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -993,7 +993,7 @@ virtenv_create()
     elif test "$python_dist" = "anaconda"
     then
         run_cmd "Create virtualenv" \
-                "conda create -y -p $virtenv python=3.5"
+                "conda create -y -p $virtenv python=3"
         if test $? -ne 0
         then
             echo "ERROR: Couldn't create virtualenv"

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -993,7 +993,7 @@ virtenv_create()
     elif test "$python_dist" = "anaconda"
     then
         run_cmd "Create virtualenv" \
-                "conda create -y -p $virtenv python=3"
+                "conda create -y -p $virtenv python=3.5"
         if test $? -ne 0
         then
             echo "ERROR: Couldn't create virtualenv"

--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -572,7 +572,7 @@
                                          "module load gcc",
                                          "module load mpi/gcc_openmpi",
                                          "module load slurm",
-                                         "module load python2"
+                                         "module load anaconda3"
                                         ],
         "default_remote_workdir"      : "$SCRATCH",
         "valid_roots"                 : ["/home", "/pylon1", "/pylon5"],


### PR DESCRIPTION
This PR introduces two changes.

1. Sets conda env python from general 3 to 3.5
2. Loads Anaconda3 in the configuration

This configuration passes all the examples on Bridges. GPU queues to be used.