### PR TITLE
Fix `processes_per_host` for SAGA job description

### DIFF
--- a/src/radical/pilot/pmgr/launching/default.py
+++ b/src/radical/pilot/pmgr/launching/default.py
@@ -1085,7 +1085,7 @@ class Default(PMGRLaunchingComponent):
         jd.total_cpu_count       = total_cpu_count
         jd.total_gpu_count       = total_gpu_count
         jd.total_physical_memory = requested_memory
-        jd.processes_per_host    = cores_per_node
+        jd.processes_per_host    = avail_cores_per_node
         jd.spmd_variation        = spmd_variation
         jd.wall_time_limit       = runtime
         jd.queue                 = queue


### PR DESCRIPTION
Since we manage how many cores per node are available for RP, that [updated] info we should transfer to SAGA layer

Examples:
- [Slurm](https://github.com/radical-cybertools/radical.saga/blob/b189d3243018aa03d04ddb133c11fba51854cc1f/src/radical/saga/adaptors/slurm/slurm_job.py#L603-L608)
```python
script += "#SBATCH --ntasks-per-node=%s\n" % processes_per_host
```
- [Cobalt](https://github.com/radical-cybertools/radical.saga/blob/b189d3243018aa03d04ddb133c11fba51854cc1f/src/radical/saga/adaptors/cobalt/cobaltjob.py#L209-L216)
```python
    # ppn: processes/cores per node (default value is an input parameter)
    if jd.attribute_exists('processes_per_host'):
        ppn = jd.processes_per_host

    # Request enough nodes to cater for the number of cores requested
    number_of_nodes = total_cpu_count / ppn
    if total_cpu_count % ppn > 0:
        number_of_nodes += 1
```