### PR TITLE
Agent stage_in test1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 
 language: python
 python:   "3.6"
-root:     disabled
 os:       linux
 dist:     xenial
 

--- a/src/radical/pilot/agent/staging_input/default.py
+++ b/src/radical/pilot/agent/staging_input/default.py
@@ -77,6 +77,10 @@ class Default(AgentStagingInputComponent):
             else:
                 no_staging_units.append(unit)
 
+        unit_testing = os.environ.get('RP_UNIT_TESTING', 'false')
+
+        if unit_testing.lower() == 'true':
+            return staging_units, no_staging_units
 
         if no_staging_units:
             self.advance(no_staging_units, rps.AGENT_SCHEDULING_PENDING,

--- a/src/radical/pilot/agent/staging_input/default.py
+++ b/src/radical/pilot/agent/staging_input/default.py
@@ -77,11 +77,6 @@ class Default(AgentStagingInputComponent):
             else:
                 no_staging_units.append(unit)
 
-        unit_testing = os.environ.get('RP_UNIT_TESTING', 'false')
-
-        if unit_testing.lower() == 'true':
-            return staging_units, no_staging_units
-
         if no_staging_units:
             self.advance(no_staging_units, rps.AGENT_SCHEDULING_PENDING,
                          publish=True, push=True)

--- a/tests/test_agent_stagein/test_cases/unit.000000.json
+++ b/tests/test_agent_stagein/test_cases/unit.000000.json
@@ -1,0 +1,27 @@
+
+{
+    "unit": {
+        "uid":         "unit.000000",
+        "description": {"input_staging": [{"source": "client:///file1",
+                                           "target": "unit:///file1",
+                                           "action": "Transfer"},
+                                          {"source": "unit:///file2",
+                                           "target": "pilot:///file2",
+                                           "action": "Link"}]
+                                                      }
+    },
+
+    "results": [[[{"uid": "unit.000000",
+                   "description": {"input_staging": [{"source": "client:///file1",
+                                                      "target": "unit:///file1",
+                                                      "action": "Transfer"},
+                                                     {"source": "unit:///file2",
+                                                      "target": "pilot:///file2",
+                                                      "action": "Link"}]}}, 
+                                                    [{"source": "unit:///file2",
+                                                      "target": "pilot:///file2",
+                                                      "action": "Link"}]]],
+                                                      []
+                                                    ]
+}
+

--- a/tests/test_agent_stagein/test_cases/unit.000000.json
+++ b/tests/test_agent_stagein/test_cases/unit.000000.json
@@ -11,17 +11,16 @@
                                                       }
     },
 
-    "results": [[[{"uid": "unit.000000",
+    "results": [[{"uid": "unit.000000",
                    "description": {"input_staging": [{"source": "client:///file1",
                                                       "target": "unit:///file1",
                                                       "action": "Transfer"},
                                                      {"source": "unit:///file2",
                                                       "target": "pilot:///file2",
-                                                      "action": "Link"}]}}, 
-                                                    [{"source": "unit:///file2",
-                                                      "target": "pilot:///file2",
-                                                      "action": "Link"}]]],
-                                                      []
+                                                      "action": "Link"}]}}], 
+                                                      [[{"source": "unit:///file2",
+                                                         "target": "pilot:///file2",
+                                                         "action": "Link"}]]
                                                     ]
 }
 

--- a/tests/test_agent_stagein/test_cases/unit.000001.json
+++ b/tests/test_agent_stagein/test_cases/unit.000001.json
@@ -1,0 +1,10 @@
+
+{
+    "unit": {
+        "uid":         "unit.000001",
+        "description": {"input_staging": []}
+    },
+
+    "results": [[],[{"uid": "unit.000001", "description": {"input_staging": []}}]]
+}
+

--- a/tests/test_agent_stagein/test_cases/unit.000001.json
+++ b/tests/test_agent_stagein/test_cases/unit.000001.json
@@ -5,6 +5,8 @@
         "description": {"input_staging": []}
     },
 
-    "results": [[],[{"uid": "unit.000001", "description": {"input_staging": []}}]]
+    "results": [[[{"uid": "unit.000001",
+                   "description": {"input_staging": []}}]],
+                ["AGENT_SCHEDULING_PENDING"]]
 }
 

--- a/tests/test_agent_stagein/test_default.py
+++ b/tests/test_agent_stagein/test_default.py
@@ -36,6 +36,7 @@ class TestDefault(TestCase):
 
         global_things = []
         global_state = []
+
         # ------------------------------------------------------------------------------
         #
         def _advance_side_effect(things, state, publish, push):
@@ -43,7 +44,6 @@ class TestDefault(TestCase):
             nonlocal global_state
             global_things.append(things)
             global_state.append(state)
-
 
         # ------------------------------------------------------------------------------
         #

--- a/tests/test_agent_stagein/test_default.py
+++ b/tests/test_agent_stagein/test_default.py
@@ -1,11 +1,8 @@
 # pylint: disable=protected-access, unused-argument
-import os
 import glob
 import radical.utils as ru
 from radical.pilot.agent.staging_input.default import Default
 from unittest import TestCase, mock
-
-os.environ['RP_UNIT_TESTING'] = 'TRUE'
 
 
 class TestDefault(TestCase):
@@ -30,20 +27,39 @@ class TestDefault(TestCase):
 
         pass
 
+
     # --------------------------------------------------------------------------
     #
     @mock.patch.object(Default, '__init__',   return_value=None)
-    @mock.patch.object(Default, '_handle_unit', return_value=None)
-    @mock.patch.object(Default, 'advance', return_value=None)
     @mock.patch('radical.utils.raise_on')
-    def test_work(self, mocked_init, mocked_raise_on, mocked_handle_unit,
-                  mocked_advance):
+    def test_work(self, mocked_init, mocked_raise_on):
+
+        global_things = []
+        global_state = []
+        # ------------------------------------------------------------------------------
+        #
+        def _advance_side_effect(things, state, publish, push):
+            nonlocal global_things
+            nonlocal global_state
+            global_things.append(things)
+            global_state.append(state)
+
+
+        # ------------------------------------------------------------------------------
+        #
+        def _handle_unit_side_effect(unit, actionables):
+            _advance_side_effect(unit, actionables, False, False)
+
 
         tests = self.setUp()
         component = Default(cfg=None, session=None)
+        component._handle_unit = mock.MagicMock(side_effect=_handle_unit_side_effect)
+        component.advance = mock.MagicMock(side_effect=_advance_side_effect)
         component._log = ru.Logger('dummy')
 
         for test in tests:
-            staging_units, no_staging_units = component._work([test[0]])
-            self.assertEqual(staging_units, test[1][0])
-            self.assertEqual(no_staging_units, test[1][1])
+            global_things = []
+            global_state = []
+            component._work([test[0]])
+            self.assertEqual(global_things, test[1][0])
+            self.assertEqual(global_state, test[1][1])

--- a/tests/test_agent_stagein/test_default.py
+++ b/tests/test_agent_stagein/test_default.py
@@ -1,0 +1,49 @@
+# pylint: disable=protected-access, unused-argument
+import os
+import glob
+import radical.utils as ru
+from radical.pilot.agent.staging_input.default import Default
+from unittest import TestCase, mock
+
+os.environ['RP_UNIT_TESTING'] = 'TRUE'
+
+
+class TestDefault(TestCase):
+
+    # ------------------------------------------------------------------------------
+    # 
+    def setUp(self):
+        ret = list()
+        for fin in glob.glob('tests/test_agent_stagein/test_cases/unit.*.json'):
+            tc     = ru.read_json(fin)
+            unit   = tc['unit'   ]
+            result = tc['results']
+            if result:
+                ret.append([unit, result])
+
+        return ret
+
+
+    # ------------------------------------------------------------------------------
+    #
+    def tearDown(self):
+
+        pass
+
+    # --------------------------------------------------------------------------
+    #
+    @mock.patch.object(Default, '__init__',   return_value=None)
+    @mock.patch.object(Default, '_handle_unit', return_value=None)
+    @mock.patch.object(Default, 'advance', return_value=None)
+    @mock.patch('radical.utils.raise_on')
+    def test_work(self, mocked_init, mocked_raise_on, mocked_handle_unit,
+                  mocked_advance):
+
+        tests = self.setUp()
+        component = Default(cfg=None, session=None)
+        component._log = ru.Logger('dummy')
+
+        for test in tests:
+            staging_units, no_staging_units = component._work([test[0]])
+            self.assertEqual(staging_units, test[1][0])
+            self.assertEqual(no_staging_units, test[1][1])


### PR DESCRIPTION
This PR includes a test for the agent's stage in component. It also show how a unit test looks like based on the guidelines introduced in #2126.

Thank you
Giannis

From @mtitov:

I have general comments yet (about test modules organization):

Should we have methods setUp and tearDown in a separate module as part of BaseTest class (that would be inherited by actual test classes)? (even we have just one module default here, that would be a one approach across other components). And then each test class can redefine these methods, but they still should be called inside with super func
Should we test public methods at the first place? test work instead of _work. I mean both works, but the primary focus better be on public methods