### PR TITLE
Resolve a "FIXME"

### DIFF
--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -233,7 +233,7 @@ class Session(rs.Session):
 
     # --------------------------------------------------------------------------
     #
-    def close(self, cleanup=None, terminate=None, download=None):
+    def close(self, **kwargs):
         '''
 
         Closes the session.  All subsequent attempts access objects attached to
@@ -259,19 +259,10 @@ class Session(rs.Session):
         self._prof.prof("session_close", uid=self._uid)
 
         # Merge kwargs with current defaults stored in self._close_options
-        self._close_options.update(
-            {
-                'cleanup': cleanup,
-                'download': download,
-                'terminate': terminate
-            }
-        )
+        self._close_options.update(kwargs)
         self._close_options.verify()  # in case to call for `_verify` method and to convert attributes
                                       # to their types if needed (but None value will stay if it is set)
 
-        del cleanup
-        del terminate
-        del download
         options = self._close_options
 
         for tmgr_uid, tmgr in self._tmgrs.items():

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -3,9 +3,11 @@
 __copyright__ = "Copyright 2013-2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
+import dataclasses
 import os
 import sys
 import copy
+import warnings
 
 import radical.utils                as ru
 import radical.saga                 as rs
@@ -43,7 +45,7 @@ class Session(rs.Session):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, dburl=None, uid=None, cfg=None, _primary=True):
+    def __init__(self, dburl=None, uid=None, cfg=None, _primary=True, **close_options):
         '''
         Creates a new session.  A new Session instance is created and
         stored in the database.
@@ -68,8 +70,13 @@ class Session(rs.Session):
               inherit the original session ID, but will not attempt to create
               a new DB collection - if such a DB connection is needed, the
               component needs to establish that on its own.
-        '''
 
+        If additional key word arguments are provided, they will be used as the
+        default arguments to Session.close(). (This can be useful when the
+        Session is used as a Python context manager, such that close() is called
+        automatically at the end of a ``with`` block.)
+        '''
+        self._close_options = _CloseOptions(**close_options)
         # NOTE: `name` and `cfg` are overloaded, the user cannot point to
         #       a predefined config and amend it at the same time.  This might
         #       be ok for the session, but introduces a minor API inconsistency.
@@ -218,18 +225,17 @@ class Session(rs.Session):
 
     # --------------------------------------------------------------------------
     # context manager `with` clause
-    # FIXME: cleanup_on_close, terminate_on_close attributes?
     #
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.close(download=True)
+        self.close()
 
 
     # --------------------------------------------------------------------------
     #
-    def close(self, cleanup=False, terminate=True, download=False):
+    def close(self, cleanup=None, terminate=None, download=None):
         '''
 
         Closes the session.  All subsequent attempts access objects attached to
@@ -254,13 +260,24 @@ class Session(rs.Session):
         self._log.debug("session %s closing", self._uid)
         self._prof.prof("session_close", uid=self._uid)
 
-        # set defaults
-        if cleanup   is None: cleanup   = True
-        if terminate is None: terminate = True
-
-        if  cleanup:
-            # cleanup implies terminate
+        # Merge kwargs with current defaults stored in self._close_options
+        if terminate is None and cleanup:
+            if not self._close_options.terminate:
+                warnings.warn(
+                    'Overriding *terminate=False* set during Session creation. '
+                    '*cleanup* implies *terminate*.'
+                )
             terminate = True
+        self._close_options = dataclasses.replace(
+            self._close_options,
+            cleanup=cleanup,
+            terminate=terminate,
+            download=download
+        )
+        del cleanup
+        del terminate
+        del download
+        options = self._close_options
 
         for tmgr_uid, tmgr in self._tmgrs.items():
             self._log.debug("session %s closes tmgr   %s", self._uid, tmgr_uid)
@@ -269,17 +286,17 @@ class Session(rs.Session):
 
         for pmgr_uid, pmgr in self._pmgrs.items():
             self._log.debug("session %s closes pmgr   %s", self._uid, pmgr_uid)
-            pmgr.close(terminate=terminate)
+            pmgr.close(terminate=options.terminate)
             self._log.debug("session %s closed pmgr   %s", self._uid, pmgr_uid)
 
         if self._cmgr:
             self._cmgr.close()
 
         if self._dbs:
-            self._log.debug("session %s closes db (%s)", self._uid, cleanup)
-            self._dbs.close(delete=cleanup)
+            self._log.debug("session %s closes db (%s)", self._uid, options.cleanup)
+            self._dbs.close(delete=options.cleanup)
 
-        self._log.debug("session %s closed (delete=%s)", self._uid, cleanup)
+        self._log.debug("session %s closed (delete=%s)", self._uid, options.cleanup)
         self._prof.prof("session_stop", uid=self._uid)
         self._prof.close()
 
@@ -287,7 +304,7 @@ class Session(rs.Session):
 
         # after all is said and done, we attempt to download the pilot log- and
         # profiles, if so wanted
-        if download:
+        if options.download:
 
             self._prof.prof("session_fetch_start", uid=self._uid)
             self._log.debug('start download')
@@ -968,3 +985,29 @@ class Session(rs.Session):
 
 
 # ------------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class _CloseOptions:
+    """Options and validation for Session.close().
+
+    **Arguments:**
+        * **cleanup**   (`bool`):
+          Remove session from MongoDB (implies * terminate). (default False)
+        * **terminate** (`bool`):
+          Shut down all pilots associated with the session. (default True)
+        * **download** (`bool`):
+          Fetch pilot profiles and database entries. (default False)
+
+    """
+    cleanup: bool = False
+    # Warning: Previously, passing `cleanup=None` would reverse the default and
+    # result in cleanup == True.
+
+    terminate: bool = True
+    download: bool = False
+
+    def __post_init__(self):
+        if self.cleanup and not self.terminate:
+            # cleanup implies terminate
+            raise ValueError('cleanup implies terminate.')

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -3,11 +3,9 @@
 __copyright__ = "Copyright 2013-2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
-import dataclasses
 import os
 import sys
 import copy
-import warnings
 
 import radical.utils                as ru
 import radical.saga                 as rs


### PR DESCRIPTION
Encapsulate kwargs handling for Session.close().

Allow kwargs for Session.close() to be provided when initializing the Session.
This allows a "FIXME" to be resolved. When used as a Python context manager,
the Session will have user input with which to override the default arguments
at close().

If key word arguments are provided both at instantiation and when calling
`close()`, the kwargs provided to `close()` take precedence.

An attempt is made to merge the new arguments with the previous arguments.
`close()` is called with `cleanup=True` but an unspecified *terminate*, and
`cleanup=False, terminate=False` was provided to `Session()`, a warning is
issued and the old value is overwritten with `terminate=True`.

Close options are evaluated for self-consistency during both
`Session.__init__()` and `Session.close()`

## Behavior changes

If the user provides inconsistent values for *cleanup* and *terminate*,
ValueError is raised.

Previously, if the user explicitly specified `cleanup=None`, this was
interpreted as `cleanup=True` instead of the default `cleanup=False`.

Fixes #2394