### PR TITLE
Use methods from the new module `host` within RU (>=1.6.7)

### DIFF
--- a/bin/radical-pilot-create-static-ve
+++ b/bin/radical-pilot-create-static-ve
@@ -28,7 +28,7 @@ then
     # by default, install all RCT dependencies
     MODULES="$MODULES apache-libcloud chardet colorama idna msgpack"
     MODULES="$MODULES msgpack-python netifaces ntplib parse pymongo"
-    MODULES="$MODULES python-hostlist pyzmq regex requests setproctitle urllib3"
+    MODULES="$MODULES pyzmq regex requests setproctitle urllib3"
 fi
 
 # setuptools="setuptools==0.6c11"

--- a/setup.py
+++ b/setup.py
@@ -245,10 +245,9 @@ setup_args = {
     'package_data'       : {'': ['*.txt', '*.sh', '*.json', '*.gz', '*.c',
                                  '*.md', 'VERSION', 'SDIST', sdist_name]},
   # 'setup_requires'     : ['pytest-runner'],
-    'install_requires'   : ['radical.utils>=1.6.6',
+    'install_requires'   : ['radical.utils>=1.6.7',
                             'radical.saga>=1.6.6',
                             'pymongo',
-                            'python-hostlist',
                             'setproctitle'
                            ],
     'extras_require'     : {'autopilot' : ['github3.py']},

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -121,10 +121,10 @@ VIRTENV_TGZ="$VIRTENV_VER.tar.gz"
 VIRTENV_TGZ_URL="https://files.pythonhosted.org/packages/66/f0/6867af06d2e2f511e4e1d7094ff663acdebc4f15d4a0cb0fed1007395124/$VIRTENV_TGZ"
 VIRTENV_IS_ACTIVATED=FALSE
 
-VIRTENV_RADICAL_DEPS="pymongo colorama python-hostlist ntplib "\
+VIRTENV_RADICAL_DEPS="pymongo colorama ntplib "\
 "pyzmq netifaces setproctitle msgpack regex"
 
-VIRTENV_RADICAL_MODS="pymongo colorama hostlist ntplib "\
+VIRTENV_RADICAL_MODS="pymongo colorama ntplib "\
 "zmq netifaces setproctitle msgpack regex"
 
 if ! test -z "$RADICAL_DEBUG"

--- a/src/radical/pilot/agent/launch_method/base.py
+++ b/src/radical/pilot/agent/launch_method/base.py
@@ -3,13 +3,9 @@
 __copyright__ = "Copyright 2016, http://radical.rutgers.edu"
 __license__   = "MIT"
 
-
 import os
-import fractions
-import collections
 
 import radical.utils as ru
-from functools import reduce
 
 
 # 'enum' for launch method types
@@ -295,68 +291,6 @@ class LaunchMethod(object):
     def construct_command(self, t, launch_script_hop):
 
         raise NotImplementedError("incomplete LaunchMethod %s" % self.name)
-
-
-    # --------------------------------------------------------------------------
-    #
-    @classmethod
-    def _create_hostfile(cls, sandbox, uid, all_hosts, separator=' ',
-                         impaired=False):
-
-        # Open appropriately named temporary file
-        # NOTE: we make an assumption about the task sandbox here
-        filename = '%s/%s.hosts' % (sandbox, uid)
-        with open(filename, 'w') as fout:
-
-            if not impaired:
-                # Write "hostN x\nhostM y\n" entries
-                # Create a {'host1': x, 'host2': y} dict
-                counter = collections.Counter(all_hosts)
-
-                # Convert it into an ordered dict,
-                # which hopefully resembles the original ordering
-                count_dict = collections.OrderedDict(sorted(counter.items(),
-                                                     key=lambda t: t[0]))
-
-                for (host, count) in count_dict.items():
-                    fout.write('%s%s%d\n' % (host, separator, count))
-
-            else:
-                # Write "hostN\nhostM\n" entries
-                for host in all_hosts:
-                    fout.write('%s\n' % host)
-
-        # Return the filename, caller is responsible for cleaning up
-        return filename
-
-
-    # --------------------------------------------------------------------------
-    #
-    @classmethod
-    def _compress_hostlist(cls, all_hosts):
-
-        # Return gcd of a list of numbers
-        def gcd_list(l):
-            return reduce(fractions.gcd, l)
-
-        # Create a {'host1': x, 'host2': y} dict
-        count_dict = dict(collections.Counter(all_hosts))
-        # Find the gcd of the host counts
-        host_gcd = gcd_list(set(count_dict.values()))
-
-        # Divide the host counts by the gcd
-        for host in count_dict:
-            count_dict[host] /= host_gcd
-
-        # Recreate a list of hosts based on the normalized dict
-        hosts = list()
-        for (host, count) in list(count_dict.items()):
-            hosts.extend([host] * count)
-
-        # sort the list for readbility
-        hosts.sort()
-
-        return hosts
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/launch_method/mpirun.py
+++ b/src/radical/pilot/agent/launch_method/mpirun.py
@@ -143,8 +143,8 @@ class MPIRun(LaunchMethod):
         if len(host_list) > 42:
 
             # Create a hostfile from the list of hosts
-            hostfile = self._create_hostfile(sandbox, uid, host_list,
-                                             impaired=True)
+            hostfile = ru.create_hostfile(sandbox, uid, host_list,
+                                          impaired=True)
             if self._mpt: hosts_string = '-file %s'     % hostfile
             else        : hosts_string = '-hostfile %s' % hostfile
 

--- a/src/radical/pilot/agent/launch_method/mpirun.py
+++ b/src/radical/pilot/agent/launch_method/mpirun.py
@@ -27,6 +27,13 @@ class MPIRun(LaunchMethod):
 
     # --------------------------------------------------------------------------
     #
+    def get_rank_cmd(self):
+
+        return "echo $PMIX_RANK"
+
+
+    # --------------------------------------------------------------------------
+    #
     def _configure(self):
 
         if '_rsh' in self.name.lower():

--- a/src/radical/pilot/agent/resource_manager/cobalt.py
+++ b/src/radical/pilot/agent/resource_manager/cobalt.py
@@ -1,7 +1,6 @@
 
-__copyright__ = "Copyright 2016, http://radical.rutgers.edu"
-__license__   = "MIT"
-
+__copyright__ = 'Copyright 2016-2021, The RADICAL-Cybertools Team'
+__license__   = 'MIT'
 
 import os
 
@@ -20,47 +19,40 @@ class Cobalt(ResourceManager):
 
         ResourceManager.__init__(self, cfg, session)
 
-
     # --------------------------------------------------------------------------
     #
     def _configure(self):
 
-        # we only support Cobalt on Theta right now, and since we know that
-        # Theta is a Cray, we know that aprun is available.  Alas, aprun
-        # provides the only way (we could find so far) to determing the list of
-        # nodes we have available (`COBALT_NODELIST` seems broken).  So we run
-        # `aprun` with the rank of nodes we *think* we have, and with `-N 1` to
-        # place one rank per node, and run `hostname` - that gives is the list
-        # of hostnames.  The number of nodes we receive from `$COBALT_PARTSIZE`.
+        try:
+            # this env variable is used for GPU nodes
+            with open(os.environ['COBALT_NODEFILE'], 'r') as f:
+                node_names = [node.strip() for node in f.readlines() if node]
+        except KeyError:
+            node_range = os.environ['COBALT_PARTNAME']
+            node_names = ru.get_hostlist_by_range(node_range, 'nid', 5)
 
-        n_nodes          = int(os.environ['COBALT_PARTSIZE'])
-        out, _, _        = ru.sh_callout('aprun -n %d -N 1 hostname' % n_nodes)
-        node_list        = out.split()
-        assert(len(node_list) == n_nodes), node_list
+            # Another option is to run `aprun` with the rank of nodes
+            # we *think* we have, and with `-N 1` to place one rank per node,
+            # and run `hostname` - that gives the list of hostnames.
+            # (The number of nodes we receive from `$COBALT_PARTSIZE`.)
+            #   out = ru.sh_callout('aprun -q -n %d -N 1 hostname' % n_nodes)[0]
+            #   node_names = out.split()
 
-        # we also want    to learn the core count per node
-        cmd              = 'cat /proc/cpuinfo | grep processor | wc -l'
-        out, _, _        = ru.sh_callout('aprun -n %d -N 1 %s' % (n_nodes, cmd))
-        core_counts      = list(set([int(x) for x in out.split()]))
-        assert(len(core_counts) == 1), core_counts
-        cores_per_node   = core_counts[0]
+        self.node_list = [[n, str(i + 1)] for i, n in enumerate(node_names)]
 
-        gpus_per_node    = self._cfg.get('gpus_per_node', 0)
-        lfs_per_node     = {'path': ru.expand_env(
+        # get info about core count per node:
+        #   cmd = 'cat /proc/cpuinfo | grep processor | wc -l'
+        #   out = ru.sh_callout('aprun -q -n %d -N 1 %s' % (n_nodes, cmd))[0]
+        #   core_counts = set([int(x) for x in out.split()])
+        #   print('=== out 2 : [%s] [%s]' % (out, core_counts))
+        #   assert(len(core_counts) == 1), core_counts
+        #   cores_per_node = core_counts[0]
+
+        self.cores_per_node = self._cfg.get('cores_per_node', 1)
+        self.gpus_per_node  = self._cfg.get('gpus_per_node', 0)
+        self.mem_per_node   = self._cfg.get('mem_per_node', 0)
+        self.lfs_per_node   = {'path': ru.expand_env(
                                        self._cfg.get('lfs_path_per_node')),
-                            'size':    self._cfg.get('lfs_size_per_node', 0)
-                           }
-        mem_per_node     = self._cfg.get('mem_per_node', 0)
-
-        self._log.info("Found unique core counts: %s", cores_per_node)
-
-        # node names are unique, so can serve as node uids
-        self.node_list        = [[node, node] for node in node_list]
-        self.cores_per_node   = cores_per_node
-        self.gpus_per_node    = gpus_per_node
-        self.lfs_per_node     = lfs_per_node
-        self.mem_per_node     = mem_per_node
-
+                               'size': self._cfg.get('lfs_size_per_node', 0)}
 
 # ------------------------------------------------------------------------------
-

--- a/src/radical/pilot/agent/resource_manager/slurm.py
+++ b/src/radical/pilot/agent/resource_manager/slurm.py
@@ -4,7 +4,6 @@ __license__   = "MIT"
 
 
 import os
-import hostlist
 
 import radical.utils as ru
 
@@ -33,7 +32,7 @@ class Slurm(ResourceManager):
             raise RuntimeError(msg)
 
         # Parse SLURM nodefile environment variable
-        slurm_nodes = hostlist.expand_hostlist(slurm_nodelist)
+        slurm_nodes = ru.get_hostlist(slurm_nodelist)
         self._log.info("Found SLURM_NODELIST %s. Expanded to: %s", slurm_nodelist, slurm_nodes)
 
         # $SLURM_NPROCS = Total number of cores allocated for the current job

--- a/src/radical/pilot/configs/resource_anl.json
+++ b/src/radical/pilot/configs/resource_anl.json
@@ -1,36 +1,62 @@
-
 {
     "theta": {
         "description"                 : "",
-        "notes"                       : null,
+        "notes"                       : "Local instance of MongoDB and pre-set VE should be used.",
         "schemas"                     : ["local"],
-        "local"                       : {
+        "local"                       :
+        {
             "job_manager_hop"         : "cobalt://localhost/",
             "job_manager_endpoint"    : "cobalt://localhost/",
             "filesystem_endpoint"     : "file://localhost/"
         },
         "default_queue"               : "debug-flat-quad",
         "resource_manager"            : "COBALT",
-        "lfs_per_node"                : "/tmp",
         "agent_config"                : "default",
         "agent_scheduler"             : "CONTINUOUS",
         "agent_spawner"               : "POPEN",
-        "agent_launch_method"         : "MPIEXEC",
-        "task_launch_method"          : "MPIEXEC",
-        "mpi_launch_method"           : "MPIEXEC",
+        "agent_launch_method"         : "SSH",
+        "task_launch_method"          : "APRUN",
+        "mpi_launch_method"           : "APRUN",
         "pre_bootstrap_0"             : [
+                                         "module load miniconda-3"
                                         ],
-        "pre_bootstrap_1"             : [
-                                        ],
-        "valid_roots"                 : [],
+        "valid_roots"                 : ["$HOME"],
         "default_remote_workdir"      : "$HOME",
-        "rp_version"                  : "local",
-        "virtenv_mode"                : "create",
+        "virtenv_mode"                : "local",
         "stage_cacerts"               : true,
-        "python_dist"                 : "default",
-        "virtenv_dist"                : "default",
-        "gpus_per_node"               : 0,
-        "cores_per_node"              : 64
+        "cores_per_node"              : 64,
+        "lfs_path_per_node"           : "/tmp",
+        "lfs_size_per_node"           : 0
+    },
+    "theta_gpu": {
+        "description"                 : "",
+        "notes"                       : "Local instance of MongoDB and pre-set VE should be used.",
+        "schemas"                     : ["local"],
+        "local"                       :
+        {
+            "job_manager_hop"         : "cobalt://localhost/",
+            "job_manager_endpoint"    : "cobalt://localhost/",
+            "filesystem_endpoint"     : "file://localhost/"
+        },
+        "default_queue"               : "full-node",
+        "resource_manager"            : "COBALT",
+        "agent_config"                : "default",
+        "agent_scheduler"             : "CONTINUOUS",
+        "agent_spawner"               : "POPEN",
+        "agent_launch_method"         : "SSH",
+        "task_launch_method"          : "MPIRUN",
+        "mpi_launch_method"           : "MPIRUN",
+        "pre_bootstrap_0"             : [
+                                         ". /home/$USER/.miniconda3/etc/profile.d/conda.sh"
+                                        ],
+        "valid_roots"                 : ["$HOME"],
+        "default_remote_workdir"      : "$HOME",
+        "virtenv_mode"                : "local",
+        "stage_cacerts"               : true,
+        "cores_per_node"              : 128,
+        "gpus_per_node"               : 8,
+        "system_architecture"         : {"options": [["mig-mode=True"]]},
+        "lfs_path_per_node"           : "/tmp",
+        "lfs_size_per_node"           : 0
     }
 }
-

--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -829,7 +829,6 @@ class Default(PMGRLaunchingComponent):
         # above syntax is ignored, and the fallback stage@local
         # is used.
 
-
         if not rp_version:
             if virtenv_mode == 'local': rp_version = 'installed'
             else                      : rp_version = DEFAULT_RP_VERSION
@@ -841,6 +840,18 @@ class Default(PMGRLaunchingComponent):
         if rp_version.startswith('@'):
             rp_version  = rp_version[1:]  # strip '@'
 
+        # use local VE ?
+        if virtenv_mode == 'local':
+            if os.environ.get('VIRTUAL_ENV'):
+                python_dist = 'default'
+                virtenv     = os.environ['VIRTUAL_ENV']
+            elif os.environ.get('CONDA_PREFIX'):
+                python_dist = 'anaconda'
+                virtenv     = os.environ['CONDA_PREFIX']
+            else:
+                # we can't use local
+                self._log.error('virtenv_mode is local, no local env found')
+                raise ValueError('no local env found')
 
         # ----------------------------------------------------------------------
         # sanity checks
@@ -874,19 +885,6 @@ class Default(PMGRLaunchingComponent):
             # we never cleanup virtenvs which are not private
             if virtenv_mode != 'private':
                 cleanup = cleanup.replace('v', '')
-
-        # use local VE ?
-        if virtenv_mode == 'local':
-            if os.environ.get('VIRTUAL_ENV'):
-                python_dist = 'default'
-                virtenv     = os.environ['VIRTUAL_ENV']
-            elif os.environ.get('CONDA_PREFIX'):
-                python_dist = 'anaconda'
-                virtenv     = os.environ['CONDA_PREFIX']
-            else:
-                # we can't use local
-                self._log.error('virtenv_mode is local, no local env found')
-                raise ValueError('no local env found')
 
         # if cores_per_node is set (!= None), then we need to
         # allocation full nodes, and thus round up

--- a/tests/unit_tests/test_rm/test_cobalt.py
+++ b/tests/unit_tests/test_rm/test_cobalt.py
@@ -1,38 +1,37 @@
-
 # pylint: disable=protected-access, unused-argument, no-value-for-parameter
 
 import os
 
-from unittest import mock, TestCase
-
 import radical.utils as ru
+
+from unittest import mock, TestCase
 
 from radical.pilot.agent.resource_manager.cobalt import Cobalt
 
 
+# ------------------------------------------------------------------------------
+#
 class TestCobalt(TestCase):
 
-    # ------------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     #
     @mock.patch.object(Cobalt, '__init__', return_value=None)
-    @mock.patch('radical.utils.raise_on')
-    @mock.patch('radical.utils.sh_callout', side_effect=[('node1', None, None),
-                                                         ('16', None, None)])
-    def test_configure(self, mocked_init, mocked_raise_on, mocked_sh_callout):
+    @mock.patch('radical.utils.Logger')
+    def test_configure(self, mocked_logger, mocked_init):
 
-        # Test 1 no config file
-        os.environ['COBALT_PARTSIZE'] = '1'
+        os.environ['COBALT_PARTNAME'] = '1'
 
         component = Cobalt(cfg=None, session=None)
-        component._log = ru.Logger('dummy')
-        component._cfg = {}
-        component.lm_info = {'cores_per_node': None}
+        component._log = mocked_logger
+        component._cfg = ru.Config(from_dict={'cores_per_node': 16})
         component._configure()
 
-        self.assertEqual(component.node_list, [['node1','node1']])
+        self.assertEqual(component.node_list, [['nid00001', '1']])
         self.assertEqual(component.cores_per_node, 16)
         self.assertEqual(component.gpus_per_node, 0)
         self.assertEqual(component.lfs_per_node, {'path': None, 'size': 0})
+
+# ------------------------------------------------------------------------------
 
 
 if __name__ == '__main__':

--- a/tests/unit_tests/test_rm/test_slurm.py
+++ b/tests/unit_tests/test_rm/test_slurm.py
@@ -16,8 +16,7 @@ class TestSlurm(TestCase):
     #
     @mock.patch.object(Slurm, '__init__',   return_value=None)
     @mock.patch('radical.utils.raise_on')
-    @mock.patch('hostlist.expand_hostlist', return_value=['nodes1', 'nodes2'])
-    def test_configure(self, mocked_init, mocked_raise_on, mocked_expand_hostlist):
+    def test_configure(self, mocked_init, mocked_raise_on):
 
         # Test 1 no config file
         os.environ['SLURM_NODELIST'] = 'nodes-[1-2]'
@@ -34,7 +33,8 @@ class TestSlurm(TestCase):
         sys.stderr.flush()
         component._configure()
 
-        self.assertEqual(component.node_list, [['nodes1','nodes1'],['nodes2','nodes2']])
+        self.assertEqual(component.node_list,
+                         [['nodes-1', 'nodes-1'], ['nodes-2', 'nodes-2']])
         self.assertEqual(component.cores_per_node, 24)
         self.assertEqual(component.gpus_per_node, 0)
         self.assertEqual(component.lfs_per_node, {'path': None, 'size': 0})
@@ -53,7 +53,8 @@ class TestSlurm(TestCase):
                           'lfs_size_per_node': 100}
         component.lm_info = {'cores_per_node': None}
         component._configure()
-        self.assertEqual(component.node_list, [['nodes1','nodes1'],['nodes2','nodes2']])
+        self.assertEqual(component.node_list,
+                         [['nodes-1', 'nodes-1'], ['nodes-2', 'nodes-2']])
         self.assertEqual(component.cores_per_node, 24)
         self.assertEqual(component.gpus_per_node, 1)
         self.assertEqual(component.lfs_per_node, {'path': 'test/', 'size': 100})
@@ -73,7 +74,8 @@ class TestSlurm(TestCase):
                           'lfs_size_per_node': 100}
         component.lm_info = {'cores_per_node': None}
         component._configure()
-        self.assertEqual(component.node_list, [['nodes1','nodes1'],['nodes2','nodes2']])
+        self.assertEqual(component.node_list,
+                         [['nodes-1', 'nodes-1'], ['nodes-2', 'nodes-2']])
         self.assertEqual(component.cores_per_node, 24)
         self.assertEqual(component.gpus_per_node, 1)
         self.assertEqual(component.lfs_per_node, {'path': '/local_folder/', 'size': 100})
@@ -85,8 +87,7 @@ class TestSlurm(TestCase):
     #
     @mock.patch.object(Slurm, '__init__',   return_value=None)
     @mock.patch('radical.utils.raise_on')
-    @mock.patch('hostlist.expand_hostlist', return_value=['nodes1', 'nodes2'])
-    def test_configure_error(self, mocked_init, mocked_raise_on, mocked_expand_hostlist):
+    def test_configure_error(self, mocked_init, mocked_raise_on):
 
         # Test 1 no config file
         if 'SLURM_NODELIST' in os.environ:

--- a/tests/unit_tests/test_rm/test_torque.py
+++ b/tests/unit_tests/test_rm/test_torque.py
@@ -17,8 +17,7 @@ class TestTorque(TestCase):
     #
     @mock.patch.object(Torque, '__init__', return_value=None)
     @mock.patch('radical.utils.raise_on')
-    @mock.patch('hostlist.expand_hostlist', return_value=['nodes1', 'nodes1'])
-    def test_configure(self, mocked_init, mocked_raise_on, mocked_expand_hoslist):
+    def test_configure(self, mocked_init, mocked_raise_on):
 
         # Test 1 no config file
         base = os.path.dirname(__file__) + '/../'
@@ -64,8 +63,7 @@ class TestTorque(TestCase):
     #
     @mock.patch.object(Torque, '__init__', return_value=None)
     @mock.patch('radical.utils.raise_on')
-    @mock.patch('hostlist.expand_hostlist', return_value=['nodes1', 'nodes1'])
-    def test_configure_error(self, mocked_init, mocked_raise_on, mocked_expand_hoslist):
+    def test_configure_error(self, mocked_init, mocked_raise_on):
 
         # Test 1 no config file check nodefile
         base = os.path.dirname(__file__) + '/../'


### PR DESCRIPTION
- removed `python-hostlist` dependency (from setup, bootstrapper, Slurm RM);
- removed host-related methods from LM base class, which are moved to RU;
- updated Cobalt RM to use host names (and updated corresponding resource config for `anl.theta/theta_gpu`);