### PR TITLE
refactor close_options

### DIFF
--- a/tests/component_tests/test_session.py
+++ b/tests/component_tests/test_session.py
@@ -82,15 +82,15 @@ class TestSession(TestCase):
     def test_close(self, mocked_closed, mocked_created):
 
         # check default values
-        self.assertFalse(self._session._close_options.cleanup)
-        self.assertFalse(self._session._close_options.download)
-        self.assertTrue(self._session._close_options.terminate)
+        self.assertFalse(self._session._close_opts['cleanup'])
+        self.assertFalse(self._session._close_opts['download'])
+        self.assertTrue(self._session._close_opts['terminate'])
 
         # only `True` values are targeted
 
         self._session._closed = False
         self._session.close(cleanup=True)
-        self.assertTrue(self._session._close_options.cleanup)
+        self.assertTrue(self._session._close_opts['cleanup'])
 
         self._session._closed = False
         self._session.fetch_json     = mock.Mock()


### PR DESCRIPTION
Hey @mtitov - I should have complained earlier, but when I re-read the `close_options` code in the session again (stumbled over it in some merge conflicts), I found it to be a bit of an overkill.  I also disliked that the `session.close()` lots its signature (just `**kwargs` were left).  Here is thus an attempt to simplify it a bit, let me know what you think.  Thanks!