### PR TITLE
Raptor worker pre_exec

### DIFF
--- a/src/radical/pilot/raptor/master.py
+++ b/src/radical/pilot/raptor/master.py
@@ -311,6 +311,7 @@ class Master(rpu.Component):
                 # this master is obviously running in a suitable python3 env,
                 # so we expect that the same env is also suitable for the worker
                 # NOTE: shell escaping is a bit tricky here - careful on change!
+                td['pre_exec']   = descr.get('pre_exec', [])
                 td['executable'] = 'python3'
                 td['arguments']  = [
                         '-c',


### PR DESCRIPTION
This PR adds the option to specify `pre_exec` to the worker description when it gets submitted via a Raptor master.