### PR TITLE
Minor resource config typos.

### DIFF
--- a/examples/misc/task_overlay.py
+++ b/examples/misc/task_overlay.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
 
     session = rp.Session()
     try:
-        pd = {'resource'   : 'local.debug',
+        pd = {'resource'   : 'local.localhost',
               'cores'      : 128,
               'runtime'    : 60}
 

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -648,7 +648,7 @@ class Session(rs.Session):
             raise RuntimeError("Resource domain '%s' is unknown." % domain)
 
         if host not in self._rcfgs[domain]:
-            raise RuntimeError("Resource host '%s' ununknown." % host)
+            raise RuntimeError("Resource host '%s' unknown." % host)
 
         resource_cfg = copy.deepcopy(self._rcfgs[domain][host])
 


### PR DESCRIPTION
Update resource name in task_overlay.py example.

Fix typo in error message.