### PR TITLE
fixing srun version command

### DIFF
--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -130,8 +130,7 @@ class Srun(LaunchMethod):
             # mapping (see above), but we at least honor the nodelist.
             nodelist = [rank['node_name'] for rank in slots['ranks']]
 
-            # newer slurm versions need a nodefile
-            # FIXME: is this really true?
+            # older slurm versions don't accept nodefiles
             if self._vmajor > 18:
                 nodefile = '%s/%s.nodes' % (sbox, uid)
                 with ru.ru_open(nodefile, 'w') as fout:

--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -44,18 +44,19 @@ class Srun(LaunchMethod):
     def _init_from_scratch(self, env, env_sh):
 
         command = ru.which('srun')
-
         out, err, ret = ru.sh_callout('%s -V' % command)
         if ret:
             raise RuntimeError('cannot use srun [%s] [%s]' % (out, err))
 
-        self._version = out.split()[-1]
-        self._log.debug('using srun from %s [%s]',
-                        command, self._version)
+        version = out.split()[-1]
+        vmajor  = int(version.split('.')[0])
+        self._log.debug('using srun from %s [v.%s]', command, version)
 
-        lm_info = {'env'    : env,
-                   'env_sh' : env_sh,
-                   'command': command}
+        lm_info = {'env'     : env,
+                   'env_sh'  : env_sh,
+                   'command' : command,
+                   'version' : version,
+                   'vmajor'  : vmajor}
 
         return lm_info
 
@@ -67,6 +68,8 @@ class Srun(LaunchMethod):
         self._env     = lm_info['env']
         self._env_sh  = lm_info['env_sh']
         self._command = lm_info['command']
+        self._version = lm_info['version']
+        self._vmajor  = lm_info['vmajor']
 
         assert self._command
 
@@ -86,21 +89,6 @@ class Srun(LaunchMethod):
             return False, 'no executable'
 
         return True, ''
-
-
-    # -------------------------------------------------------------------------
-    #
-    def get_slurm_ver(self):
-
-        command = ru.which('srun')
-
-        out, err, ret = ru.sh_callout('%s -V' % command)
-        if ret:
-            raise RuntimeError('cannot use srun [%s] [%s]' % (out, err))
-
-        self._version = out.split()[-1]
-        major_version = int(self._version.split('.')[0].split()[-1])
-        return major_version
 
 
     # --------------------------------------------------------------------------
@@ -131,18 +119,24 @@ class Srun(LaunchMethod):
         # a decent auto mapping.  In cases where the scheduler did not place
         # the task we leave the node placement to srun as well.
 
+        nodefile = None
+        nodelist = list()
+
         if not slots:
-            nodefile = None
             n_nodes  = int(math.ceil(float(n_tasks) /
                                      self._rm_info.get('cores_per_node', 1)))
         else:
             # the scheduler did place tasks - we can't honor the core and gpu
             # mapping (see above), but we at least honor the nodelist.
             nodelist = [rank['node_name'] for rank in slots['ranks']]
-            nodefile = '%s/%s.nodes' % (sbox, uid)
-            with ru.ru_open(nodefile, 'w') as fout:
-                fout.write(','.join(nodelist))
-                fout.write('\n')
+
+            # newer slurm versions need a nodefile
+            # FIXME: is this really true?
+            if self._vmajor > 18:
+                nodefile = '%s/%s.nodes' % (sbox, uid)
+                with ru.ru_open(nodefile, 'w') as fout:
+                    fout.write(','.join(nodelist))
+                    fout.write('\n')
 
             n_nodes = len(set(nodelist))
 
@@ -159,11 +153,12 @@ class Srun(LaunchMethod):
         if self._rm_info.get('gpus'):
             mapping += ' --gpus-per-task %d' % n_gpus
 
-        if nodefile:
-            if self.get_slurm_ver() <= 18:
-                mapping += ' --nodelist=%s' % ','.join(str(n) for n in nodelist)
-            else:
+        if self._vmajor > 18:
+            if nodefile:
                 mapping += ' --nodefile=%s' % nodefile
+        else:
+            if nodelist:
+                mapping += ' --nodelist=%s' % ','.join(str(n) for n in nodelist)
 
         cmd = '%s %s %s' % (self._command, mapping, exec_path)
         return cmd.rstrip()

--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -92,6 +92,13 @@ class Srun(LaunchMethod):
     #
     def get_slurm_ver(self):
 
+        command = ru.which('srun')
+
+        out, err, ret = ru.sh_callout('%s -V' % command)
+        if ret:
+            raise RuntimeError('cannot use srun [%s] [%s]' % (out, err))
+
+        self._version = out.split()[-1]
         major_version = int(self._version.split('.')[0].split()[-1])
         return major_version
 


### PR DESCRIPTION
This PR is to fix the `srun` `slurm` version here: https://github.com/radical-cybertools/radical.pilot/blob/2c0f72511f50bfe966ca36041473a8c05e824489/src/radical/pilot/agent/launch_method/srun.py#L93. 

`self._version` is not defined in the initialization of the class so the function `_get_slurm_ver` does not have that value. I propose this solution in the PR (but it introduces a code duplication) as the same chunk of code are in the `_init_from_scratch`. 

There is another option, which defines the version in the initializer of the class so all functions can see the value of the `Srun` version, but it might fail if `Srun` doesn't exist:

```python

    # --------------------------------------------------------------------------
    #
    def __init__(self, name, lm_cfg, rm_info, log, prof):

        self.command = ru.which('srun')

        LaunchMethod.__init__(self, name, lm_cfg, rm_info, log, prof)

        out, err, ret = ru.sh_callout('%s -V' % command)
        if ret:
            raise RuntimeError('cannot use srun [%s] [%s]' % (out, err))

        self.version = out.split()[-1]
```
Any suggestions please?

