### PR TITLE
fix which conda call

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -1804,7 +1804,7 @@ export PATH="$PB1_PATH"
 export LD_LIBRARY_PATH="$PB1_LDLB"
 
 # activate virtenv
-if test "$PYTHON_DIST" = "anaconda" && ! test -z $(which conda)
+if test "$PYTHON_DIST" = "anaconda" && ! test -z "\$(which conda)"
 then
     eval "\$(conda shell.posix hook)"
     conda activate $VIRTENV


### PR DESCRIPTION
Trying to deploy RP on `xsede expanse` ended up with this error: 
```shell
./bootstrap_2.sh: line 14: syntax error near unexpected token `('
./bootstrap_2.sh: line 14: `if test "default" = "anaconda" && ! test -z conda ()'
```

Calling `which conda` actually returns the body of the function instead of executing it here https://github.com/radical-cybertools/radical.pilot/blob/14c663f927b2908cf317954d9e0ab01195a812b9/src/radical/pilot/agent/bootstrap_0.sh#L1807: 
```shell
conda ()
{
    \local cmd="${1-__missing__}";
    case "$cmd" in

        activate | deactivate)
            __conda_activate "$@"
        ;;
        install | update | upgrade | remove | uninstall)
            __conda_exe "$@" || \return;
            __conda_reactivate
        ;;
        *)
            __conda_exe "$@"
        ;;
    esac
}
```
