### PR TITLE
Removed duplication call for `stop` method (`Agent_0`)

### DIFF
--- a/src/radical/pilot/agent/agent_0.py
+++ b/src/radical/pilot/agent/agent_0.py
@@ -577,8 +577,6 @@ class Agent_0(rpu.Worker):
                 self.publish(rpc.CONTROL_PUBSUB, {'cmd' : 'terminate',
                                                   'arg' : None})
                 self._final_cause = 'cancel'
-                self.stop()
-
                 return False  # we are done
 
             elif cmd == 'cancel_tasks':


### PR DESCRIPTION
When command `cancel_pilot` is received (from client side), it triggers command `terminate` for agent's components (including `Agent_0`), which is received by method `rpu.Component._cancel_monitor_cb` and which calls method `rpu.Component.stop`