### PR TITLE
decrease hb interval

### DIFF
--- a/src/radical/pilot/configs/agent_cray_aprun.json
+++ b/src/radical/pilot/configs/agent_cray_aprun.json
@@ -9,7 +9,7 @@
     "bulk_size"    : 1024,
 
     "heartbeat"    : {
-        "interval" :  5.0,
+        "interval" :  1.0,
         "timeout"  : 60.0
     },
 

--- a/src/radical/pilot/configs/agent_default.json
+++ b/src/radical/pilot/configs/agent_default.json
@@ -25,7 +25,7 @@
     "bulk_size"    : 1024,
 
     "heartbeat"    : {
-        "interval" :  5.0,
+        "interval" :  1.0,
         "timeout"  : 60.0
     },
 

--- a/src/radical/pilot/configs/agent_osg.json
+++ b/src/radical/pilot/configs/agent_osg.json
@@ -13,7 +13,7 @@
     "bulk_size"    : 1024,
 
     "heartbeat"    : {
-        "interval" :  5.0,
+        "interval" :  1.0,
         "timeout"  : 60.0
     },
 

--- a/src/radical/pilot/configs/agent_rhea.json
+++ b/src/radical/pilot/configs/agent_rhea.json
@@ -9,7 +9,7 @@
     "bulk_size"    : 1024,
 
     "heartbeat"    : {
-        "interval" :  5.0,
+        "interval" :  1.0,
         "timeout"  : 60.0
     },
 

--- a/src/radical/pilot/configs/agent_summit_sa.json
+++ b/src/radical/pilot/configs/agent_summit_sa.json
@@ -14,7 +14,7 @@
     "bulk_size"    : 1024,
 
     "heartbeat"    : {
-        "interval" :  5.0,
+        "interval" :  1.0,
         "timeout"  : 60.0
     },
 

--- a/src/radical/pilot/configs/session_default.json
+++ b/src/radical/pilot/configs/session_default.json
@@ -12,7 +12,7 @@
     "bulk_size"    : 1024,
 
     "heartbeat"    : {
-        "interval" :  5.0,
+        "interval" :  1.0,
         "timeout"  : 60.0
     },
 


### PR DESCRIPTION
We recently increased the default HB timeout to cater f or slow filesystems.  In that PR, we also increased the HB interval to keep the number of HB messages  consistent.  That slows down client and agent bootstrapping though, since we usually miss the first heartbeat message on component startup, and the second message now is delayed significantly.

This PR decreases the HB interval to avoid that.  In the long run, we may want to adapt the interval somewhat dynamically, but that is for another day...