### PR TITLE
fix cud schema

### DIFF
--- a/src/radical/pilot/compute_unit_description.py
+++ b/src/radical/pilot/compute_unit_description.py
@@ -335,8 +335,8 @@ class ComputeUnitDescription(ru.Description):
                POST_EXEC       : [str]       ,
                STDOUT          : str         ,
                STDERR          : str         ,
-               INPUT_STAGING   : [str]       ,
-               OUTPUT_STAGING  : [str]       ,
+               INPUT_STAGING   : None        ,
+               OUTPUT_STAGING  : None        ,
 
                CPU_PROCESSES   : int         ,
                CPU_PROCESS_TYPE: str         ,


### PR DESCRIPTION
I made a mistake in specifying staging directives in the task descriptions as lists of strings.  We do indeed mostly use that format, but I forgot that we in fact also support a dict format for specifying more complex staging ops.  This patch fixes that by removing the type spec for staging declarations altogether.  That's not optimal but will have to suffice for now as this needs to be released.  I'll open a ticket to track the creation of a proper value checker.