### PR TITLE
add "fake_resources" cfg option

### DIFF
--- a/src/radical/pilot/agent/resource_manager/fork.py
+++ b/src/radical/pilot/agent/resource_manager/fork.py
@@ -29,11 +29,16 @@ class Fork(ResourceManager):
 
         # For the fork ResourceManager (ie. on localhost), we fake an infinite
         # number of cores, so don't perform any sanity checks.
-        detected_cpus = multiprocessing.cpu_count()
+        detected_cores = multiprocessing.cpu_count()
 
-        if detected_cpus != self.requested_cores:
-            self._log.info("using %d instead of physically available %d cores.",
-                    self.requested_cores, detected_cpus)
+        if detected_cores != self.requested_cores:
+            if self._cfg.resource_cfg.fake_resources:
+                self._log.info("using %d instead of available %d cores.",
+                               self.requested_cores, detected_cores)
+            else:
+                if self.requested_cores > detected_cores:
+                    raise RuntimeError('insufficient cores found (%d < %d'
+                            % (detected_cores, self.requested_cores))
 
         # if cores_per_node is set in the agent config, we slice the number of
         # cores into that many virtual nodes.  cpn defaults to requested_cores,

--- a/src/radical/pilot/configs/resource_local.json
+++ b/src/radical/pilot/configs/resource_local.json
@@ -34,7 +34,8 @@
         "gpus_per_node"               : 1,
         "lfs_path_per_node"           : "/tmp",
         "lfs_size_per_node"           : 1024,
-        "memory_per_node"             : 4096
+        "memory_per_node"             : 4096,
+        "fake_resources"              : true
     },
 
     "localhost_aprun": {


### PR DESCRIPTION
This fixes #2042: adding the entry `"fake_resources" : true` to a config will allow the resource manager to fake the existence of resources.  Only the Fork RM implements this at the moment.