### PR TITLE
fix capture of exit code

### DIFF
--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -618,9 +618,8 @@ class Popen(AgentExecutingComponent):
         for cmd in cmds:
             ret += '  %s \\\n' % cmd
 
-        ret += ') 1> %s\n  2> %s %s' % (task['stdout_file_short'],
-                                        task['stderr_file_short'],
-                                        self._get_check('launch'))
+        ret += ') 1> %s \\\n  2> %s' % (task['stdout_file_short'],
+                                        task['stderr_file_short'])
         return ret
 
 


### PR DESCRIPTION
This fixes #2509
A backslash was missing :-(   Also let the exit code fall through.
