### PR TITLE
Keep default cfg without sub-agent

### DIFF
--- a/src/radical/pilot/configs/agent_default.json
+++ b/src/radical/pilot/configs/agent_default.json
@@ -82,15 +82,6 @@
         "agent_scheduling"     : {"count" : 1},
         "agent_executing"      : {"count" : 1},
         "agent_staging_output" : {"count" : 1}
-    },
-
-    "agents": {
-        "agent.1": {
-            "target": "node",
-            "components": {
-                "agent_executing" : {"count" : 1}
-            }
-        }
     }
 }
 


### PR DESCRIPTION
In case having sub-agent (for executing component) in default agent config was not intentionally, otherwise this PR should be cancelled.

p.s. sub-agent will reserve 1 node, which could be implicit for the user