### PR TITLE
executor errors should not affect task bulks

### DIFF
--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -97,7 +97,6 @@ if __name__ == '__main__':
         # Wait for all tasks to reach a final state (DONE, CANCELED or FAILED).
         tmgr.wait_tasks()
 
-
     except Exception as e:
         # Something unexpected happened in the pilot code above
         report.error('caught Exception: %s\n' % e)

--- a/src/radical/pilot/agent/executing/flux.py
+++ b/src/radical/pilot/agent/executing/flux.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-error
 
 __copyright__ = 'Copyright 2013-2020, http://radical.rutgers.edu'
 __license__   = 'MIT'
@@ -183,7 +184,7 @@ class Flux(AgentExecutingComponent) :
 
         for event in events:
 
-            flux_id, flux_state = event
+            flux_state = event[1]  # event: flux_id, flux_state
             state = self._event_map[flux_state]
 
             if state is None:
@@ -246,7 +247,7 @@ class Flux(AgentExecutingComponent) :
                                     if flux_id in events: del(events[flux_id])
                                     if flux_id in tasks : del(tasks[flux_id])
 
-                        except Exception as e:
+                        except Exception:
 
                             self._log.exception("error collecting Task")
                             if task['stderr'] is None:
@@ -268,7 +269,7 @@ class Flux(AgentExecutingComponent) :
 
                     for event in self._event_q.get_nowait():
 
-                        flux_id, flux_event = event
+                        flux_id = event[0]  # event: flux_id, flux_state
 
                         if flux_id in tasks:
 

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -15,7 +15,6 @@ import pprint
 import signal
 import tempfile
 import threading as mt
-import traceback
 import subprocess
 
 import radical.utils as ru
@@ -129,7 +128,7 @@ class Popen(AgentExecutingComponent) :
             try:
                 self._handle_task(task)
 
-            except Exception as e:
+            except Exception:
                 # append the startup error to the tasks stderr.  This is
                 # not completely correct (as this text is not produced
                 # by the task), but it seems the most intuitive way to

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -122,70 +122,68 @@ class Popen(AgentExecutingComponent) :
     #
     def work(self, tasks):
 
-        if not isinstance(tasks, list):
-            tasks = [tasks]
-
         self.advance(tasks, rps.AGENT_EXECUTING, publish=True, push=False)
 
         for task in tasks:
-            self._handle_task(task)
+
+            try:
+                self._handle_task(task)
+
+            except Exception as e:
+                # append the startup error to the tasks stderr.  This is
+                # not completely correct (as this text is not produced
+                # by the task), but it seems the most intuitive way to
+                # communicate that error to the application/user.
+                self._log.exception("error running Task")
+                if task['stderr'] is None:
+                    task['stderr'] = ''
+                task['stderr'] += '\nPilot cannot start task:\n'
+                task['stderr'] += '\n'.join(ru.get_exception_trace())
+
+                # can't rely on the executor base to free the task resources
+                self._prof.prof('unschedule_start', uid=task['uid'])
+                self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
+
+                self.advance(task, rps.FAILED, publish=True, push=False)
 
 
     # --------------------------------------------------------------------------
     #
     def _handle_task(self, task):
 
-        try:
-            descr = task['description']
+        descr = task['description']
 
-            # ensure that the named env exists
-            env = descr.get('named_env')
-            if env:
-                if not os.path.isdir('%s/%s' % (self._pwd, env)):
-                    raise ValueError('invalid named env %s for task %s'
-                                    % (env, task['uid']))
-                pre = ru.as_list(descr.get('pre_exec'))
-                pre.insert(0, '. %s/%s/bin/activate' % (self._pwd, env))
-                pre.insert(0, '. %s/deactivate'      % (self._pwd))
-                descr['pre_exec'] = pre
+        # ensure that the named env exists
+        env = descr.get('named_env')
+        if env:
+            if not os.path.isdir('%s/%s' % (self._pwd, env)):
+                raise ValueError('invalid named env %s for task %s'
+                                % (env, task['uid']))
+            pre = ru.as_list(descr.get('pre_exec'))
+            pre.insert(0, '. %s/%s/bin/activate' % (self._pwd, env))
+            pre.insert(0, '. %s/deactivate'      % (self._pwd))
+            descr['pre_exec'] = pre
 
 
-            # prep stdout/err so that we can append w/o checking for None
-            task['stdout'] = ''
-            task['stderr'] = ''
+        # prep stdout/err so that we can append w/o checking for None
+        task['stdout'] = ''
+        task['stderr'] = ''
 
-            cpt = descr['cpu_process_type']
-          # gpt = descr['gpu_process_type']  # FIXME: use
+        cpt = descr['cpu_process_type']
+      # gpt = descr['gpu_process_type']  # FIXME: use
 
-            # FIXME: this switch is insufficient for mixed tasks (MPI/OpenMP)
-            if cpt == 'MPI': launcher = self._mpi_launcher
-            else           : launcher = self._task_launcher
+        # FIXME: this switch is insufficient for mixed tasks (MPI/OpenMP)
+        if cpt == 'MPI': launcher = self._mpi_launcher
+        else           : launcher = self._task_launcher
 
-            if not launcher:
-                raise RuntimeError("no launcher (process type = %s)" % cpt)
+        if not launcher:
+            raise RuntimeError("no launcher (process type = %s)" % cpt)
 
-            self._log.debug("Launching task with %s (%s).",
-                            launcher.name, launcher.launch_command)
+        self._log.debug("Launching task with %s (%s).",
+                        launcher.name, launcher.launch_command)
 
-            # Start a new subprocess to launch the task
-            self.spawn(launcher=launcher, task=task)
-
-        except Exception as e:
-            # append the startup error to the tasks stderr.  This is
-            # not completely correct (as this text is not produced
-            # by the task), but it seems the most intuitive way to
-            # communicate that error to the application/user.
-            self._log.exception("error running Task")
-            if task.get('stderr') is None:
-                task['stderr'] = ''
-            task['stderr'] += "\nPilot cannot start task:\n%s\n%s" \
-                            % (str(e), traceback.format_exc())
-
-            # Free the Slots, Flee the Flots, Ree the Frots!
-            self._prof.prof('unschedule_start', uid=task['uid'])
-            self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
-
-            self.advance(task, rps.FAILED, publish=True, push=False)
+        # Start a new subprocess to launch the task
+        self.spawn(launcher=launcher, task=task)
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/executing/shell.py
+++ b/src/radical/pilot/agent/executing/shell.py
@@ -186,7 +186,7 @@ class Shell(AgentExecutingComponent):
             try:
                 self._handle_task(task)
 
-            except Exception as e:
+            except Exception:
                 # append the startup error to the tasks stderr.  This is
                 # not completely correct (as this text is not produced
                 # by the task), but it seems the most intuitive way to

--- a/src/radical/pilot/agent/executing/shell.py
+++ b/src/radical/pilot/agent/executing/shell.py
@@ -179,14 +179,29 @@ class Shell(AgentExecutingComponent):
     #
     def work(self, tasks):
 
-        if not isinstance(tasks, list):
-            tasks = [tasks]
-
         self.advance(tasks, rps.AGENT_EXECUTING, publish=True, push=False)
 
         for task in tasks:
 
-            self._handle_task(task)
+            try:
+                self._handle_task(task)
+
+            except Exception as e:
+                # append the startup error to the tasks stderr.  This is
+                # not completely correct (as this text is not produced
+                # by the task), but it seems the most intuitive way to
+                # communicate that error to the application/user.
+                self._log.exception("error running Task")
+                if task['stderr'] is None:
+                    task['stderr'] = ''
+                task['stderr'] += '\nPilot cannot start task:\n'
+                task['stderr'] += '\n'.join(ru.get_exception_trace())
+
+                # can't rely on the executor base to free the task resources
+                self._prof.prof('unschedule_start', uid=task['uid'])
+                self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
+
+                self.advance(task, rps.FAILED, publish=True, push=False)
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/executing/sleep.py
+++ b/src/radical/pilot/agent/executing/sleep.py
@@ -63,26 +63,49 @@ class Sleep(AgentExecutingComponent) :
     #
     def work(self, tasks):
 
-        if not isinstance(tasks, list):
-            tasks = [tasks]
-
         self.advance(tasks, rps.AGENT_EXECUTING, publish=True, push=False)
 
-        now = time.time()
-        for t in tasks:
-          # assert(t['description']['executable'].endswith('sleep'))
-            t['to_finish'] = now + float(t['description']['arguments'][0])
+        for task in tasks:
 
-        for t in tasks:
-            uid = t['uid']
-            self._prof.prof('exec_start',      uid=uid)
-            self._prof.prof('exec_ok',         uid=uid)
-            self._prof.prof('task_start',      uid=uid)
-            self._prof.prof('task_exec_start', uid=uid)
-            self._prof.prof('app_start',       uid=uid)
+            try:
+                self._handle_task(task)
+
+            except Exception as e:
+                # append the startup error to the tasks stderr.  This is
+                # not completely correct (as this text is not produced
+                # by the task), but it seems the most intuitive way to
+                # communicate that error to the application/user.
+                self._log.exception("error running Task")
+                if task['stderr'] is None:
+                    task['stderr'] = ''
+                task['stderr'] += '\nPilot cannot start task:\n'
+                task['stderr'] += '\n'.join(ru.get_exception_trace())
+
+                # can't rely on the executor base to free the task resources
+                self._prof.prof('unschedule_start', uid=task['uid'])
+                self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
+
+                self.advance(task, rps.FAILED, publish=True, push=False)
 
         with self._tasks_lock:
             self._tasks.extend(tasks)
+
+
+    # --------------------------------------------------------------------------
+    #
+    def _handle_task(self, task):
+
+        now = time.time()
+
+        # assert(t['description']['executable'].endswith('sleep'))
+        task['to_finish'] = now + float(task['description']['arguments'][0])
+
+        uid = task['uid']
+        self._prof.prof('exec_start',      uid=uid)
+        self._prof.prof('exec_ok',         uid=uid)
+        self._prof.prof('task_start',      uid=uid)
+        self._prof.prof('task_exec_start', uid=uid)
+        self._prof.prof('app_start',       uid=uid)
 
 
     # --------------------------------------------------------------------------
@@ -98,15 +121,18 @@ class Sleep(AgentExecutingComponent) :
                 to_finish   = [t for t in self._tasks if t['to_finish'] <= now]
                 self._tasks = [t for t in self._tasks if t['to_finish'] >  now]
 
-            for t in to_finish:
-                uid = t['uid']
-                t['target_state'] = 'DONE'
+            for task in to_finish:
+                uid = task['uid']
+                task['target_state'] = 'DONE'
                 self._prof.prof('app_stop',         uid=uid)
                 self._prof.prof('task_exec_stop',   uid=uid)
                 self._prof.prof('task_stop',        uid=uid)
                 self._prof.prof('exec_stop',        uid=uid)
                 self._prof.prof('unschedule_start', uid=uid)
-                self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, t)
+                self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
+
+            self._prof.prof('unschedule_start', uid=task['uid'])
+            self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
 
             self.advance(to_finish, rps.AGENT_STAGING_OUTPUT_PENDING,
                                     publish=True, push=True)

--- a/src/radical/pilot/agent/executing/sleep.py
+++ b/src/radical/pilot/agent/executing/sleep.py
@@ -70,7 +70,7 @@ class Sleep(AgentExecutingComponent) :
             try:
                 self._handle_task(task)
 
-            except Exception as e:
+            except Exception:
                 # append the startup error to the tasks stderr.  This is
                 # not completely correct (as this text is not produced
                 # by the task), but it seems the most intuitive way to
@@ -130,9 +130,6 @@ class Sleep(AgentExecutingComponent) :
                 self._prof.prof('exec_stop',        uid=uid)
                 self._prof.prof('unschedule_start', uid=uid)
                 self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
-
-            self._prof.prof('unschedule_start', uid=task['uid'])
-            self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
 
             self.advance(to_finish, rps.AGENT_STAGING_OUTPUT_PENDING,
                                     publish=True, push=True)

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -516,9 +516,6 @@ class AgentSchedulingComponent(rpu.Component):
         process (self._schedule_tasks).
         '''
 
-        # unify handling of bulks / non-bulks
-        tasks = ru.as_list(tasks)
-
         # advance state, publish state change, and push to scheduler process
         self.advance(tasks, rps.AGENT_SCHEDULING, publish=True, push=False)
         self._queue_sched.put(tasks)


### PR DESCRIPTION
instead, errors should only affect the individual task on which the
error occured.  We also need to unschedule affected tasks.