### PR TITLE
Setting anaconda python to 3.6

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -980,7 +980,7 @@ virtenv_create()
     elif test "$python_dist" = "anaconda"
     then
         run_cmd "Create virtualenv" \
-                "conda create -y -p $virtenv python=3.6"
+                "conda create -y -p $virtenv python=3.8"
         if test $? -ne 0
         then
             echo "ERROR: Couldn't create virtualenv"

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -980,7 +980,7 @@ virtenv_create()
     elif test "$python_dist" = "anaconda"
     then
         run_cmd "Create virtualenv" \
-                "conda create -y -p $virtenv python=3"
+                "conda create -y -p $virtenv python=3.6"
         if test $? -ne 0
         then
             echo "ERROR: Couldn't create virtualenv"


### PR DESCRIPTION
Anaconda currently pull python3.8 when python 3 is specified. This change forces anaconda to pull python3.6