### PR TITLE
Support ALCF/JLSE Arcticus and Iris testbeds

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -1,258 +1,229 @@
-
 {
-    "local.localhost" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : null,
-        "cores"    : 1,
-        "gpus"     : 0
+    "local.localhost": {
+        "project": null,
+        "queue": null,
+        "schema": null,
+        "cores": 1,
+        "gpus": 0
     },
-
-    "local.localhost_test" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : null,
-        "cores"    : 1,
-        "gpus"     : 0
+    "local.localhost_test": {
+        "project": null,
+        "queue": null,
+        "schema": null,
+        "cores": 1,
+        "gpus": 0
     },
-
-    "local.localhost_flux" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : null,
-        "cores"    : 128,
-        "gpus"     : 0
+    "local.localhost_flux": {
+        "project": null,
+        "queue": null,
+        "schema": null,
+        "cores": 128,
+        "gpus": 0
     },
-
-    "local.localhost_prte" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : null,
-        "cores"    : 64
+    "local.localhost_prte": {
+        "project": null,
+        "queue": null,
+        "schema": null,
+        "cores": 64
     },
-
-    "local.localhost_funcs" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : "local",
-        "cores"    : 16
+    "local.localhost_funcs": {
+        "project": null,
+        "queue": null,
+        "schema": "local",
+        "cores": 16
     },
-
-    "local.local" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : null,
-        "cores"    : 64
+    "local.local": {
+        "project": null,
+        "queue": null,
+        "schema": null,
+        "cores": 64
     },
-
-    "nersc.edison" : {
-        "project"  : null,
-        "queue"    : "debug",
-        "schema"   : "ssh",
-        "cores"    : 64
+    "anl.arcticus": {
+        "project": null,
+        "queue": "arcticus",
+        "schema": "local",
+        "cores": 96,
+        "gpus": 2
     },
-
-    "xsede.supermic_ssh" : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "workq",
-        "schema"   : "gsissh",
-        "cores"    : 64
+    "nersc.edison": {
+        "project": null,
+        "queue": "debug",
+        "schema": "ssh",
+        "cores": 64
     },
-
-    "xsede.supermic" : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "workq",
-        "schema"   : "gsissh",
-        "cores"    : 80
+    "xsede.supermic_ssh": {
+        "project": "TG-MCB090174",
+        "queue": "workq",
+        "schema": "gsissh",
+        "cores": 64
     },
-
-    "xsede.supermic_orte" : {
-        "project"  : "TG-CCR140028",
-        "queue"    : "workq",
-        "schema"   : "gsissh",
-        "cores"    : 80
+    "xsede.supermic": {
+        "project": "TG-MCB090174",
+        "queue": "workq",
+        "schema": "gsissh",
+        "cores": 80
     },
-
-    "princeton.traverse" : {
-        "project"  : "tromp",
-        "queue"    : "all",
-        "schema"   : "local",
-        "cores"    : 32,
-        "gpus"     : 4
+    "xsede.supermic_orte": {
+        "project": "TG-CCR140028",
+        "queue": "workq",
+        "schema": "gsissh",
+        "cores": 80
     },
-
-    "princeton.tiger_cpu" : {
-        "project"  : "geo",
-        "queue"    : "cpu",
-        "schema"   : "ssh",
-        "cores"    : 40
+    "princeton.traverse": {
+        "project": "tromp",
+        "queue": "all",
+        "schema": "local",
+        "cores": 32,
+        "gpus": 4
     },
-
-    "princeton.tiger_gpu" : {
-        "project"  : "geo",
-        "queue"    : "gpu",
-        "schema"   : "local",
-        "cores"    : 56
+    "princeton.tiger_cpu": {
+        "project": "geo",
+        "queue": "cpu",
+        "schema": "ssh",
+        "cores": 40
     },
-
-    "xsede.frontera" : {
-        "project"  : "FTA-Jha",
-        "queue"    : "development",
-        "schema"   : "local",
-        "cores"    : 64
+    "princeton.tiger_gpu": {
+        "project": "geo",
+        "queue": "gpu",
+        "schema": "local",
+        "cores": 56
     },
-
-    "xsede.longhorn" : {
-        "project"  : "FTA-Jha",
-        "queue"    : "development",
-        "schema"   : "local",
-        "cores"    : 40
+    "xsede.frontera": {
+        "project": "FTA-Jha",
+        "queue": "development",
+        "schema": "local",
+        "cores": 64
     },
-
-    "xsede.bridges2" : {
-        "project"  : null,
-        "queue"    : "RM",
-        "schema"   : "gsissh",
-        "cores"    : 128
+    "xsede.longhorn": {
+        "project": "FTA-Jha",
+        "queue": "development",
+        "schema": "local",
+        "cores": 40
     },
-
-    "xsede.wrangler" : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "debug",
-        "schema"   : "gsissh",
-        "cores"    : 24
+    "xsede.bridges2": {
+        "project": null,
+        "queue": "RM",
+        "schema": "gsissh",
+        "cores": 128
     },
-
-    "xsede.comet"  : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "compute",
-        "schema"   : "gsissh",
-        "cores"    : 64
+    "xsede.wrangler": {
+        "project": "TG-MCB090174",
+        "queue": "debug",
+        "schema": "gsissh",
+        "cores": 24
     },
-
-    "xsede.comet_ssh"  : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "compute",
-        "schema"   : "gsissh",
-        "cores"    : 64
+    "xsede.comet": {
+        "project": "TG-MCB090174",
+        "queue": "compute",
+        "schema": "gsissh",
+        "cores": 64
     },
-
-    "xsede.comet_ssh_funcs"  : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "compute",
-        "schema"   : "gsissh",
-        "cores"    : 64
+    "xsede.comet_ssh": {
+        "project": "TG-MCB090174",
+        "queue": "compute",
+        "schema": "gsissh",
+        "cores": 64
     },
-
-    "xsede.comet_ortelib"  : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "debug",
-        "schema"   : "gsissh",
-        "cores"    : 96
+    "xsede.comet_ssh_funcs": {
+        "project": "TG-MCB090174",
+        "queue": "compute",
+        "schema": "gsissh",
+        "cores": 64
     },
-
-    "xsede.stampede2_ssh"  : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "development",
-        "schema"   : "local",
-        "cores"    : 204
+    "xsede.comet_ortelib": {
+        "project": "TG-MCB090174",
+        "queue": "debug",
+        "schema": "gsissh",
+        "cores": 96
     },
-
-    "xsede.stampede2_srun"  : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "development",
-        "schema"   : "local",
-        "cores"    : 204
+    "xsede.stampede2_ssh": {
+        "project": "TG-MCB090174",
+        "queue": "development",
+        "schema": "local",
+        "cores": 204
     },
-
-    "xsede.stampede2_ibrun"  : {
-        "project"  : "TG-MCB090174",
-        "queue"    : "development",
-        "schema"   : "local",
-        "cores"    : 204
+    "xsede.stampede2_srun": {
+        "project": "TG-MCB090174",
+        "queue": "development",
+        "schema": "local",
+        "cores": 204
     },
-
+    "xsede.stampede2_ibrun": {
+        "project": "TG-MCB090174",
+        "queue": "development",
+        "schema": "local",
+        "cores": 204
+    },
     "ncar.cheyenne": {
-	    "project"  : "URTG0014",
-	    "queue"    : "regular",
-	    "schema"   : "local",
-	    "cores"    : 72
+        "project": "URTG0014",
+        "queue": "regular",
+        "schema": "local",
+        "cores": 72
     },
-
-    "llnl.lassen"  : {
-        "project"  : "CV_DDMD",
-        "queue"    : "pdebug",
-      # "queue"    : "pbatch",
-        "schema"   : "local",
-        "cores"    : 30,
-        "gpus"     : 0
+    "llnl.lassen": {
+        "project": "CV_DDMD",
+        "queue": "pdebug",
+      # "queue": "pbatch",
+        "schema": "local",
+        "cores": 30,
+        "gpus": 0
     },
-
-    "ornl.summit"  : {
-        "project"  : "CSC343",
-        "queue"    : "batch",
-        "schema"   : "local",
-        "cores"    : 168,
-        "gpus"     : 6
+    "ornl.summit": {
+        "project": "CSC343",
+        "queue": "batch",
+        "schema": "local",
+        "cores": 168,
+        "gpus": 6
     },
-
-    "ornl.summit_prte" : {
-        "project"  : "geo111",
-        "queue"    : "batch",
-        "schema"   : "local",
-        "cores"    : 168,
-        "gpus"     : 6
+    "ornl.summit_prte": {
+        "project": "geo111",
+        "queue": "batch",
+        "schema": "local",
+        "cores": 168,
+        "gpus": 6
     },
-
-    "ornl.rhea_aprun"   : {
-        "project"  : "BIP149",
-        "queue"    : "batch",
-        "schema"   : "local",
-        "cores"    : 64
+    "ornl.rhea_aprun": {
+        "project": "BIP149",
+        "queue": "batch",
+        "schema": "local",
+        "cores": 64
     },
-
-    "osg.xsede-virt-clust"   : {
-      # "project"  : "TG-CCR140028",
-        "project"  : "TG-MCB090174",
-        "queue"    : null,
-        "schema"   : "gsissh",
-        "cores"    : 1
+    "osg.xsede-virt-clust": {
+      # "project": "TG-CCR140028",
+        "project": "TG-MCB090174",
+        "queue": null,
+        "schema": "gsissh",
+        "cores": 1
     },
-
-    "osg.connect" : {
-        "project"  : "RADICAL",
-        "queue"    : null,
-        "schema"   : "ssh",
-        "cores"    : 64
+    "osg.connect": {
+        "project": "RADICAL",
+        "queue": null,
+        "schema": "ssh",
+        "cores": 64
     },
-
-    "fub.allegro"   : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : "ssh",
-        "cores"    : 36,
-        "gpus"     : 12
+    "fub.allegro": {
+        "project": null,
+        "queue": null,
+        "schema": "ssh",
+        "cores": 36,
+        "gpus": 12
     },
-
-    "radical.one" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : "ssh",
-        "cores"    : 8
+    "radical.one": {
+        "project": null,
+        "queue": null,
+        "schema": "ssh",
+        "cores": 8
     },
-
-    "radical.two" : {
-        "project"  : null,
-        "queue"    : null,
-        "schema"   : "ssh",
-        "cores"    : 8
+    "radical.two": {
+        "project": null,
+        "queue": null,
+        "schema": "ssh",
+        "cores": 8
     },
-
-    "rutgers.amarel" : {
-         "project" : null,
-         "queue"   : null,
-         "schema"  : "ssh",
-         "cores"   : 8
+    "rutgers.amarel": {
+        "project": null,
+        "queue": null,
+        "schema": "ssh",
+        "cores": 8
     }
 }
-

--- a/src/radical/pilot/configs/resource_anl.json
+++ b/src/radical/pilot/configs/resource_anl.json
@@ -1,64 +1,113 @@
-
 {
     "theta": {
-        "description"                 : "Cray XC40, 4392 nodes (Intel KNL 7230)",
-        "notes"                       : "Local instance of MongoDB and pre-set VE should be used.",
-        "schemas"                     : ["local"],
-        "local"                       :
-        {
-            "job_manager_hop"         : "cobalt://localhost/",
-            "job_manager_endpoint"    : "cobalt://localhost/",
-            "filesystem_endpoint"     : "file://localhost/"
+        "description": "Cray XC40, 4392 nodes (Intel KNL 7230)",
+        "notes": "Local instance of MongoDB and pre-set VE should be used.",
+        "schemas": [
+            "local"
+        ],
+        "local": {
+            "job_manager_hop": "cobalt://localhost/",
+            "job_manager_endpoint": "cobalt://localhost/",
+            "filesystem_endpoint": "file://localhost/"
         },
-        "default_queue"               : "debug-flat-quad",
-        "resource_manager"            : "COBALT",
-        "agent_config"                : "default",
-        "agent_scheduler"             : "CONTINUOUS",
-        "agent_spawner"               : "POPEN",
-        "agent_launch_method"         : "SSH",
-        "task_launch_method"          : "APRUN",
-        "mpi_launch_method"           : "APRUN",
-        "pre_bootstrap_0"             : [
-                                         "module load miniconda-3"
-                                        ],
-        "valid_roots"                 : ["$HOME"],
-        "default_remote_workdir"      : "$HOME",
-        "virtenv_mode"                : "local",
-        "stage_cacerts"               : true,
-        "cores_per_node"              : 64,
-        "lfs_path_per_node"           : "/tmp",
-        "lfs_size_per_node"           : 0
+        "default_queue": "debug-flat-quad",
+        "resource_manager": "COBALT",
+        "agent_config": "default",
+        "agent_scheduler": "CONTINUOUS",
+        "agent_spawner": "POPEN",
+        "agent_launch_method": "SSH",
+        "task_launch_method": "APRUN",
+        "mpi_launch_method": "APRUN",
+        "pre_bootstrap_0": [
+            "module load miniconda-3"
+        ],
+        "valid_roots": [
+            "$HOME"
+        ],
+        "default_remote_workdir": "$HOME",
+        "virtenv_mode": "local",
+        "stage_cacerts": true,
+        "cores_per_node": 64,
+        "lfs_path_per_node": "/tmp",
+        "lfs_size_per_node": 0
     },
-
     "theta_gpu": {
-        "description"                 : "Extension of Theta, 24 NVIDIA DGX A100 nodes",
-        "notes"                       : "Local instance of MongoDB and pre-set VE should be used.",
-        "schemas"                     : ["local"],
-        "local"                       :
-        {
-            "job_manager_hop"         : "cobalt://localhost/",
-            "job_manager_endpoint"    : "cobalt://localhost/",
-            "filesystem_endpoint"     : "file://localhost/"
+        "description": "Extension of Theta, 24 NVIDIA DGX A100 nodes",
+        "notes": "Local instance of MongoDB and pre-set VE should be used.",
+        "schemas": [
+            "local"
+        ],
+        "local": {
+            "job_manager_hop": "cobalt://localhost/",
+            "job_manager_endpoint": "cobalt://localhost/",
+            "filesystem_endpoint": "file://localhost/"
         },
-        "default_queue"               : "full-node",
-        "resource_manager"            : "COBALT",
-        "agent_config"                : "default",
-        "agent_scheduler"             : "CONTINUOUS",
-        "agent_spawner"               : "POPEN",
-        "agent_launch_method"         : "SSH",
-        "task_launch_method"          : "MPIRUN",
-        "mpi_launch_method"           : "MPIRUN",
-        "pre_bootstrap_0"             : [
-                                         ". /home/$USER/.miniconda3/etc/profile.d/conda.sh"
-                                        ],
-        "valid_roots"                 : ["$HOME"],
-        "default_remote_workdir"      : "$HOME",
-        "virtenv_mode"                : "local",
-        "stage_cacerts"               : true,
-        "cores_per_node"              : 128,
-        "gpus_per_node"               : 8,
-        "system_architecture"         : {"options": ["mig-mode=True"]},
-        "lfs_path_per_node"           : "/tmp",
-        "lfs_size_per_node"           : 0
+        "default_queue": "full-node",
+        "resource_manager": "COBALT",
+        "agent_config": "default",
+        "agent_scheduler": "CONTINUOUS",
+        "agent_spawner": "POPEN",
+        "agent_launch_method": "SSH",
+        "task_launch_method": "MPIRUN",
+        "mpi_launch_method": "MPIRUN",
+        "pre_bootstrap_0": [
+            ". /home/$USER/.miniconda3/etc/profile.d/conda.sh"
+        ],
+        "valid_roots": [
+            "$HOME"
+        ],
+        "default_remote_workdir": "$HOME",
+        "virtenv_mode": "local",
+        "stage_cacerts": true,
+        "cores_per_node": 128,
+        "gpus_per_node": 8,
+        "system_architecture": {
+            "options": [
+                "mig-mode=True"
+            ]
+        },
+        "lfs_path_per_node": "/tmp",
+        "lfs_size_per_node": 0
+    },
+    "arcticus": {
+        "description": "JLSE Aurora testbed; 17x Coyote Pass nodes, 2x XeHP_SDV",
+        "notes": "Duo two-factor login. Local instance of MongoDB and virtualenv should be used.",
+        "schemas": [
+            "local"
+        ],
+        "local": {
+            "job_manager_hop": "cobalt://localhost/",
+            "job_manager_endpoint": "cobalt://localhost/",
+            "filesystem_endpoint": "file://localhost/"
+        },
+        "forward_tunnel_endpoint": "jlselogin5",
+        "default_queue": "full-node",
+        "resource_manager": "COBALT",
+        "agent_config": "default",
+        "agent_scheduler": "CONTINUOUS",
+        "agent_spawner": "POPEN",
+        "agent_launch_method": "SSH",
+        "task_launch_method": "MPIRUN",
+        "mpi_launch_method": "MPIRUN",
+        "pre_bootstrap_0": [
+            "module purge",
+            "module use  /soft/modulefiles",
+            "module load spack/linux-rhel7-x86_64",
+            "module load openmpi/4.1.1-gcc",
+            "module load py-virtualenv"
+        ],
+        "valid_roots": [
+            "$HOME"
+        ],
+        "default_remote_workdir": "$HOME",
+        "virtenv_mode": "local",
+        "stage_cacerts": true,
+        "cores_per_node": 96,
+        "gpus_per_node": 2,
+        "system_architecture": {
+            "gpu": "XeHP_SDV"
+        },
+        "lfs_path_per_node": "/tmp",
+        "lfs_size_per_node": 0
     }
 }

--- a/tests/integration_tests/test_config/resources.json
+++ b/tests/integration_tests/test_config/resources.json
@@ -1,22 +1,31 @@
 {
-    "comet" : {
-      "cores_per_node"   : 24,
-      "gpus_per_node"    : 0,
-      "ssh_path"         : "/bin/ssh",
-      "resource"         : "xsede.comet"
-    },
-    "bridges2" : {
-        "cores_per_node" : 40,
-        "gpus_per_node"  : 0,
-        "mpirun_path"    : "mpirun",
-        "mpi_flavor"     : "OMPI",
-        "mpi_version"    : "3.1.6",
-        "resource"       : "xsede.bridges2"
-    },
-    "summit" : {
-      "cores_per_node"   : 42,
-      "gpus_per_node"    : 0,
-      "jsrun_path"       : "/opt/ibm/spectrum_mpi/jsm_pmix/bin/jsrun",
-        "resource"       : "ornl.summit"
-    }
+  "arcticus": {
+    "cores_per_node": 48,
+    "gpus_per_node": 2,
+    "mpi_flavor": "OMPI",
+    "mpi_version": "4.1.1",
+    "mpirun_path": "mpirun",
+    "resource": "anl.arcticus",
+    "ssh_path": "/usr/bin/ssh"
+  },
+  "bridges2": {
+    "cores_per_node": 40,
+    "gpus_per_node": 0,
+    "mpirun_path": "mpirun",
+    "mpi_flavor": "OMPI",
+    "mpi_version": "3.1.6",
+    "resource": "xsede.bridges2"
+  },
+  "comet": {
+    "cores_per_node": 24,
+    "gpus_per_node": 0,
+    "ssh_path": "/bin/ssh",
+    "resource": "xsede.comet"
+  },
+  "summit": {
+    "cores_per_node": 42,
+    "gpus_per_node": 0,
+    "jsrun_path": "/opt/ibm/spectrum_mpi/jsm_pmix/bin/jsrun",
+    "resource": "ornl.summit"
+  }
 }


### PR DESCRIPTION
Add resources for Arcticus and Iris nodes. In particular,

o) added Arcticus and Iris configs in the ANL set of
   resources; and

o) resources for Arcticus and Iris was added to the `example`
   configurations.