### PR TITLE
Update Spock endpoints in resource config

### DIFF
--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -94,9 +94,8 @@
         "notes"                       : "",
         "schemas"                     : ["local"],
         "local"                       : {
-            "job_manager_hop"         : "fork://localhost/",
-            "job_manager_endpoint"    : "slurm://localhost/",
-            "filesystem_endpoint"     : "file://localhost/"
+            "job_manager_endpoint"    : "slurm://spock.olcf.ornl.gov/",
+            "filesystem_endpoint"     : "file://spock.olcf.ornl.gov/"
         },
         "default_queue"               : "batch",
         "resource_manager"            : "SLURM",


### PR DESCRIPTION
Endpoint full name should be set, so SAGA would be able to distinguish it

https://github.com/radical-cybertools/radical.saga/blob/ab9b9b703934385d939c8dbc4822128f131d23fc/src/radical/saga/adaptors/slurm/slurm_job.py#L665