### PR TITLE
set RP_RANK on non-MPI tasks

### DIFF
--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -712,7 +712,16 @@ class Popen(AgentExecutingComponent):
 
         ret  = ''
         ret += 'export RP_RANKS=%s\n' % n_ranks
-        ret += launcher.get_rank_cmd()
+
+        if n_ranks > 1:
+            ret += launcher.get_rank_cmd()
+
+            # make sure that RP_RANK is known (otherwise task fails silently)
+            ret += 'test -z "$RP_RANK" && echo "Cannot determine rank"\n'
+            ret += 'test -z "$RP_RANK" && exit 1\n'
+
+        else:
+            ret += 'export RP_RANK=0\n'
 
         return ret
 

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -712,16 +712,13 @@ class Popen(AgentExecutingComponent):
 
         ret  = ''
         ret += 'export RP_RANKS=%s\n' % n_ranks
+        ret += launcher.get_rank_cmd()
 
         if n_ranks > 1:
-            ret += launcher.get_rank_cmd()
 
             # make sure that RP_RANK is known (otherwise task fails silently)
             ret += 'test -z "$RP_RANK" && echo "Cannot determine rank"\n'
             ret += 'test -z "$RP_RANK" && exit 1\n'
-
-        else:
-            ret += 'export RP_RANK=0\n'
 
         return ret
 


### PR DESCRIPTION
Non-MPI tasks miss the `RP_RANK` env setting and fall through the rank switch in `task_uid.exec.sh`.

See also https://github.com/radical-cybertools/radical.entk/issues/599