### PR TITLE
expanse support

### DIFF
--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -377,5 +377,61 @@
         "task_pre_exec"               : [],
         "gpus_per_node"               : 8,
         "system_architecture"         : {"gpu": "v100"}
+    },
+
+    "expanse": {
+        "description"                 : "(https://www.sdsc.edu/support/user_guides/expanse.html).",
+        "schemas": [
+            "local",
+            "ssh"
+        ],
+        "ssh": {
+            "filesystem_endpoint": "sftp://expanse.sdsc.xsede.org",
+            "job_manager_endpoint": "slurm+ssh://expanse.sdsc.xsede.org"
+        },
+        "local": {
+            "filesystem_endpoint": "file://expanse.sdsc.xsede.org/",
+            "job_manager_endpoint": "slurm://expanse.sdsc.xsede.org/"
+        },
+        "agent_config"                : "default",
+        "agent_scheduler"             : "CONTINUOUS",
+        "agent_spawner"               : "POPEN",
+        "cores_per_node"              : 128,
+        "gpus_per_node"               : 0,
+        "lfs_path_per_node": null,
+        "lfs_size_per_node": 1000000,
+        "default_queue"               : "compute",
+        "default_remote_workdir"      : "/expanse/lustre/scratch/$USER/temp_project",
+        "launch_methods"              : {
+            "SRUN": {
+                "pre_exec_cached": [
+                  # "module load slurm",
+                  # "module load intel",
+                  # "module load openmpi"
+                ]
+            },
+            "order": [
+                "SRUN"
+            ]
+        },
+        "notes": "Always set the ``project`` attribute in the PilotDescription.",
+        "pre_bootstrap_0": [
+          # "module purge",
+          # "module load cpu",
+          # "module load slurm",
+          # "module load gcc",
+          # "module load openmpi",
+            "module load anaconda3"
+        ],
+        "python_dist": "anaconda",
+        "resource_manager": "SLURM",
+        "system_architecture": {
+            "gpu": "v100"
+        },
+        "valid_roots": [
+            "/expanse/lustre/scratch/$USER/temp_project"
+        ],
+        "virtenv_mode": "create"
     }
 }
+

--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -381,57 +381,39 @@
 
     "expanse": {
         "description"                 : "(https://www.sdsc.edu/support/user_guides/expanse.html).",
-        "schemas": [
-            "local",
-            "ssh"
-        ],
+        "notes"                       : "",
+        "schemas"                     : ["local", "ssh"],
         "ssh": {
-            "filesystem_endpoint": "sftp://expanse.sdsc.xsede.org",
-            "job_manager_endpoint": "slurm+ssh://expanse.sdsc.xsede.org"
+            "filesystem_endpoint"     : "sftp://expanse.sdsc.xsede.org/",
+            "job_manager_endpoint"    : "slurm+ssh://expanse.sdsc.xsede.org/"
         },
         "local": {
-            "filesystem_endpoint": "file://expanse.sdsc.xsede.org/",
-            "job_manager_endpoint": "slurm://expanse.sdsc.xsede.org/"
+            "filesystem_endpoint"     : "file://expanse.sdsc.xsede.org/",
+            "job_manager_endpoint"    : "slurm://expanse.sdsc.xsede.org/"
         },
+
+        "virtenv_mode"                : "create",
+        "python_dist"                 : "anaconda",
         "agent_config"                : "default",
         "agent_scheduler"             : "CONTINUOUS",
         "agent_spawner"               : "POPEN",
-        "cores_per_node"              : 128,
-        "gpus_per_node"               : 0,
-        "lfs_path_per_node": null,
-        "lfs_size_per_node": 1000000,
+        "resource_manager"            : "SLURM",
+        "launch_methods"              : {
+            "order"                   : ["SRUN"],
+            "SRUN"                    : {}
+        },
+
         "default_queue"               : "compute",
         "default_remote_workdir"      : "/expanse/lustre/scratch/$USER/temp_project",
-        "launch_methods"              : {
-            "SRUN": {
-                "pre_exec_cached": [
-                  # "module load slurm",
-                  # "module load intel",
-                  # "module load openmpi"
-                ]
-            },
-            "order": [
-                "SRUN"
-            ]
-        },
-        "notes": "Always set the ``project`` attribute in the PilotDescription.",
-        "pre_bootstrap_0": [
-          # "module purge",
-          # "module load cpu",
-          # "module load slurm",
-          # "module load gcc",
-          # "module load openmpi",
-            "module load anaconda3"
-        ],
-        "python_dist": "anaconda",
-        "resource_manager": "SLURM",
-        "system_architecture": {
-            "gpu": "v100"
-        },
-        "valid_roots": [
-            "/expanse/lustre/scratch/$USER/temp_project"
-        ],
-        "virtenv_mode": "create"
+        "valid_roots"                 : ["/expanse/lustre/"],
+        "pre_bootstrap_0"             : ["module load anaconda3"],
+
+        "cores_per_node"              : 128,
+        "gpus_per_node"               : 4,
+        "mem_per_node"                : 256000,
+        "lfs_path_per_node"           : "/tmp/",
+        "lfs_size_per_node"           : 1000000,
+        "system_architecture"         : {"gpu": "v100"}
     }
 }
 

--- a/src/radical/pilot/pmgr/launching/base.py
+++ b/src/radical/pilot/pmgr/launching/base.py
@@ -963,6 +963,7 @@ class PMGRLaunchingComponent(rpu.Component):
         jd_dict.project               = project
         jd_dict.output                = 'bootstrap_0.out'
         jd_dict.error                 = 'bootstrap_0.err'
+        jd_dict.node_count            = requested_nodes
         jd_dict.total_cpu_count       = total_cpu_count
         jd_dict.total_gpu_count       = total_gpu_count
         jd_dict.total_physical_memory = requested_memory

--- a/src/radical/pilot/pmgr/launching/psi_j.py
+++ b/src/radical/pilot/pmgr/launching/psi_j.py
@@ -145,16 +145,21 @@ class PilotLauncherPSIJ(PilotLauncherBase):
             assert(jex)
 
             jd = pilot['jd_dict']
+
+            proj, res = None, None
             if jd.project:
-                proj, res = jd.project.split(':', 1)
-            else:
-                proj, res = None, None
+                if ':' in jd.project:
+                    proj, res = jd.project.split(':', 1)
+                else:
+                    proj = jd.project
 
             attr = psij.JobAttributes()
-            attr.duration       = jd.runtime
+            attr.duration       = jd.wall_time_limit
             attr.queue_name     = jd.queue
             attr.project_name   = proj
             attr.reservation_id = res
+
+            self._log.debug('=== rt: %s', jd.runtime)
 
             spec = psij.JobSpec()
             spec.attributes  = attr
@@ -166,6 +171,7 @@ class PilotLauncherPSIJ(PilotLauncherBase):
             spec.stderr_path = jd.error
 
             spec.resources   = psij.ResourceSpecV1()
+            spec.resources.node_count            = jd.node_count
             spec.resources.process_count         = jd.total_cpu_count
             spec.resources.cpu_cores_per_process = 1
           # spec.resources.gpu_cores_per_process = jd.total_gpu_count


### PR DESCRIPTION
This PR adds an expanse resource config.

@AymenFJA : can you please check if this is in sync with what you configured?  For one thing, this uses `srun` as LM instead of `mpirun` - the `openmpi` module you loaded does not seem available anymore?