### PR TITLE
yet another remaining python -> python3 rename

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -469,7 +469,7 @@ rehash()
     # we need to do this again after the virtenv is loaded
     if test -z "$explicit_python"
     then
-        PYTHON=`which python`
+        PYTHON=`which python3`
     else
         PYTHON="$explicit_python"
     fi


### PR DESCRIPTION
It's annoying that we *still* find places in the code where `python` is used instead of `python3`...  Let's hope this the last one...

Thanks @kartikmodi for reporting this!  
Fixes  #2498