### PR TITLE
str default should not be `None`

### DIFF
--- a/src/radical/pilot/compute_unit_description.py
+++ b/src/radical/pilot/compute_unit_description.py
@@ -357,16 +357,16 @@ class ComputeUnitDescription(ru.Description):
     }
 
     _defaults = {
-               EXECUTABLE      : None        ,
-               KERNEL          : None        ,
-               NAME            : None        ,
-               SANDBOX         : None        ,
+               EXECUTABLE      : ''          ,
+               KERNEL          : ''          ,
+               NAME            : ''          ,
+               SANDBOX         : ''          ,
                ARGUMENTS       : list()      ,
                ENVIRONMENT     : dict()      ,
                PRE_EXEC        : list()      ,
                POST_EXEC       : list()      ,
-               STDOUT          : None        ,
-               STDERR          : None        ,
+               STDOUT          : ''          ,
+               STDERR          : ''          ,
                INPUT_STAGING   : list()      ,
                OUTPUT_STAGING  : list()      ,
 


### PR DESCRIPTION
This fixes #2053.  I am positively surprised that this went unnoticed before: basically means that units are well isolated even when sharing a sandbox ;-)  Either way, this needs to be released ASAP.  Thanks for opening the ticket, @iparask !