### PR TITLE
Add fixed path to codecov yaml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,3 +11,5 @@ coverage:
 github_checks:
   annotations: false
 
+fixes:
+  - "*/site-packages/radical/pilot/::src/radical/pilot/"


### PR DESCRIPTION
@andre-merzky, can we merge this to devel-branch to check that it will fix codecov report? (if it will not help then I will revert it with the ongoing PR)

Codecov uses yaml file from a _default_ branch ([link](https://docs.codecov.io/docs/codecov-yaml))
> Why does the current repository yaml not match what I have in my repo?
> - The repository-level YAML is not in what Codecov considers the default branch. If the YAML is in a feature branch, you should be able to see it in Current repository yaml section of the /settings/yaml page after merging the feature branch into the default branch. You can identify the default branch in the Default Branch section of the /settings page.