### PR TITLE
Fixed session cache

### DIFF
--- a/src/radical/pilot/utils/db_utils.py
+++ b/src/radical/pilot/utils/db_utils.py
@@ -1,13 +1,13 @@
 
-import os
-import json
-import time
 import datetime
+import json
+import os
+import sys
+import time
 
 import radical.utils as ru
 
-
-_CACHE_BASEDIR = '/tmp/rp_cache_%d/' % os.getuid ()
+_CACHE_BASEDIR = '/tmp/rp_cache_%d/' % os.getuid()
 
 
 # ------------------------------------------------------------------------------
@@ -57,6 +57,18 @@ def get_session_docs(sid, db=None, cachedir=None):
     # much quicker.  Also, we do cache any retrieved docs to that place, for
     # later use.  An optional cachdir parameter changes that default location
     # for lookup and storage.
+
+    if not cachedir:
+        cachedir = _CACHE_BASEDIR
+
+    cache = os.path.join(cachedir, '%s.json' % sid)
+    try:
+        if os.path.isfile(cache):
+            return ru.read_json(cache)
+    except Exception as e:
+        # continue w/o cache
+        sys.stderr.write('cannot read session cache from %s: %s\n' % (cache, e))
+
     if db:
         json_data = dict()
         # convert bson to json, i.e. serialize the ObjectIDs into strings.
@@ -70,9 +82,9 @@ def get_session_docs(sid, db=None, cachedir=None):
             raise ValueError ('no session %s in db' % sid)
     else:
         import glob
-        path = "%s/rp.session.*.json" % os.path.abspath(sid)
+        path = '%s/rp.session.*.json' % os.path.abspath(sid)
         session_json = glob.glob(path)[0]
-        with open(session_json, 'r', encoding='utf8') as f:
+        with ru.ru_open(session_json, 'r') as f:
             json_data = json.load(f)
 
     # we want to add a list of handled tasks to each pilot doc
@@ -88,9 +100,9 @@ def get_session_docs(sid, db=None, cachedir=None):
     # if we got here, we did not find a cached version -- thus add this dataset
     # to the cache
     try:
-        os.system ('mkdir -p %s' % cachedir)
-        ru.write_json (json_data, "%s/%s.json" % (cachedir, sid))
-    except Exception:
+        os.system('mkdir -p %s' % cachedir)
+        ru.write_json(json_data, cache)
+    except:
         # we can live without cache, no problem...
         pass
 

--- a/src/radical/pilot/utils/db_utils.py
+++ b/src/radical/pilot/utils/db_utils.py
@@ -82,8 +82,9 @@ def get_session_docs(sid, db=None, cachedir=None):
             raise ValueError ('no session %s in db' % sid)
     else:
         import glob
-        path = '%s/rp.session.*.json' % os.path.abspath(sid)
-        session_json = glob.glob(path)[0]
+        jsons = glob.glob('%s/r[ep].session.*.json' % os.path.abspath(sid))
+        assert jsons, 'session docs missed, check <sid>/<sid>.json'
+        session_json = jsons[0]
         with ru.ru_open(session_json, 'r') as f:
             json_data = json.load(f)
 

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,20 +1,16 @@
-#!/usr/bin/env python3
+# pylint: disable=protected-access, unused-argument, no-value-for-parameter
+
+import glob
+import os
+import shutil
 
 from unittest import TestCase
 
-import radical.utils       as ru
-import radical.pilot       as rp
+import radical.utils        as ru
+import radical.pilot.states as rps
 
-from radical.pilot import states as s
-
-from radical.pilot.utils.prof_utils import _expand_sduration, _convert_sdurations
-
-
-# ------------------------------------------------------------------------------
-#
-# Helper for the `load_class` test
-#
-class Foo(rp.PilotDescription): pass
+import radical.pilot.utils.db_utils   as rpu_db
+import radical.pilot.utils.prof_utils as rpu_prof
 
 
 # ------------------------------------------------------------------------------
@@ -23,67 +19,119 @@ class TestUtils(TestCase):
 
     # --------------------------------------------------------------------------
     #
+    @classmethod
+    def tearDownClass(cls):
+        for p in ['./rp.session.*', '/tmp/rp_cache_*']:
+            for d in glob.glob(p):
+                if os.path.isdir(d):
+                    try:
+                        shutil.rmtree(d)
+                    except OSError as e:
+                        print('[ERROR] %s - %s' % (e.filename, e.strerror))
+
+    # --------------------------------------------------------------------------
+    #
     def test_expand_sduration(self):
 
-        duration_0 = {'STATE': s.NEW}
+        duration_0 = {'STATE': rps.NEW}
         duration_1 = {'EVENT': 'event_name'}
         duration_2 = {'MSG': 'message_name'}
         duration_3 = {ru.EVENT: 'arbitrary', ru.STATE: 'arbitrary'}
         duration_4 = {'X': 'arbitrary'}
         duration_5 = {'X': 'arbitrary', 'Y': 'arbitrary', 'Z': 'arbitrary'}
 
-        self.assertEqual(_expand_sduration(duration_0),
-            {ru.EVENT: 'state', ru.STATE: s.NEW})
-        self.assertEqual(_expand_sduration(duration_1),
+        self.assertEqual(
+            rpu_prof._expand_sduration(duration_0),
+            {ru.EVENT: 'state', ru.STATE: rps.NEW})
+        self.assertEqual(
+            rpu_prof._expand_sduration(duration_1),
             {ru.EVENT: 'event_name', ru.STATE: None})
-        self.assertEqual(_expand_sduration(duration_2),
+        self.assertEqual(
+            rpu_prof._expand_sduration(duration_2),
             {ru.EVENT: 'cmd', ru.MSG: 'message_name'})
-        self.assertEqual(_expand_sduration(duration_3),
+        self.assertEqual(
+            rpu_prof._expand_sduration(duration_3),
             {ru.EVENT: 'arbitrary', ru.STATE: 'arbitrary'})
         with self.assertRaises(Exception):
-            _expand_sduration(duration_4)
+            rpu_prof._expand_sduration(duration_4)
         with self.assertRaises(Exception):
-            _expand_sduration(duration_5)
+            rpu_prof._expand_sduration(duration_5)
 
-
-    # ------------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     #
     def test_convert_sdurations(self):
 
-        durations_0 = {'name_of_duration': [{'STATE': s.NEW},
+        durations_0 = {'name_of_duration': [{'STATE': rps.NEW},
                                             {'EVENT': 'event_name'}]}
-        durations_1 = {'name_of_duration': [{'STATE': s.NEW},
+        durations_1 = {'name_of_duration': [{'STATE': rps.NEW},
                                             [{'EVENT': 'event_name'},
-                                             {'STATE': s.NEW}]]}
-        durations_2 = {'name_of_duration': [{'STATE': s.NEW},
+                                             {'STATE': rps.NEW}]]}
+        durations_2 = {'name_of_duration': [{'STATE': rps.NEW},
                                             {'MSG': 'message_name'}]}
         durations_3 = {'name_of_duration': [{ru.EVENT: 'arbitrary',
                                              ru.STATE: 'arbitrary'},
                                             {ru.EVENT: 'arbitrary',
                                              ru.STATE: 'arbitrary'}]}
 
-        self.assertEqual(_convert_sdurations(durations_0),
+        self.assertEqual(
+            rpu_prof._convert_sdurations(durations_0),
             {'name_of_duration': [{ru.EVENT: 'state',
-                                   ru.STATE: s.NEW},
+                                   ru.STATE: rps.NEW},
                                   {ru.EVENT: 'event_name',
                                    ru.STATE: None}]})
-        self.assertEqual(_convert_sdurations(durations_1),
+        self.assertEqual(
+            rpu_prof._convert_sdurations(durations_1),
             {'name_of_duration': [{ru.EVENT: 'state',
-                                   ru.STATE: s.NEW},
+                                   ru.STATE: rps.NEW},
                                   [{ru.EVENT: 'event_name',
                                     ru.STATE: None},
                                    {ru.EVENT: 'state',
-                                    ru.STATE: s.NEW}]]})
-        self.assertEqual(_convert_sdurations(durations_2),
+                                    ru.STATE: rps.NEW}]]})
+        self.assertEqual(
+            rpu_prof._convert_sdurations(durations_2),
             {'name_of_duration': [{ru.EVENT: 'state',
-                                   ru.STATE: s.NEW},
+                                   ru.STATE: rps.NEW},
                                   {ru.EVENT: 'cmd',
                                    ru.MSG: 'message_name'}]})
-        self.assertEqual(_convert_sdurations(durations_3),
+        self.assertEqual(
+            rpu_prof._convert_sdurations(durations_3),
             {'name_of_duration': [{ru.EVENT: 'arbitrary',
                                    ru.STATE: 'arbitrary'},
                                   {ru.EVENT: 'arbitrary',
                                    ru.STATE: 'arbitrary'}]})
+
+    # --------------------------------------------------------------------------
+    #
+    def test_get_session_docs(self):
+
+        with self.assertRaises(AssertionError):
+            rpu_db.get_session_docs('unknown_sid', db=None, cachedir=None)
+
+        sid = 'rp.session.0000'
+        ru.rec_makedir(sid)
+
+        session_json = {
+            'pilot': [{'uid': 'pilot.0000'}],
+            'task' : [{'uid': 'task.0000', 'pilot': 'pilot.0000'}]
+        }
+        session_file = os.path.join(os.path.abspath(sid), sid + '.json')
+        ru.write_json(session_json, session_file)
+        self.assertTrue(os.path.exists(session_file))
+
+        cache = os.path.join(rpu_db._CACHE_BASEDIR, '%s.json' % sid)
+
+        # no cache dir and no cache file
+        self.assertFalse(os.path.exists(rpu_db._CACHE_BASEDIR))
+        self.assertFalse(os.path.exists(cache))
+
+        json_data = rpu_db.get_session_docs(sid, db=None, cachedir=None)
+
+        # cache file was created
+        self.assertTrue(os.path.isfile(cache))
+        self.assertEqual(json_data, ru.read_json(cache))
+
+        # read from cache
+        self.assertEqual(json_data, rpu_db.get_session_docs(sid))
 
 
 # ------------------------------------------------------------------------------
@@ -93,6 +141,7 @@ if __name__ == '__main__':
     tc = TestUtils()
     tc.test_convert_sdurations()
     tc.test_expand_sduration()
+    tc.test_get_session_docs()
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Issue related to the method `rp.utils.db_utils.get_session_docs` - if `cachedir` is not provided, then `None` directory is created (within the directory where RP/RE is launched) with session json-data