### PR TITLE
Hotfix/mpiexec hosts

### DIFF
--- a/src/radical/pilot/agent/launch_method/mpiexec.py
+++ b/src/radical/pilot/agent/launch_method/mpiexec.py
@@ -88,7 +88,7 @@ class MPIExec(LaunchMethod):
         # For smaller node sets, we construct command line parameters as
         # clusters of nodes with the same number of processes, like this:
         #
-        #   -H node_name_1,node_name_2 -np 8 : -H node_name_3 -np 4 : ...
+        #   -host node_name_1,node_name_2 -n 8 : -host node_name_3 -n 4 : ...
         #
         # POSIX defines a min argument limit of 4096 bytes, so we try to
         # construct a command line, and switch to hostfile if that limit is
@@ -103,7 +103,7 @@ class MPIExec(LaunchMethod):
         # cluster hosts by number of slots
         host_string = ''
         for node,nslots in list(host_slots.items()):
-            host_string += '-H %s -np %s ' % (','.join([node] * nslots), nslots)
+            host_string += '-host %s -n %s ' % (','.join([node] * nslots), nslots)
         command = command_stub % host_string
 
         if len(command) > arg_max:

--- a/tests/test_cases/unit.000000.json
+++ b/tests/test_cases/unit.000000.json
@@ -49,7 +49,7 @@
             "rsh"     : "ValueError",
             "ccmrun"  : ["ccmrun -n 1 /bin/sleep ",null],
             "jsrun"   : ["jsrun --erf_input rs_layout_cu_000000   /bin/sleep",null],
-            "mpiexec" : ["mpiexec -H node1 -np 1   /bin/sleep",null],
+            "mpiexec" : ["mpiexec -host node1 -n 1   /bin/sleep",null],
             "prte"    : ["prun --hnp \"dvm_uri\"  -np 1 --cpus-per-proc 1 --bind-to hwthread:overload-allowed --use-hwthread-cpus --oversubscribe --pmca ptl_base_max_msg_size 1073741824 -host node1  -x \"LD_LIBRARY_PATH\" -x \"PATH\" -x \"PYTHONPATH\" -x \"OMP_NUM_THREADS\" -x \"CUDA_VISIBLE_DEVICES\" -x \"RP_AGENT_ID\" -x \"RP_GTOD\" -x \"RP_PILOT_ID\" -x \"RP_PILOT_STAGING\" -x \"RP_PROF\" -x \"RP_SESSION_ID\" -x \"RP_SPAWNER_ID\" -x \"RP_TMP\" -x \"RP_UNIT_ID\" -x \"RP_UNIT_NAME\"  /bin/sleep", null]
         },
         "resource_file": {

--- a/tests/test_cases/unit.000003.json
+++ b/tests/test_cases/unit.000003.json
@@ -43,7 +43,7 @@
             "rsh"     : ["/bin/sleep \"10\" ","rsh node1 LD_LIBRARY_PATH=/usr/local/lib/ PATH=test_path 1"],
             "spark"   : "RuntimeError",
             "jsrun"   : ["jsrun --erf_input rs_layout_cu_000003   /bin/sleep \"10\" ",null],
-            "mpiexec" : ["mpiexec -H node1 -np 1   /bin/sleep \"10\" ", null]
+            "mpiexec" : ["mpiexec -host node1 -n 1   /bin/sleep \"10\" ", null]
         },
         "resource_file": {
             "jsrun" : ["cpu_index_using: physical\n","rank: 0: { host: node1; cpu: {0,1,2,3}}\n"]

--- a/tests/test_cases/unit.000005.json
+++ b/tests/test_cases/unit.000005.json
@@ -45,7 +45,7 @@
             "ibrun"   : ["ibrun -n 1 -o 0 /bin/sleep \"10\" ", null],
             "ssh"     : ["/bin/sleep \"10\" ","ssh node1 LD_LIBRARY_PATH=/usr/local/lib/ PATH=test_path 1"],
             "jsrun"   : ["jsrun --erf_input rs_layout_cu_000005 --smpiargs=\"-gpu\"  /bin/sleep \"10\" ", null],
-            "mpiexec" : ["mpiexec -H node1 -np 1   /bin/sleep \"10\" ", null],
+            "mpiexec" : ["mpiexec -host node1 -n 1   /bin/sleep \"10\" ", null],
             "prte"    : ["prun --hnp \"dvm_uri\"  -np 1 --cpus-per-proc 1 --bind-to hwthread:overload-allowed --use-hwthread-cpus --oversubscribe --pmca ptl_base_max_msg_size 1073741824 -host node1  -x \"LD_LIBRARY_PATH\" -x \"PATH\" -x \"PYTHONPATH\" -x \"OMP_NUM_THREADS\" -x \"CUDA_VISIBLE_DEVICES\" -x \"RP_AGENT_ID\" -x \"RP_GTOD\" -x \"RP_PILOT_ID\" -x \"RP_PILOT_STAGING\" -x \"RP_PROF\" -x \"RP_SESSION_ID\" -x \"RP_SPAWNER_ID\" -x \"RP_TMP\" -x \"RP_UNIT_ID\" -x \"RP_UNIT_NAME\"  /bin/sleep \"10\" ", null]
         },
         "resource_file": {

--- a/tests/test_cases/unit.000009.json
+++ b/tests/test_cases/unit.000009.json
@@ -39,7 +39,7 @@
 
     "results": {
         "lm": {
-            "mpiexec" : ["mpiexec -H node1 -np 1   /bin/sleep", null]
+            "mpiexec" : ["mpiexec -host node1 -n 1   /bin/sleep", null]
         }
     }
 }


### PR DESCRIPTION
This popped up on Bridges when using the default intel MPI module.  While the old version worked with OpenMPI's `mpiexec`, it is not what's prescribed for `mpiexec` arguments in the standard and thus was not portable.  Using `-host` and `-n` should fix this.