### PR TITLE
Support job name

### DIFF
--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -334,8 +334,6 @@ class Default(PMGRLaunchingComponent):
         with self._pilots_lock, self._check_lock:
 
             for pid in self._checking:
-                
-                self._log.debug('GIANNIS: %s %s', pid,self._pilots[pid]['job'])
                 tc.add(self._pilots[pid]['job'])
 
         states = tc.get_states()
@@ -570,6 +568,7 @@ class Default(PMGRLaunchingComponent):
 
     # --------------------------------------------------------------------------
     #
+    # pylint: disable=undefined-loop-variable
     def _start_pilot_bulk(self, resource, schema, pilots):
         """
         For each pilot, we prepare by determining what files need to be staged,
@@ -879,6 +878,7 @@ class Default(PMGRLaunchingComponent):
 
     # --------------------------------------------------------------------------
     #
+    # pylint: enable=undefined-loop-variable
     def _prepare_pilot(self, resource, rcfg, pilot, expand):
 
         pid = pilot["uid"]

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -567,7 +567,8 @@ class Default(PMGRLaunchingComponent):
 
 
     # --------------------------------------------------------------------------
-    #    def _start_pilot_bulk(self, resource, schema, pilots):
+    #
+    def _start_pilot_bulk(self, resource, schema, pilots):
         """
         For each pilot, we prepare by determining what files need to be staged,
         and what job description needs to be submitted.

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -567,9 +567,7 @@ class Default(PMGRLaunchingComponent):
 
 
     # --------------------------------------------------------------------------
-    #
-    # pylint: disable=undefined-loop-variable
-    def _start_pilot_bulk(self, resource, schema, pilots):
+    #    def _start_pilot_bulk(self, resource, schema, pilots):
         """
         For each pilot, we prepare by determining what files need to be staged,
         and what job description needs to be submitted.
@@ -854,7 +852,7 @@ class Default(PMGRLaunchingComponent):
                     break
 
             assert(pilot)
-            pid = p['uid']
+            pid = pilot['uid']
 
             # Update the Pilot's state to 'PMGR_ACTIVE_PENDING' if SAGA job
             # submission was successful.  Since the pilot leaves the scope of
@@ -878,7 +876,6 @@ class Default(PMGRLaunchingComponent):
 
     # --------------------------------------------------------------------------
     #
-    # pylint: enable=undefined-loop-variable
     def _prepare_pilot(self, resource, rcfg, pilot, expand):
 
         pid = pilot["uid"]

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -330,12 +330,12 @@ class Default(PMGRLaunchingComponent):
         # we don't want to lock our members all the time.  For that reason we
         # use a copy of the pilots_tocheck list and iterate over that, and only
         # lock other members when they are manipulated.
-
         tc = rs.job.Container()
         with self._pilots_lock, self._check_lock:
 
             for pid in self._checking:
-
+                
+                self._log.debug('GIANNIS: %s %s', pid,self._pilots[pid]['job'])
                 tc.add(self._pilots[pid]['job'])
 
         states = tc.get_states()
@@ -354,7 +354,7 @@ class Default(PMGRLaunchingComponent):
             for pid in self._checking:
 
                 state = self._pilots[pid]['job'].state
-                self._log.debug('saga job state: %s %s', pid, state)
+                self._log.debug('saga job state: %s %s %s', pid, self._pilots[pid]['job'],  state)
 
                 if state in [rs.job.DONE, rs.job.FAILED, rs.job.CANCELED]:
                     pilot = self._pilots[pid]['pilot']
@@ -835,13 +835,20 @@ class Default(PMGRLaunchingComponent):
                 raise RuntimeError("SAGA Job state is FAILED. (%s)" % jd.name)
 
             pilot = None
-            pid   = jd.name
+            # pid   = jd.name
             for p in pilots:
-                if p['uid'] == pid:
+                if p['uid'] in self._pilots:
+                    continue
+                if p['description']['job_name']:
+                    p_name = p['description']['job_name']
+                else:
+                    p_name = p['uid']
+                if p_name == jd.name:
                     pilot = p
                     break
 
             assert(pilot)
+            pid = p['uid']
 
             # Update the Pilot's state to 'PMGR_ACTIVE_PENDING' if SAGA job
             # submission was successful.  Since the pilot leaves the scope of

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -835,14 +835,21 @@ class Default(PMGRLaunchingComponent):
                 raise RuntimeError("SAGA Job state is FAILED. (%s)" % jd.name)
 
             pilot = None
-            # pid   = jd.name
+
             for p in pilots:
+                # we do not force unique job_names and multiple pilots may have
+                # the same job_name. By checking if p['uid'] is in PMGR pilots
+                # we ensure that each pilot is checked only once.
                 if p['uid'] in self._pilots:
                     continue
+
+                # SAGA job name is equal to a pilot's job_name if it exists
+                # otherwise the pilot's uid. Pick job_name if it exists
                 if p['description']['job_name']:
                     p_name = p['description']['job_name']
                 else:
                     p_name = p['uid']
+
                 if p_name == jd.name:
                     pilot = p
                     break


### PR DESCRIPTION
This PR makes sure that the pilot manager gets the correct information when launching pilots that have the `job_name` attribute set. It also takes into account that multiple pilots have the same `job_name`.

It closes #2248.