### PR TITLE
fixed package paths for launch methods in unit tests (tests.test_lm.test_unit)

### DIFF
--- a/tests/test_lm/test_unit/test_aprun.py
+++ b/tests/test_lm/test_unit/test_aprun.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from .test_common                  import setUp
-from radical.pilot.agent.lm.aprun import APRun
+from radical.pilot.agent.launch_method.aprun import APRun
 
 import radical.utils as ru
 

--- a/tests/test_lm/test_unit/test_base.py
+++ b/tests/test_lm/test_unit/test_base.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 
-from radical.pilot.agent.lm.base import LM
+from radical.pilot.agent.launch_method.base import LaunchMethod
 
 import radical.utils as ru
 import pytest
@@ -15,11 +15,11 @@ except ImportError:
 
 # ------------------------------------------------------------------------------
 #
-# @mock.patch.object(LM, '_configure', return_value=None)
+# @mock.patch.object(LaunchMethod, '_configure', return_value=None)
 # def test_init(mocked_configure):
 #     session = mock.Mock()
 #     session._log = mock.Mock()
-#     lm = LM(name='test', cfg={}, session=session)
+#     lm = LaunchMethod(name='test', cfg={}, session=session)
 #     assert lm.name     == 'test'
 #     assert lm._cfg     == {}
 #     assert lm._session == session
@@ -33,16 +33,16 @@ def test_configure():
     session = mock.Mock()
     session._log = mock.Mock()
     with pytest.raises(NotImplementedError):
-        LM(name='test', cfg={}, session=session)
+        LaunchMethod(name='test', cfg={}, session=session)
 # ------------------------------------------------------------------------------
 
 
 # ------------------------------------------------------------------------------
 #
-@mock.patch.object(LM,'__init__',return_value=None)
+@mock.patch.object(LaunchMethod,'__init__',return_value=None)
 def test_get_mpi_info(mocked_init):
 
-    lm = LM(name=None, cfg={}, session=None)
+    lm = LaunchMethod(name=None, cfg={}, session=None)
     lm._log = mock.Mock()
     ru.sh_callout = mock.Mock()
     ru.sh_callout.side_effect = [['test',1,0]]

--- a/tests/test_lm/test_unit/test_ccmrun.py
+++ b/tests/test_lm/test_unit/test_ccmrun.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from   .test_common                   import setUp
-from   radical.pilot.agent.lm.ccmrun import CCMRun
+from   radical.pilot.agent.launch_method.ccmrun import CCMRun
 
 import radical.utils as ru
 

--- a/tests/test_lm/test_unit/test_fork.py
+++ b/tests/test_lm/test_unit/test_fork.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from   .test_common                 import setUp
-from   radical.pilot.agent.lm.fork import Fork
+from   radical.pilot.agent.launch_method.fork import Fork
 
 import radical.utils as ru
 

--- a/tests/test_lm/test_unit/test_ibrun.py
+++ b/tests/test_lm/test_unit/test_ibrun.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from   .test_common                   import setUp
-from   radical.pilot.agent.lm.ibrun import IBRun
+from   radical.pilot.agent.launch_method.ibrun import IBRun
 
 import radical.utils as ru
 import pytest

--- a/tests/test_lm/test_unit/test_jsrun.py
+++ b/tests/test_lm/test_unit/test_jsrun.py
@@ -4,7 +4,7 @@ import os
 import glob
 import radical.utils as ru
 from .test_common                  import setUp
-from radical.pilot.agent.lm.jsrun import JSRUN
+from radical.pilot.agent.launch_method.jsrun import JSRUN
 
 try:
     import mock

--- a/tests/test_lm/test_unit/test_mpiexec.py
+++ b/tests/test_lm/test_unit/test_mpiexec.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from   .test_common                    import setUp
-from   radical.pilot.agent.lm.mpiexec import MPIExec
+from   radical.pilot.agent.launch_method.mpiexec import MPIExec
 
 import radical.utils as ru
 

--- a/tests/test_lm/test_unit/test_mpirun.py
+++ b/tests/test_lm/test_unit/test_mpirun.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from   .test_common                   import setUp
-from   radical.pilot.agent.lm.mpirun import MPIRun
+from   radical.pilot.agent.launch_method.mpirun import MPIRun
 
 import radical.utils as ru
 
@@ -126,8 +126,8 @@ def test_construct_command(mocked_init,
     component._log           = ru.Logger('dummy')
     component.mpi_flavor     = None
     component.launch_command = 'mpirun'
-    component.ccmrun_command = ''
-    component.dplace_command = ''
+    component._ccmrun = ''
+    component._dplace = ''
 
     for unit, result in test_cases:
         command, hop = component.construct_command(unit, None)

--- a/tests/test_lm/test_unit/test_prte.py
+++ b/tests/test_lm/test_unit/test_prte.py
@@ -3,7 +3,7 @@
 import pytest
 
 from .test_common                import setUp
-from radical.pilot.agent.lm.prte import PRTE
+from radical.pilot.agent.launch_method.prte import PRTE
 
 import radical.utils as ru
 

--- a/tests/test_lm/test_unit/test_rsh.py
+++ b/tests/test_lm/test_unit/test_rsh.py
@@ -4,7 +4,7 @@
 import os
 
 from   .test_common                 import setUp
-from   radical.pilot.agent.lm.rsh import RSH
+from   radical.pilot.agent.launch_method.rsh import RSH
 import pytest
 
 import radical.utils as ru
@@ -47,8 +47,9 @@ def test_configure_fail(mocked_init, mocked_raise_on, mocked_which):
 #
 @mock.patch.object(RSH, '__init__',   return_value=None)
 @mock.patch.object(RSH, '_configure', return_value=None)
-@mock.patch.dict(os.environ,{'PATH'           :'test_path',
-                             'LD_LIBRARY_PATH':'/usr/local/lib/'})
+@mock.patch.dict(os.environ,
+                 {'PATH': 'test_path', 'LD_LIBRARY_PATH': '/usr/local/lib/'},
+                 clear=True)
 @mock.patch('radical.utils.raise_on')
 def test_construct_command(mocked_init,
                            mocked_configure,
@@ -56,7 +57,6 @@ def test_construct_command(mocked_init,
 
     test_cases = setUp('lm', 'rsh')
     component  = RSH(name=None, cfg=None, session=None)
-
     component._log           = ru.Logger('dummy')
     component.name           = 'RSH'
     component.mpi_flavor     = None

--- a/tests/test_lm/test_unit/test_spark.py
+++ b/tests/test_lm/test_unit/test_spark.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from   .test_common                  import setUp
-from   radical.pilot.agent.lm.spark import Spark
+from   radical.pilot.agent.launch_method.spark import Spark
 
 import radical.utils as ru
 

--- a/tests/test_lm/test_unit/test_ssh.py
+++ b/tests/test_lm/test_unit/test_ssh.py
@@ -4,7 +4,7 @@
 import os
 
 from   .test_common                 import setUp
-from   radical.pilot.agent.lm.ssh import SSH
+from   radical.pilot.agent.launch_method.ssh import SSH
 import pytest
 
 import radical.utils as ru
@@ -48,7 +48,9 @@ def test_configure_fail(mocked_init, mocked_raise_on, mocked_which):
 #
 @mock.patch.object(SSH, '__init__',   return_value=None)
 @mock.patch.object(SSH, '_configure', return_value=None)
-@mock.patch.dict(os.environ,{'PATH':'test_path'})
+@mock.patch.dict(os.environ,
+                 {'PATH': 'test_path', 'LD_LIBRARY_PATH': '/usr/local/lib/'},
+                 clear=True)
 @mock.patch('radical.utils.raise_on')
 def test_construct_command(mocked_init,
                            mocked_configure,

--- a/tests/test_lm/test_unit/test_yarn.py
+++ b/tests/test_lm/test_unit/test_yarn.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access, unused-argument
 
 from   .test_common                 import setUp
-from   radical.pilot.agent.lm.yarn import Yarn
+from   radical.pilot.agent.launch_method.yarn import Yarn
 
 import radical.utils as ru
 


### PR DESCRIPTION
fixed package paths for launch methods (radical.pilot.agent.launch_method) in unit tests (tests.test_lm.test_unit)

- additionally: 1) test_mpirun.py: fixed attributes names; 2) test_rsh.py and test_ssh.py: fixed environment for testing (cleared os.environ before testing with predefined variables)