### PR TITLE
Fix/issue 2129

### DIFF
--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         # Launch the pilot.
         pilot = pmgr.submit_pilots(pdesc)
 
-        n = 24  # number of tasks to run
+        n = 1024  # number of tasks to run
         report.header('submit %d tasks' % n)
 
         # Register the pilot in a TaskManager object.
@@ -83,8 +83,7 @@ if __name__ == '__main__':
             # Here we don't use dict initialization.
             td = rp.TaskDescription()
             td.executable    = '/bin/date'
-            td.cpu_processes = n - i + 1
-            td.cpu_process_type = rp.MPI
+            td.cpu_processes = 1
             tds.append(td)
             report.progress()
 
@@ -93,13 +92,10 @@ if __name__ == '__main__':
         # Submit the previously created task descriptions to the
         # PilotManager. This will trigger the selected scheduler to start
         # assigning tasks to the pilots.
-        tasks = tmgr.submit_tasks(tds)
+        tmgr.submit_tasks(tds)
 
         # Wait for all tasks to reach a final state (DONE, CANCELED or FAILED).
         tmgr.wait_tasks()
-
-        for task in tasks:
-            print(task.uid, task.state, task.stdout, task.stderr)
 
     except Exception as e:
         # Something unexpected happened in the pilot code above

--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         # Launch the pilot.
         pilot = pmgr.submit_pilots(pdesc)
 
-        n = 1024  # number of tasks to run
+        n = 24  # number of tasks to run
         report.header('submit %d tasks' % n)
 
         # Register the pilot in a TaskManager object.
@@ -83,7 +83,8 @@ if __name__ == '__main__':
             # Here we don't use dict initialization.
             td = rp.TaskDescription()
             td.executable    = '/bin/date'
-            td.cpu_processes = 1
+            td.cpu_processes = n - i + 1
+            td.cpu_process_type = rp.MPI
             tds.append(td)
             report.progress()
 
@@ -92,10 +93,13 @@ if __name__ == '__main__':
         # Submit the previously created task descriptions to the
         # PilotManager. This will trigger the selected scheduler to start
         # assigning tasks to the pilots.
-        tmgr.submit_tasks(tds)
+        tasks = tmgr.submit_tasks(tds)
 
         # Wait for all tasks to reach a final state (DONE, CANCELED or FAILED).
         tmgr.wait_tasks()
+
+        for task in tasks:
+            print(task.uid, task.state, task.stdout, task.stderr)
 
     except Exception as e:
         # Something unexpected happened in the pilot code above

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -684,9 +684,10 @@ class AgentSchedulingComponent(rpu.Component):
                                                 log=self._log)
 
         for task, error in failed:
-            task['stderr']  = error
-            task['control'] = 'tmgr_pending'
-            task['$all']    = True
+            task['stderr']       = error
+            task['control']      = 'tmgr_pending'
+            task['target_state'] = 'FAILED'
+            task['$all']         = True
 
             self._log.error('bisect failed on %s: %s', task['uid'], error)
             self.advance(scheduled, rps.FAILED, publish=True, push=False)
@@ -783,9 +784,10 @@ class AgentSchedulingComponent(rpu.Component):
 
             except Exception as e:
 
-                task['stderr']  = str(e)
-                task['control'] = 'tmgr_pending'
-              # task['$all']    = True
+                task['stderr']       = str(e)
+                task['control']      = 'tmgr_pending'
+                task['target_state'] = 'FAILED'
+                task['$all']         = True
 
                 self._log.exception('scheduling failed for %s', task['uid'])
 

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -216,8 +216,6 @@ class AgentSchedulingComponent(rpu.Component):
     def __init__(self, cfg, session):
 
         self.nodes = None
-        self._uid  = ru.generate_id(cfg['owner'] + '.scheduling.%(counter)s',
-                                    ru.ID_CUSTOM)
         rpu.Component.__init__(self, cfg, session)
 
 

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -261,7 +261,7 @@ class AgentSchedulingComponent(rpu.Component):
         self._waitpool   = dict()  # map uid:task
         self._ts_map     = dict()
         self._ts_valid   = False   # set to False to trigger re-binning
-        self._active_cnt = 0       # count of currently schedled tasks
+        self._active_cnt = 0       # count of currently scheduled tasks
         self._log.debug('=== active: %s', self._active_cnt)
 
         # the scheduler algorithms have two inputs: tasks to be scheduled, and

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -258,9 +258,11 @@ class AgentSchedulingComponent(rpu.Component):
         # waitlist to a binned list where tasks are binned by size for faster
         # lookups of replacement tasks.  And outdated binlist is mostly
         # sufficient, only rebuild when we run dry
-        self._waitpool = dict()  # map uid:task
-        self._ts_map   = dict()
-        self._ts_valid = False  # set to False to trigger re-binning
+        self._waitpool   = dict()  # map uid:task
+        self._ts_map     = dict()
+        self._ts_valid   = False   # set to False to trigger re-binning
+        self._active_cnt = 0       # count of currently schedled tasks
+        self._log.debug('=== active: %s', self._active_cnt)
 
         # the scheduler algorithms have two inputs: tasks to be scheduled, and
         # slots becoming available (after tasks complete).
@@ -587,6 +589,9 @@ class AgentSchedulingComponent(rpu.Component):
         self.register_output(rps.AGENT_EXECUTING_PENDING,
                              rpc.AGENT_EXECUTING_QUEUE)
 
+        self._publishers = dict()
+        self.register_publisher(rpc.STATE_PUBSUB)
+
         resources = True  # fresh start, all is free
         while not self._proc_term.is_set():
 
@@ -673,10 +678,18 @@ class AgentSchedulingComponent(rpu.Component):
                  reverse=True)
 
         # cycle through waitpool, and see if we get anything placed now.
-        scheduled, unscheduled = ru.lazy_bisect(to_test,
+        scheduled, unscheduled, failed = ru.lazy_bisect(to_test,
                                                 check=self._try_allocation,
                                                 on_skip=self._prof_sched_skip,
                                                 log=self._log)
+
+        for task, error in failed:
+            task['stderr']  = error
+            task['control'] = 'tmgr_pending'
+            task['$all']    = True
+
+            self._log.error('bisect failed on %s: %s', task['uid'], error)
+            self.advance(scheduled, rps.FAILED, publish=True, push=False)
 
         self._waitpool = {task['uid']: task for task in (unscheduled + to_wait)}
 
@@ -753,20 +766,31 @@ class AgentSchedulingComponent(rpu.Component):
 
             # either we can place the task straight away, or we have to
             # put it in the wait pool.
-            if self._try_allocation(task):
+            try:
+                if self._try_allocation(task):
+                    # task got scheduled - advance state, notify world about the
+                    # state change, and push it out toward the next component.
+                    td = task['description']
+                    task['$set']      = ['resources']
+                    task['resources'] = {'cpu': td['cpu_processes'] *
+                                                td.get('cpu_threads', 1),
+                                         'gpu': td['gpu_processes']}
+                    self.advance(task, rps.AGENT_EXECUTING_PENDING,
+                                 publish=True, push=True)
 
-                # task got scheduled - advance state, notify world about the
-                # state change, and push it out toward the next component.
-                td = task['description']
-                task['$set']      = ['resources']
-                task['resources'] = {'cpu': td['cpu_processes'] *
-                                            td.get('cpu_threads', 1),
-                                     'gpu': td['gpu_processes']}
-                self.advance(task, rps.AGENT_EXECUTING_PENDING,
-                             publish=True, push=True)
+                else:
+                    to_wait.append(task)
 
-            else:
-                to_wait.append(task)
+            except Exception as e:
+
+                task['stderr']  = str(e)
+                task['control'] = 'tmgr_pending'
+              # task['$all']    = True
+
+                self._log.exception('scheduling failed for %s', task['uid'])
+
+                self.advance(task, rps.FAILED, publish=True, push=False)
+
 
         # all tasks which could not be scheduled are added to the waitpool
         self._waitpool.update({task['uid']: task for task in to_wait})
@@ -854,6 +878,7 @@ class AgentSchedulingComponent(rpu.Component):
           #     # schedule other tasks of other sizes.
           #     to_release.append(task)
 
+            self._active_cnt -= 1
             to_release.append(task)
 
         if not to_release:
@@ -895,7 +920,15 @@ class AgentSchedulingComponent(rpu.Component):
 
             # schedule failure
           # self._prof.prof('schedule_fail', uid=uid)
+
+            # if schedule fails while no other task is scheduled, then the
+            # `schedule_task` will never be able to succeed - fail that task
+            if self._active_cnt == 0:
+                raise RuntimeError('insufficient resources')
+
             return False
+
+        self._active_cnt += 1
 
         # the task was placed, we need to reflect the allocation in the
         # nodelist state (BUSY) and pass placement to the task, to have

--- a/tests/unit_tests/test_scheduler/test_base.py
+++ b/tests/unit_tests/test_scheduler/test_base.py
@@ -66,6 +66,7 @@ class TestBase(TestCase):
         component._log           = ru.Logger('dummy')
         component._allocate_slot = mock.Mock(side_effect=[None,
                                                           {'slot':'test_slot'}])
+        component._active_cnt    = 0
         component._prof          = mock.Mock()
         component._prof.prof     = mock.Mock(return_value=True)
         component._wait_pool     = list()


### PR DESCRIPTION
This fixes #2129: if scheduling a task fails, and at the same time the scheduler has all resources available ( no other tasks have resources allocated), then the scheduler will fail the task.