### PR TITLE
Add fallback for ssh tunnel on ifconfig-less nodes

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -1609,11 +1609,16 @@ get_tunnel(){
     echo "# Setting up forward tunnel to $addr."
 
     # Bind to localhost
-    BIND_ADDRESS=$(/sbin/ifconfig $TUNNEL_BIND_DEVICE|grep "inet addr"|cut -f2 -d:|cut -f1 -d" ")
-
-    if test -z "$BIND_ADDRESS"
+    # Check if ifconfig exists
+    if test -f /sbin/ifconfig
     then
-        BIND_ADDRESS=$(/sbin/ifconfig lo | grep 'inet' | xargs echo | cut -f 2 -d ' ')
+        BIND_ADDRESS=$(/sbin/ifconfig $TUNNEL_BIND_DEVICE|grep "inet addr"|cut -f2 -d:|cut -f1 -d" ")
+        if test -z "$BIND_ADDRESS"
+        then
+            BIND_ADDRESS=$(/sbin/ifconfig lo0 | grep 'inet' | xargs echo | cut -f 2 -d ' ')
+        fi
+    else
+        BIND_ADDRESS=$(host `hostname` | awk '{print $NF}')
     fi
 
     if test -z "$BIND_ADDRESS"


### PR DESCRIPTION
Currently, `ifconfig` is the primary executable for determining
the bind address for creating an SSH tunnel for nodes without an
outside-world connection. However, some machine nodes are not
equipped with `ifconfig` -- e.g, anl.arcticus -- and the last-case
scenario using `ip` returns a string of IP addresses instead of a
single one.

This commit employs the use of `host` to get the node IP address
for SSH tunnel binding (thanks to @andre-merzky for the tip!) when
`ifconfig` is unavailable in the 'usual' location.