### PR TITLE
fix get_consumed_resourced for multi-pilot

### DIFF
--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -586,6 +586,9 @@ def get_consumed_resources(session):
 
         for unit in session.get(etype='unit'):
 
+            if unit.cfg.get('pilot') != pid:
+                continue
+
             try:
                 snodes = unit.cfg['slots']['nodes']
                 ut     = unit.timestamps


### PR DESCRIPTION
This fixes radical-cybertools/radical.analytics/issues/107