### PR TITLE
avoid a termination race

### DIFF
--- a/src/radical/pilot/tmgr/scheduler/base.py
+++ b/src/radical/pilot/tmgr/scheduler/base.py
@@ -103,8 +103,8 @@ class TMGRSchedulingComponent(rpu.Component):
             impl = impl(cfg, session)
             return impl
 
-        except KeyError:
-            raise ValueError("Scheduler '%s' unknown or defunct" % name)
+        except KeyError as e:
+            raise ValueError("Scheduler '%s' unknown or defunct" % name) from e
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/tmgr/scheduler/base.py
+++ b/src/radical/pilot/tmgr/scheduler/base.py
@@ -308,10 +308,16 @@ class TMGRSchedulingComponent(rpu.Component):
                                 to_cancel[pid] = list()
                             to_cancel[pid].append(uid)
 
+            dbs = self._session._dbs
+
+            if not dbs:
+                # too late, already closing down
+                return True
+
             for pid in to_cancel:
-                self._session._dbs.pilot_command(cmd='cancel_tasks',
-                                                 arg={'uids' : to_cancel[pid]},
-                                                 pids=pid)
+                dbs.pilot_command(cmd='cancel_tasks',
+                                  arg={'uids' : to_cancel[pid]},
+                                  pids=pid)
 
         return True
 


### PR DESCRIPTION
This fixed #2348.  The issue was caused by a termination race in the tmgr scheduler which, as a side effect of an active cancel followed by termination, lead to the tmgr missing out on a state transition.  Fixing the termination race results in proper state transition events.