### PR TITLE
Introduce safe branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ dist:     xenial
 git:
   depth: 1
 
+# safelist
+branches:
+  only:
+  - devel
+
 env:
   global:
     - CODECOV_TOKEN="c7e0d993-d31a-4d39-8ffa-07c30ea73e48"


### PR DESCRIPTION
This PR introduces what is called safelist. The safe list is a set of branches that travis will build as soon as there is a push. This will help  us have the correct coverage diff from codecov.

The change was triggered by PR #2255. The PR introduces a test for the change it makes, but codecov still shows negative delta in coverage, where it should be 0 change or minimal positive change. 

Thank you!