### PR TITLE
Status callback for SAGA Launcher

### DIFF
--- a/src/radical/pilot/pmgr/launching/base.py
+++ b/src/radical/pilot/pmgr/launching/base.py
@@ -229,7 +229,7 @@ class PMGRLaunchingComponent(rpu.Component):
             if not isinstance(pids, list):
                 pids = [pids]
 
-            self._log.info('received pilot_cancel command (%s)', pids)
+            self._log.info('received "kill_pilots" command (%s)', pids)
 
             self._kill_pilots(pids)
 

--- a/src/radical/pilot/pmgr/launching/saga.py
+++ b/src/radical/pilot/pmgr/launching/saga.py
@@ -70,7 +70,7 @@ class PilotLauncherSAGA(PilotLauncherBase):
         try:
             with self._lock:
 
-                if job.id not in self._pilots:
+                if pid not in self._pilots:
                     return
 
                 rp_state = self._translate_state(saga_state)
@@ -93,7 +93,7 @@ class PilotLauncherSAGA(PilotLauncherBase):
         with self._lock:
 
             # cancel pilots
-            for _, job in self._jobs:
+            for job in self._jobs.values():
                 job.cancel()
 
             # close job services


### PR DESCRIPTION
TBD: `_job_state_cb` is not triggered when SAGA jobs changes its state - @andre-merzky can you please have a look