### PR TITLE
fix bootstrapper timestamps and resource details

### DIFF
--- a/src/radical/pilot/agent/agent_0.py
+++ b/src/radical/pilot/agent/agent_0.py
@@ -56,7 +56,6 @@ class Agent_0(rpu.Worker):
 
         # this is the earliest point to sync bootstrap and agent profiles
         prof = ru.Profiler(ns='radical.pilot', name='agent.0')
-        prof.prof('sync_rel', uid=cfg.pid, msg='agent.0')
         prof.prof('hostname', uid=cfg.pid, msg=ru.get_hostname())
 
         # connect to MongoDB for state push/pull

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -3,6 +3,8 @@
 # Unset functions/aliases of commands that will be used during bootstrap as
 # these custom functions can break assumed/expected behavior
 export PS1='#'
+export LC_NUMERIC="en_US.UTF-8"
+
 unset PROMPT_COMMAND
 unset -f cd ls uname pwd date bc cat echo grep
 
@@ -200,6 +202,7 @@ create_gtod()
         test -x '/bin/bash' && shell=/bin/bash
 
         echo "#!$SHELL"                                > ./gtod
+        echo "export LC_NUMERIC=en_US.UTF-8"          >> ./gtod
         echo "if test -z \"\$EPOCHREALTIME\""         >> ./gtod
         echo "then"                                   >> ./gtod
         echo "  awk 'BEGIN {srand(); print srand()}'" >> ./gtod
@@ -210,8 +213,20 @@ create_gtod()
 
     chmod 0755 ./gtod
 
-    TIME_ZERO=`./gtod`
-    export TIME_ZERO
+    # initialize profile
+    PROFILE="bootstrap_0.prof"
+    now=$(./gtod)
+    echo "#time,name,uid,state,event,msg" > "$PROFILE"
+
+    ip=$(ip addr \
+         | grep 'state UP' -A2 \
+         | grep 'inet' \
+         | awk '{print $2}' \
+         | cut -f1 -d'/')
+    printf "%.4f,%s,%s,%s,%s,%s,%s\n" \
+        "$now" "sync_abs" "bootstrap_0" "MainThread" "$PILOT_ID" \
+        "PMGR_ACTIVE_PENDING" "$(hostname):$ip:$now:$now:$now" \
+        | tee -a "$PROFILE"
 }
 
 
@@ -228,15 +243,7 @@ profile_event()
 
     event=$1
     msg=$2
-
-    epoch=`./gtod`
-    now=$(awk "BEGIN{print($epoch - $TIME_ZERO)}")
-
-    if ! test -f "$PROFILE"
-    then
-        # initialize profile
-        echo "#time,name,uid,state,event,msg" > "$PROFILE"
-    fi
+    now=$(./gtod)
 
     # TIME   = 0  # time of event (float, seconds since epoch)  mandatory
     # EVENT  = 1  # event ID (string)                           mandatory
@@ -1869,7 +1876,7 @@ fi
 create_deactivate
 
 # start the master agent instance (zero)
-profile_event 'sync_rel' 'agent.0'
+profile_event 'bootstrap_0_ok'
 if test -z "$CCM"; then
     ./bootstrap_2.sh 'agent.0'    \
                    1> agent.0.bootstrap_2.out \

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -3,7 +3,7 @@
 # Unset functions/aliases of commands that will be used during bootstrap as
 # these custom functions can break assumed/expected behavior
 export PS1='#'
-export LC_NUMERIC="en_US.UTF-8"
+export LC_NUMERIC="C"
 
 unset PROMPT_COMMAND
 unset -f cd ls uname pwd date bc cat echo grep
@@ -202,7 +202,7 @@ create_gtod()
         test -x '/bin/bash' && shell=/bin/bash
 
         echo "#!$SHELL"                                > ./gtod
-        echo "export LC_NUMERIC=en_US.UTF-8"          >> ./gtod
+        echo "export LC_NUMERIC=C"                    >> ./gtod
         echo "if test -z \"\$EPOCHREALTIME\""         >> ./gtod
         echo "then"                                   >> ./gtod
         echo "  awk 'BEGIN {srand(); print srand()}'" >> ./gtod

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -216,7 +216,7 @@ create_gtod()
     # initialize profile
     PROFILE="bootstrap_0.prof"
     now=$(./gtod)
-    echo "#time,name,uid,state,event,msg" > "$PROFILE"
+    echo "#time,event,comp,thread,uid,state,msg" > "$PROFILE"
 
     ip=$(ip addr \
          | grep 'state UP' -A2 \

--- a/src/radical/pilot/compute_pilot.py
+++ b/src/radical/pilot/compute_pilot.py
@@ -254,7 +254,7 @@ class ComputePilot(object):
                'js_url':           str(self._pilot_jsurl),
                'js_hop':           str(self._pilot_jshop),
                'description':      self.description,  # this is a deep copy
-               'resource_details': self.resource_details
+             # 'resource_details': self.resource_details
               }
 
         return ret

--- a/src/radical/pilot/utils/prof_utils.py
+++ b/src/radical/pilot/utils/prof_utils.py
@@ -35,8 +35,8 @@ PILOT_DURATIONS = {
     # or the pilot is starving for workload.
     'consume' : {
         'boot'      : [{ru.EVENT: 'bootstrap_0_start'},
-                       {ru.EVENT: 'sync_rel'         }],
-        'setup_1'   : [{ru.EVENT: 'sync_rel'         },
+                       {ru.EVENT: 'bootstrap_0_ok'   }],
+        'setup_1'   : [{ru.EVENT: 'bootstrap_0_ok'   },
                        {ru.STATE: s.PMGR_ACTIVE      }],
         'ignore'    : [{ru.STATE: s.PMGR_ACTIVE      },
                        {ru.EVENT: 'cmd'              ,


### PR DESCRIPTION
Somewhere on the way, we lost the alignment of bootstrapper timestamps
in certain conditions.  This hotfix provides:

  - recording of timestamps independent of locale (LC_NUMERIC)
  - time alignment with `sync_abs` (previous `sync_rel`)

The PR also has a small fix which avoids overwriting of resource details
in some cases.