### PR TITLE
Fixed launch command for PRTE2 LM

### DIFF
--- a/src/radical/pilot/agent/launch_method/prte2.py
+++ b/src/radical/pilot/agent/launch_method/prte2.py
@@ -340,11 +340,8 @@ class PRTE2(LaunchMethod):
         partition_id = slots.get('partition_id') or partitions.keys()[0]
         dvm_uri = '--dvm-uri "%s"' % partitions[partition_id]['dvm_uri']
 
-        if n_threads == 1: map_to_object = 'hwthread'
-        else             : map_to_object = 'node:HWTCPUS'
-
-        flags  = ' --np %d'                         % n_procs
-        flags += ' --map-by %s:PE=%d:OVERSUBSCRIBE' % (map_to_object, n_threads)
+        flags  = ' --np %d'                                   % n_procs
+        flags += ' --map-by node:HWTCPUS:PE=%d:OVERSUBSCRIBE' % n_threads
         flags += ' --bind-to hwthread:overload-allowed'
         if self._verbose:
             flags += ':REPORT'

--- a/tests/unit_tests/test_cases/task.000000.json
+++ b/tests/unit_tests/test_cases/task.000000.json
@@ -54,7 +54,7 @@
             "jsrun"   : ["jsrun --erf_input rs_layout_task_000000   /bin/sleep",null],
             "mpiexec" : ["mpiexec -host node1 -n 1    /bin/sleep",null],
             "prte"    : ["prun --hnp \"dvm_uri\"  -np 1 --cpus-per-proc 1 --bind-to hwthread:overload-allowed --use-hwthread-cpus --oversubscribe --pmca ptl_base_max_msg_size 1073741824 -host node1 --verbose -x \"LD_LIBRARY_PATH\" -x \"PATH\" -x \"PYTHONPATH\" -x \"OMP_NUM_THREADS\" -x \"RP_AGENT_ID\" -x \"RP_GTOD\" -x \"RP_PILOT_ID\" -x \"RP_PILOT_STAGING\" -x \"RP_PROF\" -x \"RP_SESSION_ID\" -x \"RP_SPAWNER_ID\" -x \"RP_TMP\" -x \"RP_TASK_ID\" -x \"RP_TASK_NAME\" -x \"RP_PILOT_SANDBOX\" -x \"RADICAL_BASE\"  /bin/sleep", null],
-            "prte2"   : ["prun --dvm-uri \"dvm_uri\"  --np 1 --map-by hwthread:PE=1:OVERSUBSCRIBE --bind-to hwthread:overload-allowed --host node1:1 --pmixmca ptl_base_max_msg_size 1073741824 --verbose /bin/sleep", null]
+            "prte2"   : ["prun --dvm-uri \"dvm_uri\"  --np 1 --map-by node:HWTCPUS:PE=1:OVERSUBSCRIBE --bind-to hwthread:overload-allowed --host node1:1 --pmixmca ptl_base_max_msg_size 1073741824 --verbose /bin/sleep", null]
         },
         "resource_file": {
             "jsrun" : ["cpu_index_using: physical\n","rank: 0: { host: node1; cpu: {0}}\n"]

--- a/tests/unit_tests/test_cases/task.000005.json
+++ b/tests/unit_tests/test_cases/task.000005.json
@@ -49,7 +49,7 @@
             "jsrun"   : ["jsrun --erf_input rs_layout_task_000005 --smpiargs=\"-gpu\"  /bin/sleep \"10\" ", null],
             "mpiexec" : ["mpiexec -host node1 -n 1    /bin/sleep \"10\" ", null],
             "prte"    : ["prun --hnp \"dvm_uri\"  -np 1 --cpus-per-proc 1 --bind-to hwthread:overload-allowed --use-hwthread-cpus --oversubscribe --pmca ptl_base_max_msg_size 1073741824 -host node1 --verbose -x \"LD_LIBRARY_PATH\" -x \"PATH\" -x \"PYTHONPATH\" -x \"OMP_NUM_THREADS\" -x \"RP_AGENT_ID\" -x \"RP_GTOD\" -x \"RP_PILOT_ID\" -x \"RP_PILOT_STAGING\" -x \"RP_PROF\" -x \"RP_SESSION_ID\" -x \"RP_SPAWNER_ID\" -x \"RP_TMP\" -x \"RP_TASK_ID\" -x \"RP_TASK_NAME\" -x \"RP_PILOT_SANDBOX\" -x \"RADICAL_BASE\" -x \"CUDA_VISIBLE_DEVICES\"  /bin/sleep \"10\" ", null],
-            "prte2"   : ["prun --dvm-uri \"dvm_uri\"  --np 1 --map-by hwthread:PE=1:OVERSUBSCRIBE --bind-to hwthread:overload-allowed --host node1:1 --pmixmca ptl_base_max_msg_size 1073741824 --verbose /bin/sleep \"10\" ", null]
+            "prte2"   : ["prun --dvm-uri \"dvm_uri\"  --np 1 --map-by node:HWTCPUS:PE=1:OVERSUBSCRIBE --bind-to hwthread:overload-allowed --host node1:1 --pmixmca ptl_base_max_msg_size 1073741824 --verbose /bin/sleep \"10\" ", null]
 },
         "resource_file": {
             "jsrun" : ["cpu_index_using: physical\n","rank: 0: { host: node1; cpu: {0}; gpu: {0}}\n"]


### PR DESCRIPTION
With oncoming version of prrte,`prun` command with `--map-by hwthread` is not supported for certain machines* and raises the following error:
```
We cannot bind to hardware threads if we are not treating hardware
threads as independent CPUs since the lowest allocatable unit is
"core" by default. In order to bind to hardware threads, you must
therefore specify that we treat hardware threads as independent CPUs
by adding the "HWTCPUS" modifier to the "--map-by" directive.

The combination "--map-by core:hwtcpus --bind-to hwthread" or
"--map-by :hwtcpus --bind-to hwthread" will result in one process
being placed on each core, with the process bound to the first
hardware thread in that core.

In contrast, a case such as "--map-by package:hwtcpus --bind-to hwthread"
would result in each process being bound to successive hardware threads
on each package.
```
(*) doesn't work for Frontera, but works for Summit

`prun` command with `--map-by node:HWTCPUS` works for both machines