### PR TITLE
cu level profiling needs to be python independent

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -141,13 +141,13 @@ create_gtod()
         shell=/bin/sh
         test -x '/bin/bash' && shell=/bin/bash
 
-        echo "#!$SHELL"                                                > ./gtod
-        echo "if test -z \"\$EPOCHREALTIME\""                         >> ./gtod
-        echo "then"                                                   >> ./gtod
-        echo "  python3 -c 'import time;print(\"%.6f\"%time.time())'" >> ./gtod
-        echo "else"                                                   >> ./gtod
-        echo "  echo \${EPOCHREALTIME:0:20}"                          >> ./gtod
-        echo "fi"                                                     >> ./gtod
+        echo "#!$SHELL"                                > ./gtod
+        echo "if test -z \"\$EPOCHREALTIME\""         >> ./gtod
+        echo "then"                                   >> ./gtod
+        echo "  awk 'BEGIN {srand(); print srand()}'" >> ./gtod
+        echo "else"                                   >> ./gtod
+        echo "  echo \${EPOCHREALTIME:0:20}"          >> ./gtod
+        echo "fi"                                     >> ./gtod
     fi
 
     chmod 0755 ./gtod

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -152,10 +152,8 @@ create_gtod()
 
     chmod 0755 ./gtod
 
-    set -x
     TIME_ZERO=`./gtod`
     export TIME_ZERO
-    set +x
 }
 
 
@@ -163,7 +161,6 @@ create_gtod()
 #
 profile_event()
 {
-    set -x
     if test -z "$RADICAL_PILOT_PROFILE$RADICAL_PROFILE"
     then
         return
@@ -194,7 +191,6 @@ profile_event()
     printf "%.4f,%s,%s,%s,%s,%s,%s\n" \
         "$now" "$event" "bootstrap_0" "MainThread" "$PILOT_ID" "PMGR_ACTIVE_PENDING" "$msg" \
         | tee -a "$PROFILE"
-    set +x
 }
 
 


### PR DESCRIPTION
Within the CU script we recently switched to Python to get timestamps for profiling.  That breaks when the python module gets unloaded by the task's `pre_exec` directives.  This patch switches back to a plain awk command line.