### PR TITLE
Fix #2347

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ def get_version(_mod_root):
         _path = '%s/%s' % (src_root, _mod_root)
         with open(_path + '/VERSION', 'w') as f:
             f.write(_version_base + '\n')
-            f.write(_version + '\n')
+            f.write(_version      + '\n')
 
         _sdist_name = '%s-%s.tar.gz' % (name, _version_base)
       # _sdist_name = _sdist_name.replace('/', '-')

--- a/setup.py
+++ b/setup.py
@@ -108,11 +108,11 @@ def get_version(_mod_root):
         with open(_path + '/VERSION', 'w') as f:
             f.write(_version + '\n')
 
-        _sdist_name = '%s-%s.tar.gz' % (name, _version)
-        _sdist_name = _sdist_name.replace('/', '-')
-        _sdist_name = _sdist_name.replace('@', '-')
-        _sdist_name = _sdist_name.replace('#', '-')
-        _sdist_name = _sdist_name.replace('_', '-')
+        _sdist_name = '%s-%s.tar.gz' % (name, _version_base)
+      # _sdist_name = _sdist_name.replace('/', '-')
+      # _sdist_name = _sdist_name.replace('@', '-')
+      # _sdist_name = _sdist_name.replace('#', '-')
+      # _sdist_name = _sdist_name.replace('_', '-')
 
         if '--record'    in sys.argv or \
            'bdist_egg'   in sys.argv or \

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ def get_version(_mod_root):
         # make sure the version files exist for the runtime version inspection
         _path = '%s/%s' % (src_root, _mod_root)
         with open(_path + '/VERSION', 'w') as f:
+            f.write(_version_base + '\n')
             f.write(_version + '\n')
 
         _sdist_name = '%s-%s.tar.gz' % (name, _version_base)


### PR DESCRIPTION
This fixes #2347 by enforcing pep-440 versions for sdist and wheels.

This PR replaces #2355 