### PR TITLE
Reconcile Session.close() docstring

### DIFF
--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -226,7 +226,7 @@ class Session(rs.Session):
         '''
 
         Closes the session.  All subsequent attempts access objects attached to
-        the session will result in an error. If cleanup is set to True (default)
+        the session will result in an error. If cleanup is set to True,
         the session data is removed from the database.
 
         **Arguments:**


### PR DESCRIPTION
The default behavior of Session.close() changed in c8ea920178884b3394518ff0402b8b9dafdbe39d but the docstring was not updated.