### PR TITLE
Hotfix/launcher termination

### DIFF
--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         # Submit the previously created ComputeUnit descriptions to the
         # PilotManager. This will trigger the selected scheduler to start
         # assigning ComputeUnits to the ComputePilots.
-        umgr.submit_units(cuds)
+      # umgr.submit_units(cuds)
 
         # Wait for all compute units to reach a final state (DONE, CANCELED or FAILED).
         umgr.wait_units()

--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         # Submit the previously created ComputeUnit descriptions to the
         # PilotManager. This will trigger the selected scheduler to start
         # assigning ComputeUnits to the ComputePilots.
-      # umgr.submit_units(cuds)
+        umgr.submit_units(cuds)
 
         # Wait for all compute units to reach a final state (DONE, CANCELED or FAILED).
         umgr.wait_units()

--- a/src/radical/pilot/agent/launch_method/prte.py
+++ b/src/radical/pilot/agent/launch_method/prte.py
@@ -73,17 +73,17 @@ class PRTE(LaunchMethod):
         prte += ' --report-uri %s' % furi
         prte += ' --hostfile %s'   % fhosts
 
-        if profiler.enabled or True:
+        if profiler.enabled:
             prte += ' --pmca orte_state_base_verbose 1'  # prte profiling
 
         # large tasks imply large message sizes, and we need to account for that
         # FIXME: we should derive the message size from DVM size - smaller DVMs
         #        will never need large messages, as they can't run large tasks)
         prte += ' --pmca ptl_base_max_msg_size %d' % (1024 * 1024 * 1024 * 1)
-        prte += ' --pmca rmaps_base_verbose 5'
+      # prte += ' --pmca rmaps_base_verbose 5'
 
         # debug mapper problems for large tasks
-        if log.isEnabledFor(logging.DEBUG) or True:
+        if log.isEnabledFor(logging.DEBUG):
             prte += ' -pmca orte_rmaps_base_verbose 100'
 
         # we apply two temporary tweaks on Summit which should not be needed in
@@ -111,7 +111,7 @@ class PRTE(LaunchMethod):
 
         # Additional (debug) arguments to prte
         verbose = bool(os.environ.get('RADICAL_PILOT_PRUN_VERBOSE'))
-        if verbose or True:
+        if verbose:
             debug_strings = [
                              '--debug-devel',
                              '--pmca odls_base_verbose 100',
@@ -290,7 +290,7 @@ class PRTE(LaunchMethod):
 
         # see DVM startup
         map_flag += ' --pmca ptl_base_max_msg_size %d' % (1024 * 1024 * 1024 * 1)
-        map_flag += ' --pmca rmaps_base_verbose 5'
+      # map_flag += ' --pmca rmaps_base_verbose 5'
 
         if 'nodes' not in slots:
             # this task is unscheduled - we leave it to PRRTE/PMI-X to
@@ -313,7 +313,7 @@ class PRTE(LaunchMethod):
 
         # Additional (debug) arguments to prun
         debug_string = ''
-        if self._verbose or True:
+        if self._verbose:
             debug_string += ' '.join([
                                         '-verbose',
                                       # '--debug-devel',

--- a/src/radical/pilot/agent/launch_method/prte.py
+++ b/src/radical/pilot/agent/launch_method/prte.py
@@ -73,16 +73,17 @@ class PRTE(LaunchMethod):
         prte += ' --report-uri %s' % furi
         prte += ' --hostfile %s'   % fhosts
 
-        if profiler.enabled:
+        if profiler.enabled or True:
             prte += ' --pmca orte_state_base_verbose 1'  # prte profiling
 
         # large tasks imply large message sizes, and we need to account for that
         # FIXME: we should derive the message size from DVM size - smaller DVMs
         #        will never need large messages, as they can't run large tasks)
         prte += ' --pmca ptl_base_max_msg_size %d' % (1024 * 1024 * 1024 * 1)
+        prte += ' --pmca rmaps_base_verbose 5'
 
         # debug mapper problems for large tasks
-        if log.isEnabledFor(logging.DEBUG):
+        if log.isEnabledFor(logging.DEBUG) or True:
             prte += ' -pmca orte_rmaps_base_verbose 100'
 
         # we apply two temporary tweaks on Summit which should not be needed in
@@ -110,7 +111,7 @@ class PRTE(LaunchMethod):
 
         # Additional (debug) arguments to prte
         verbose = bool(os.environ.get('RADICAL_PILOT_PRUN_VERBOSE'))
-        if verbose:
+        if verbose or True:
             debug_strings = [
                              '--debug-devel',
                              '--pmca odls_base_verbose 100',
@@ -289,6 +290,7 @@ class PRTE(LaunchMethod):
 
         # see DVM startup
         map_flag += ' --pmca ptl_base_max_msg_size %d' % (1024 * 1024 * 1024 * 1)
+        map_flag += ' --pmca rmaps_base_verbose 5'
 
         if 'nodes' not in slots:
             # this task is unscheduled - we leave it to PRRTE/PMI-X to
@@ -311,7 +313,7 @@ class PRTE(LaunchMethod):
 
         # Additional (debug) arguments to prun
         debug_string = ''
-        if self._verbose:
+        if self._verbose or True:
             debug_string += ' '.join([
                                         '-verbose',
                                       # '--debug-devel',

--- a/src/radical/pilot/pmgr/launching/base.py
+++ b/src/radical/pilot/pmgr/launching/base.py
@@ -28,6 +28,7 @@ class PMGRLaunchingComponent(rpu.Component):
 
         self._pmgr = self._owner
 
+
     # --------------------------------------------------------------------------
     #
     # This class-method creates the appropriate sub-class for the Launcher.

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -91,35 +91,26 @@ class Default(PMGRLaunchingComponent):
     def finalize(self):
 
         try:
-            self._log.debug('=== finalize 0')
-            self._log.debug('=== close js %s', self._saga_js_cache.keys())
-
             self.unregister_timed_cb(self._pilot_watcher_cb)
             self.unregister_input(rps.PMGR_LAUNCHING_PENDING,
                                   rpc.PMGR_LAUNCHING_QUEUE, self.work)
-            self._log.debug('=== finalize 1')
-
 
             # FIXME: always kill all saga jobs for non-final pilots at termination,
-            #        and set the pilot states to CANCELED.  This will confluct with
+            #        and set the pilot states to CANCELED.  This will conflict with
             #        disconnect/reconnect semantics.
             with self._pilots_lock:
                 pids = list(self._pilots.keys())
-            self._log.debug('=== finalize 2')
 
             self._cancel_pilots(pids)
             self._kill_pilots(pids)
-            self._log.debug('=== finalize 3')
 
             with self._cache_lock:
-                self._log.debug('=== finalize 4')
                 for url,js in self._saga_js_cache.items():
-                    self._log.debug('=== close js %s', url)
+                    self._log.debug('close js %s', url)
                     js.close()
-            self._log.debug('=== finalize 5')
 
         except:
-            self._log.exception('=== finalization error')
+            self._log.exception('finalization error')
 
 
     # --------------------------------------------------------------------------
@@ -797,7 +788,6 @@ class Default(PMGRLaunchingComponent):
             else:
                 js_tmp  = rs.job.Service(js_url, session=self._session)
                 self._saga_js_cache[js_url] = js_tmp
-                self._log.debug('=== create js 1: %s %s', js_url, self._saga_js_cache.keys())
 
       # cmd = "tar zmxvf %s/%s -C / ; rm -f %s" % \
         cmd = "tar zmxvf %s/%s -C %s" % \
@@ -821,7 +811,6 @@ class Default(PMGRLaunchingComponent):
             else:
                 js = rs.job.Service(js_ep, session=self._session)
                 self._saga_js_cache[js_ep] = js
-                self._log.debug('=== create js 2: %s %s', js_ep, self._saga_js_cache.keys())
 
         # now that the scripts are in place and configured,
         # we can launch the agent


### PR DESCRIPTION
Houston, we have a problem...

I was looking into the thread limit problem we recently faced on Frontera, and found that in many cases, the pmgr.launching component did not terminate.  I checked on other machines and found the same on Summit, but not on localhost.  It turned our to be related to the SAGA adaptor used for the pilot launching.  What happened is the following:

Sometime in June 2019, a fix was made to the Python threading module to get rid of those pesky `exception in bootstrap_inner` messages which randomly appeared on thread termination, and which shows random stack traces.  You may remember those - or not if your brain does the sane thing and blends out stuff like that.  Either way, while I applaud the patch of fixing that problem, it changed the code path taking during thread termination *for daemon threads*.  

Sometime in December, we changed our process management to be heartbeat based.  For that to be functional, we changed *all* threads to daemon threads (process termination will not wait for daemon threads to complete).  Specifically, the threads used by SAGA to watch process health are now daemon threads.

Along with those changes, we got rid of quite some code which manages thread termination, as daemon threads *always* terminate - that's the definition of daemon threads.

Now, it happens that the RS threads use a **private signal** `self._stop = threading.Event()` to communicate with the main thread and to allow for early termination, for example on job service instance close or garbage collection, i.e., before the actual process termination kicks in and kills all daemon threads.

The Python code changes I mentioned above are related to a lock management problem.  That lock is now cleanly released for all threads on termination, either explicit, daemonized, or garbage collected.  The change however now triggers a code path when terminating daemonized, garbage collected threads to call a private **function** `self._stop()` -- Oh oh..

So, when our SAGA threads which have a `_stop` Event are daemonized, and when we close the job service, then the threads get garbage collected eventually, and then the threading module will call `self._stop()` **on that `threading.Event` instance** which our implementation re-defines, and kaboom, and the fucking daemon(!) thread will just hangs and will not terminate, and so won't the pmgr.launching component.

The fix is easy: rename `self._stop` to something else.  We use `self._term` in RP and RU, so `self._term` it is.  Why I am telling you all this?  Because (a) it was a nightmare to debug and find, and I wanted to leave a trace of it, but also (b) because it means that we can't rely on daemon threads to die on termination and may need to re-introduce some sanity checks.  Urgh.

Last but not least, you may want to check on the different login nodes of Frontera and Summit if you left rp instances behind.  The following commands should help:
```
$ name=$(uid -un)
$ ps -f -u $name | grep rp.pmgr_launching.0
```

You may want to kill those (which will also tear down some other dependent processes and threads:
```
$ ps -f -u $name | grep rp.pmgr_launching.0 | grep -v grep | cut -c 9-15 | xargs -n 1 -t kill
```

This PR contains some debugging support and cleanup to make observing this problem easier, and will be accompanied by two similar PRs on RS and RU level.