### PR TITLE
Remove TMPDIR setup for pip installation

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -1269,10 +1269,6 @@ rp_install()
   #     fi
   # fi
 
-    OLD_TMPDIR="$TMPDIR"
-    export TMPDIR="$PILOT_SANDBOX/rp_install/build"
-    mkdir $TMPDIR
-
     pip_flags="$pip_flags --src '$PILOT_SANDBOX/rp_install/src'"
     pip_flags="$pip_flags --prefix '$RP_INSTALL'"
     pip_flags="$pip_flags --no-deps --no-cache-dir --no-build-isolation"
@@ -1294,9 +1290,6 @@ rp_install()
             rm -r "$src"
         fi
     done
-
-    rm -rf "$TMPDIR"
-    export TMPDIR="$OLD_TMPDIR"
 
     profile_event 'rp_install_stop'
 }


### PR DESCRIPTION
Related to EnTK ticket [#515](https://github.com/radical-cybertools/radical.entk/issues/515)

p.s. just for records: option `--build` was introduced [here](https://github.com/radical-cybertools/radical.pilot/commit/951adf520397033224688a2ccd0e66f44e06edfd#diff-56c4dddccccd0fff0a9907f6d9a54b6aed2124a4724e38f49295e3e79d962e2a), I would think as a standard approach for py2