### PR TITLE
removing module reset

### DIFF
--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -325,10 +325,7 @@
                                              ]
                                          }
                                         },
-        "pre_bootstrap_0"             : ["module reset",
-                                       # "module load slurm",
-                                         "module load anaconda3"
-                                        ],
+        "pre_bootstrap_0"             : ["module load anaconda3"],
         "default_remote_workdir"      : "$PROJECT",
         "valid_roots"                 : ["/home", "/ocean"],
         "rp_version"                  : "local",


### PR DESCRIPTION
removing `module reset` from `bridges2`  resource file as it raises warning if no module exists leading to RP bootstrapping failure.