### PR TITLE
Empty env var NODE_LFS_PATH

### DIFF
--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -840,9 +840,9 @@ class AgentSchedulingComponent(rpu.Component):
         self._change_slot_states(slots, rpc.BUSY)
         unit['slots'] = slots
 
-        env_dict = unit['description'].get('environment', {})
-        env_dict['NODE_LFS_PATH'] = slots['lfs_per_node']['path']
-        unit['description']['environment'] = env_dict
+        if slots['lfs_per_node']['path']:
+            unit['description']['environment']['NODE_LFS_PATH'] = \
+                slots['lfs_per_node']['path']
 
         self._handle_cuda(unit)
 

--- a/tests/test_scheduler/test_unit/test_base.py
+++ b/tests/test_scheduler/test_unit/test_base.py
@@ -78,12 +78,8 @@ class TestBase(TestCase):
             self.assertEqual(unit['slots'], result['slots'])
 
             # test environment variable(s)
-            if 'NODE_LFS_PATH' not in result['description']['environment']:
-                self.assertNotIn('NODE_LFS_PATH',
-                                 unit['description']['environment'])
-            else:
-                self.assertEqual(unit['description']['environment'],
-                                 result['description']['environment'])
+            self.assertEqual(unit['description']['environment'],
+                             result['description']['environment'])
 
 
     # ------------------------------------------------------------------------------

--- a/tests/test_scheduler/test_unit/test_base.py
+++ b/tests/test_scheduler/test_unit/test_base.py
@@ -51,20 +51,9 @@ class TestBase(TestCase):
     #
     @mock.patch.object(AgentSchedulingComponent, '__init__', return_value=None)
     @mock.patch.object(AgentSchedulingComponent, '_handle_cuda', return_value=True)
-    @mock.patch.object(AgentSchedulingComponent, 'schedule_unit',
-                       return_value={"cores_per_node": 16,
-                                     "lfs_per_node": {"size": 0, "path": "/dev/null"},
-                                     "nodes": [{"lfs": {"path": "/dev/null", "size": 0},
-                                                "core_map": [[0]],
-                                                "name": "a",
-                                                "gpu_map": None,
-                                                "uid": 1,"mem": None}],
-                                     "lm_info": "INFO",
-                                     "gpus_per_node": 6,
-                                     })
     @mock.patch.object(AgentSchedulingComponent, '_change_slot_states',
                        return_value=True)
-    def test_try_allocation(self, mocked_init, mocked_schedule_unit, mocked_handle_cuda,
+    def test_try_allocation(self, mocked_init, mocked_handle_cuda,
                             mocked_change_slot_states):
 
         component = AgentSchedulingComponent()
@@ -75,18 +64,25 @@ class TestBase(TestCase):
         component._wait_pool = list()
         component._wait_lock = threading.RLock()
         component._slot_lock = threading.RLock()
-        unit = {'description':{'note':'this is a unit'}, 'uid': 'test'}
-        component._try_allocation(unit=unit)
-        self.assertEqual(unit['slots'], {"cores_per_node": 16,
-                                 "lfs_per_node": {"size": 0, "path": "/dev/null"},
-                                 "nodes": [{"lfs": {"path": "/dev/null", "size": 0},
-                                            "core_map": [[0]],
-                                            "name": "a",
-                                            "gpu_map": None,
-                                            "uid": 1,"mem": None}],
-                                 "lm_info": "INFO",
-                                 "gpus_per_node": 6,
-                                 })
+
+        tests = self.setUp()['try_allocation']
+        for input_data, result in zip(tests['setup'], tests['results']):
+            component.schedule_unit = mock.Mock(
+                return_value=input_data['scheduled_unit_slots'])
+
+            unit = input_data['unit']
+            component._try_allocation(unit=unit)
+
+            # test unit's slots
+            self.assertEqual(unit['slots'], result['slots'])
+
+            # test environment variable(s)
+            if 'NODE_LFS_PATH' not in result['description']['environment']:
+                self.assertNotIn('NODE_LFS_PATH',
+                                 unit['description']['environment'])
+            else:
+                self.assertEqual(unit['description']['environment'],
+                                 result['description']['environment'])
 
 
     # ------------------------------------------------------------------------------

--- a/tests/test_scheduler/test_unit/test_cases/test_base.json
+++ b/tests/test_scheduler/test_unit/test_cases/test_base.json
@@ -86,7 +86,82 @@
                                "RuntimeError"
                               ]
                    },
-    "try_allocation":{},
+    "try_allocation":{
+        "setup": [
+            {
+                "unit": {"uid": "unit.000000",
+                         "description": {"executable": "/bin/sleep",
+                                         "environment": {}}},
+                "scheduled_unit_slots": {"cores_per_node": 16,
+                                         "lfs_per_node": {"size": 0,
+                                                          "path": "/dev/null"},
+                                         "nodes": [
+                                             {"lfs": {"path": "/dev/null",
+                                                      "size": 0},
+                                              "core_map": [[0]],
+                                              "name": "a",
+                                              "gpu_map": null,
+                                              "uid": 1,
+                                              "mem": null}
+                                         ],
+                                         "lm_info": "INFO",
+                                         "gpus_per_node": 6
+                                     }
+            },
+            {
+                "unit": {"uid": "unit.000001",
+                         "description": {"executable": "/bin/sleep",
+                                         "environment": {}}},
+                "scheduled_unit_slots": {"cores_per_node": 16,
+                                         "lfs_per_node": {"size": 0,
+                                                          "path": null},
+                                         "nodes": [
+                                             {"lfs": {"path": null,
+                                                      "size": 0},
+                                              "core_map": [[0]],
+                                              "name": "a",
+                                              "gpu_map": null,
+                                              "uid": 1,
+                                              "mem": null}
+                                         ],
+                                         "lm_info": "INFO",
+                                         "gpus_per_node": 6
+                                     }
+            }
+        ],
+        "results": [
+            {
+                "description": {"environment": {"NODE_LFS_PATH": "/dev/null"},
+                                "executable": "/bin/sleep"},
+                "slots": {"cores_per_node": 16,
+                          "gpus_per_node": 6,
+                          "lfs_per_node": {"path": "/dev/null", "size": 0},
+                          "lm_info": "INFO",
+                          "nodes": [{"core_map": [[0]],
+                                     "gpu_map": null,
+                                     "lfs": {"path": "/dev/null", "size": 0},
+                                     "mem": null,
+                                     "name": "a",
+                                     "uid": 1}]},
+                "uid": "unit.000000"
+            },
+            {
+                "description": {"environment": {},
+                                "executable": "/bin/sleep"},
+                "slots": {"cores_per_node": 16,
+                          "gpus_per_node": 6,
+                          "lfs_per_node": {"path": null, "size": 0},
+                          "lm_info": "INFO",
+                          "nodes": [{"core_map": [[0]],
+                                     "gpu_map": null,
+                                     "lfs": {"path": null, "size": 0},
+                                     "mem": null,
+                                     "name": "a",
+                                     "uid": 1}]},
+                "uid": "unit.000001"
+            }
+        ]
+    },
     "handle_cuda": {"setup": [{"rm_info":{"lm_info":{}}},
                               {"rm_info":{"lm_info":{}}},
                               {"rm_info":{"lm_info":{"cvd_id_mode":"physical"}}},


### PR DESCRIPTION
If task description has `None` value in `path` for `lfs_per_node` (e.g., `unit.000000.sl` has the following `'lfs_per_node': {'path': None, 'size': 0},`) and then exec script has the following line `export "NODE_LFS_PATH=None"`. Thus `NODE_LFS_PATH` should be set only if there is a path