### PR TITLE
Checking input staging exists before tar-ing Fixes #2483

### DIFF
--- a/src/radical/pilot/pmgr/launching/base.py
+++ b/src/radical/pilot/pmgr/launching/base.py
@@ -280,7 +280,7 @@ class PMGRLaunchingComponent(rpu.Component):
         self.advance(pilots, rps.PMGR_LAUNCHING, publish=True, push=False)
 
         # We can only use bulk submission for pilots which go to the same
-        # target, thus we sort them into buckets and lunch the buckets
+        # target, thus we sort them into buckets and launch the buckets
         # individually
         buckets = defaultdict(lambda: defaultdict(list))
         for pilot in pilots:
@@ -421,6 +421,13 @@ class PMGRLaunchingComponent(rpu.Component):
 
             for fname in ru.as_list(pilot['description'].get('input_staging')):
                 base = os.path.basename(fname)
+                # checking if input staging file exists
+
+                assert os.path.exists(fname) == False
+                # or raise a RuntimeException
+                if not os.path.exists(fname):
+                    raise RuntimeError('input_staging file does not exists: %s for pilot %s' % fname, pid)
+
                 ft_list.append({'src': fname,
                                 'tgt': '%s/%s' % (pid, base),
                                 'rem': False})

--- a/src/radical/pilot/pmgr/launching/base.py
+++ b/src/radical/pilot/pmgr/launching/base.py
@@ -422,9 +422,6 @@ class PMGRLaunchingComponent(rpu.Component):
             for fname in ru.as_list(pilot['description'].get('input_staging')):
                 base = os.path.basename(fname)
                 # checking if input staging file exists
-
-                assert os.path.exists(fname) == False
-                # or raise a RuntimeException
                 if not os.path.exists(fname):
                     raise RuntimeError('input_staging file does not exists: %s for pilot %s' % fname, pid)
 


### PR DESCRIPTION
The behaviour - 
This fix will stop ALL pilots on agent end, if ANY of the pilot has input staging path missing.
I understand that is the expectation, and NOT we skip that particular pilot and  ERROR log. 

Also, currently checking at pilot level only, not at task level