### PR TITLE
re-order termination

### DIFF
--- a/src/radical/pilot/agent/agent_0.py
+++ b/src/radical/pilot/agent/agent_0.py
@@ -73,6 +73,7 @@ class Agent_0(rpu.Worker):
         # and start those
         self._cmgr = rpu.ComponentManager(self._cfg)
         self._cfg.heartbeat = self._cmgr.cfg.heartbeat
+
         self._cmgr.start_bridges()
         self._cmgr.start_components()
 
@@ -227,6 +228,8 @@ class Agent_0(rpu.Worker):
                     self._log.error('output tarring failed: %s', cmd)
 
 
+    # --------------------------------------------------------------------------
+    #
     def finalize(self):
 
         # tar up output staging data
@@ -248,59 +251,31 @@ class Agent_0(rpu.Worker):
         # we don't rely on the existence / viability of the update worker at
         # that point.
         self._log.debug('update db state: %s: %s', state, self._final_cause)
-        self._update_db(state, self._final_cause)
 
         # NOTE: we do not push the final pilot state, as that is done by the
         #       bootstrapper *after* this pilot *actually* finished.
+        with open('./killme.signal', 'w') as fout:
+            fout.write('%s\n' % state)
 
         self._log.info('pilot state: %s [%s]', state, self._final_cause)
-
-        out, out, err = None, None, None
-
-        try   : out = open('./agent.0.out', 'r').read(1024)
-        except: pass
-        try   : err = open('./agent.0.err', 'r').read(1024)
-        except: pass
-        try   : log = open('./agent.0.log', 'r').read(1024)
-        except: pass
-
-        self._dbs._c.update({'type': 'pilot',
-                             'uid' : self._pid},
-                            {'$set': {'stdout' : rpu.tail(out),
-                                      'stderr' : rpu.tail(err),
-                                      'logfile': rpu.tail(log)} })
-
-
-    # --------------------------------------------------------------------------
-    #
-    def _update_db(self, state, msg=None):
-
-        # NOTE: we do not push the final pilot state, as that is done by the
-        #       bootstrapper *after* this poilot *actually* finished.
-
-        self._log.info('pilot state: %s', state)
         self._log.info('rusage: %s', rpu.get_rusage())
-        self._log.info(msg)
 
-        if state == rps.FAILED:
-            self._log.info(ru.get_trace())
+        out, out, err = '', '', ''
 
-        out = None
-        err = None
-        log = None
-
-        try   : out = open('./agent_0.out', 'r').read(1024)
+        try   : out   = open('./agent.0.out', 'r').read(1024)
         except: pass
-        try   : err = open('./agent_0.err', 'r').read(1024)
+        try   : err   = open('./agent.0.err', 'r').read(1024)
         except: pass
-        try   : log = open('./agent_0.log', 'r').read(1024)
+        try   : log   = open('./agent.0.log', 'r').read(1024)
         except: pass
 
-        ret = self._dbs._c.update({'type': 'pilot',
-                                   'uid' : self._pid},
-                                  {'$set': {'stdout' : rpu.tail(out),
-                                            'stderr' : rpu.tail(err),
-                                            'logfile': rpu.tail(log)}
+        ret = self._dbs._c.update({'type' : 'pilot',
+                                   'uid'  : self._pid},
+                                  {'$set' : {'stdout' : rpu.tail(out),
+                                             'stderr' : rpu.tail(err),
+                                             'logfile': rpu.tail(log),
+                                             'state'  : state},
+                                   '$push': {'states' : state}
                                   })
         self._log.debug('update ret: %s', ret)
 

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -1835,6 +1835,7 @@ do
     sleep 3
     if kill -0 $AGENT_PID 2>/dev/null
     then
+        echo -n '.'
         if test -e "./killme.signal"
         then
             profile_event 'killme' "`date --rfc-3339=ns | cut -c -23`"
@@ -1849,6 +1850,7 @@ do
             kill  -9 $AGENT_PID
         fi
     else
+        echo
         profile_event 'agent_gone' "`date --rfc-3339=ns | cut -c -23`"
         echo "agent $AGENT_PID is gone"
         break

--- a/src/radical/pilot/pilot_manager.py
+++ b/src/radical/pilot/pilot_manager.py
@@ -190,7 +190,6 @@ class PilotManager(rpu.Component):
         if self._closed:
             return
 
-        self._terminate.set()
         self._rep.info('<<close pilot manager')
 
         # disable callbacks during shutdown
@@ -201,11 +200,12 @@ class PilotManager(rpu.Component):
 
         # If terminate is set, we cancel all pilots.
         if terminate:
-            self.cancel_pilots(_timeout=10)
+            self.cancel_pilots(_timeout=20)
             # if this cancel op fails and the pilots are s till alive after
             # timeout, the pmgr.launcher termination will kill them
 
 
+        self._terminate.set()
         self._cmgr.close()
 
         self._log.info("Closed PilotManager %s." % self._uid)
@@ -717,8 +717,7 @@ class PilotManager(rpu.Component):
                     self._log.debug ("wait timed out")
                     break
 
-                time.sleep (0.1)
-
+            time.sleep (0.1)
 
         self._rep.idle(mode='stop')
 

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -697,7 +697,7 @@ class Default(PMGRLaunchingComponent):
             tgt_dir = os.path.dirname(tgt)
 
             if tgt_dir.startswith('..'):
-              # raise ValueError('staging target %s outside of pilot sandbox: %s' % (ft['tgt'], tgt))
+              # raise ValueError('staging tgt %s outside pilot sbox: %s' % (ft['tgt'], tgt))
                 tgt = ft['tgt']
                 tgt_dir = os.path.dirname(tgt)
 


### PR DESCRIPTION
`self.terminate` was set too early in the pilot manager, so that the `wait_pilots` call never actually waited for the pilots, but bailed out immediately complaining about timeout.  This PR fixes that - but also cleans up the state reporting done by the pilot, to re-introduce the `rp_state_push` utility to account for clean state pushes on bootstrap failures.