### PR TITLE
fix cache keys for rs urls

### DIFF
--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -207,9 +207,9 @@ class Default(PMGRLaunchingComponent):
             # the directory if it does not yet exist.
 
             # url used for cache (sandbox url w/o path)
-            tmp      = rs.Url(pilot['pilot_sandbox'])
-            tmp.path = '/'
-            key = str(tmp)
+            fs_url      = rs.Url(pilot['pilot_sandbox'])
+            fs_url.path = '/'
+            key         = str(fs_url)
 
             self._log.debug("rs.file.Directory ('%s')", key)
 
@@ -218,7 +218,7 @@ class Default(PMGRLaunchingComponent):
                     fs = self._saga_fs_cache[key]
 
                 else:
-                    fs = rsfs.Directory(key, session=self._session)
+                    fs = rsfs.Directory(fs_url, session=self._session)
                     self._saga_fs_cache[key] = fs
 
             fs.copy(src, tgt, flags=flags)
@@ -279,16 +279,16 @@ class Default(PMGRLaunchingComponent):
                 # Define and open the staging directory for the pilot
 
                 # url used for cache (sandbox url w/o path)
-                tmp      = rs.Url(pilot['pilot_sandbox'])
-                tmp.path = '/'
-                key = str(tmp)
+                fs_url      = rs.Url(pilot['pilot_sandbox'])
+                fs_url.path = '/'
+                key         = str(fs_url)
 
                 with self._cache_lock:
                     if key in self._saga_fs_cache:
                         fs = self._saga_fs_cache[key]
 
                     else:
-                        fs = rsfs.Directory(key, session=self._session)
+                        fs = rsfs.Directory(fs_url, session=self._session)
                         self._saga_fs_cache[key] = fs
 
                 fs.copy(src, tgt, flags=flags)
@@ -748,15 +748,16 @@ class Default(PMGRLaunchingComponent):
 
         fs_endpoint = rcfg['filesystem_endpoint']
         fs_url      = rs.Url(fs_endpoint)
+        key         = str(fs_url)
 
         self._log.debug("rs.file.Directory ('%s')", fs_url)
 
         with self._cache_lock:
-            if fs_url in self._saga_fs_cache:
-                fs = self._saga_fs_cache[fs_url]
+            if key in self._saga_fs_cache:
+                fs = self._saga_fs_cache[key]
             else:
                 fs = rsfs.Directory(fs_url, session=self._session)
-                self._saga_fs_cache[fs_url] = fs
+                self._saga_fs_cache[key] = fs
 
         tar_rem      = rs.Url(fs_url)
         tar_rem.path = "%s/%s" % (session_sandbox, tar_name)
@@ -913,7 +914,6 @@ class Default(PMGRLaunchingComponent):
         virtenv                 = rcfg.get('virtenv',             default_virtenv)
         cores_per_node          = rcfg.get('cores_per_node', 0)
         gpus_per_node           = rcfg.get('gpus_per_node',  0)
-        self._log.debug('=== gpus_per_node 0: %d', gpus_per_node)
         lfs_path_per_node       = rcfg.get('lfs_path_per_node', None)
         lfs_size_per_node       = rcfg.get('lfs_size_per_node',  0)
         python_dist             = rcfg.get('python_dist')
@@ -1135,11 +1135,9 @@ class Default(PMGRLaunchingComponent):
         # if gpus_per_node is set (!= None), then we need to
         # allocation full nodes, and thus round up
         if gpus_per_node:
-            self._log.debug('=== gpus_per_node 1: %d', gpus_per_node)
             gpus_per_node = int(gpus_per_node)
             number_gpus   = int(gpus_per_node *
                             math.ceil(float(number_gpus) / gpus_per_node))
-            self._log.debug('=== gpus_per_node 2: %d', gpus_per_node)
 
         # set mandatory args
         bootstrap_args  = ""

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 
 __copyright__ = "Copyright 2013-2016, http://radical.rutgers.edu"
 __license__   = "MIT"


### PR DESCRIPTION
We cache SAGA dir handles to minimize number of connections to the target resource.  The key used for those caches was based on URL instances, not on URL strings, which lead to repeated cache misses (instances are unique).  This PR fixes that issue (and removes some debug prints).