### PR TITLE
fix LM error message on missing exe

### DIFF
--- a/src/radical/pilot/agent/lm/base.py
+++ b/src/radical/pilot/agent/lm/base.py
@@ -370,6 +370,9 @@ class LaunchMethod(object):
         returns version and flavor of MPI version.
         '''
 
+        if not exe:
+            raise ValueError('no executable found')
+
         version = None
         flavor  = self.MPI_FLAVOR_UNKNOWN
 


### PR DESCRIPTION
Improve the  error message on missing MPI launch method executable.