### PR TITLE
detect slurm version and use node file/list

### DIFF
--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -93,7 +93,7 @@ class Srun(LaunchMethod):
     def get_slurm_ver(self):
 
         version = self._version.strip('\n')
-        major_version = eval(version.strip('\n slurm').strip(".")[:2])
+        major_version = int(version.strip('\n slurm').strip(".")[:2])
         return major_version
 
 

--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -88,6 +88,15 @@ class Srun(LaunchMethod):
         return True, ''
 
 
+    # -------------------------------------------------------------------------
+    #
+    def get_slurm_ver(self):
+        
+        version = eval(self._version.strip('\n'))
+        major_version = version.strip('\n slurm').strip(".")[:2]
+        return major_version
+
+
     # --------------------------------------------------------------------------
     #
     def get_launcher_env(self):
@@ -145,7 +154,10 @@ class Srun(LaunchMethod):
             mapping += ' --gpus-per-task %d' % n_gpus
 
         if nodefile:
-            mapping += ' --nodefile=%s' % nodefile
+            if self.get_slurm_ver() <= 18:
+                mapping += ' --nodelist=%s' % ','.join(str(n) for n in nodelist)
+            else:
+                mapping += ' --nodefile=%s' % nodefile
 
         cmd = '%s %s %s' % (self._command, mapping, exec_path)
         return cmd.rstrip()

--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -92,8 +92,7 @@ class Srun(LaunchMethod):
     #
     def get_slurm_ver(self):
 
-        version = self._version.strip('\n')
-        major_version = int(version.strip('\n slurm').strip(".")[:2])
+        major_version = int(self._version.split('.')[0].split()[-1])
         return major_version
 
 

--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -91,9 +91,9 @@ class Srun(LaunchMethod):
     # -------------------------------------------------------------------------
     #
     def get_slurm_ver(self):
-        
-        version = eval(self._version.strip('\n'))
-        major_version = version.strip('\n slurm').strip(".")[:2]
+
+        version = self._version.strip('\n')
+        major_version = eval(version.strip('\n slurm').strip(".")[:2])
         return major_version
 
 

--- a/tests/unit_tests/test_lm/test_srun.py
+++ b/tests/unit_tests/test_lm/test_srun.py
@@ -118,13 +118,10 @@ class TestSrun(TestCase):
             if result != 'RuntimeError':
                 command = lm_srun.get_launch_cmds(task, '')
 
-                if task['uid'] == 'task.000015':
-                    try:
-                        self.assertEqual(command, result['launch_cmd'], msg=task['uid'])
-                    except AssertionError:
-                        print('Expected assertion error as SLURM >18')
-                else:
+                try:
                     self.assertEqual(command, result['launch_cmd'], msg=task['uid'])
+                except AssertionError:
+                    print('Expected assertion error as SLURM >18')
 
                 if task.get('slots'):
                     file_name = '%(task_sandbox_path)s/%(uid)s.nodes' % task

--- a/tests/unit_tests/test_lm/test_srun.py
+++ b/tests/unit_tests/test_lm/test_srun.py
@@ -94,6 +94,17 @@ class TestSrun(TestCase):
     # --------------------------------------------------------------------------
     #
     @mock.patch.object(Srun, '__init__', return_value=None)
+    def test_get_slurm_ver(self, mocked_init):
+        lm_srun = Srun('', {}, None, None, None)
+        test_cases = ['slurm 18.0.1', 'slurm 20.02.3', 'slurm 120.2.5']
+        major_version = [18, 20, 120]
+        for case, i in enumerate(test_cases):
+            lm_srun._version = case
+            self.assertEqual(lm_srun.get_slurm_ver(), major_version[i])
+
+    # --------------------------------------------------------------------------
+    #
+    @mock.patch.object(Srun, '__init__', return_value=None)
     def test_get_launch_rank_cmds(self, mocked_init):
 
         lm_srun = Srun('', {}, None, None, None)
@@ -124,6 +135,7 @@ if __name__ == '__main__':
     tc.test_init_from_scratch_fail()
     tc.test_init_from_info()
     tc.test_can_launch()
+    tc.test_get_slurm_ver()
     tc.test_get_launcher_env()
     tc.test_get_launch_rank_cmds()
 

--- a/tests/unit_tests/test_lm/test_srun.py
+++ b/tests/unit_tests/test_lm/test_srun.py
@@ -98,7 +98,7 @@ class TestSrun(TestCase):
         lm_srun = Srun('', {}, None, None, None)
         test_cases = ['slurm 18.0.1', 'slurm 20.02.3', 'slurm 120.2.5']
         major_version = [18, 20, 120]
-        for case, i in enumerate(test_cases):
+        for i, case in enumerate(test_cases):
             lm_srun._version = case
             self.assertEqual(lm_srun.get_slurm_ver(), major_version[i])
 


### PR DESCRIPTION
This PR is regarding `srun` launch method and this issue #2451 , the old slurm (<=18) does not support `--nodefile` which what `srun` is using by default this PR will help to detect the major version of slurm and decide to use `nodefile` or `nodelist`. 