### PR TITLE
interactive bridges2

### DIFF
--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -321,12 +321,12 @@
         "notes"                       : "Always set the ``project`` attribute in the PilotDescription.",
         "schemas"                     : ["local", "interactive", "gsissh", "ssh"],
       # "mandatory_args"              : [],
-        "local"                      :
+        "local"                       :
         {
             "job_manager_endpoint"    : "slurm://bridges2.psc.xsede.org/",
             "filesystem_endpoint"     : "file://bridges2.psc.xsede.org/"
         },
-        "interactive"
+        "interactive"                 :
         {
             "job_manager_endpoint"    : "fork://bridges2.psc.xsede.org/",
             "filesystem_endpoint"     : "file://bridges2.psc.xsede.org/"

--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -328,8 +328,8 @@
         },
         "interactive"                 :
         {
-            "job_manager_endpoint"    : "fork://bridges2.psc.xsede.org/",
-            "filesystem_endpoint"     : "file://bridges2.psc.xsede.org/"
+            "job_manager_endpoint"    : "fork://localhost/",
+            "filesystem_endpoint"     : "file://localhost/"
         },
         "gsissh"                      :
         {

--- a/src/radical/pilot/configs/resource_xsede.json
+++ b/src/radical/pilot/configs/resource_xsede.json
@@ -319,11 +319,16 @@
     "bridges2": {
         "description"                 : "The XSEDE 'Bridges2' cluster at PSC (https://portal.xsede.org/psc-bridges/).",
         "notes"                       : "Always set the ``project`` attribute in the PilotDescription.",
-        "schemas"                     : ["local", "gsissh", "ssh"],
+        "schemas"                     : ["local", "interactive", "gsissh", "ssh"],
       # "mandatory_args"              : [],
         "local"                      :
         {
             "job_manager_endpoint"    : "slurm://bridges2.psc.xsede.org/",
+            "filesystem_endpoint"     : "file://bridges2.psc.xsede.org/"
+        },
+        "interactive"
+        {
+            "job_manager_endpoint"    : "fork://bridges2.psc.xsede.org/",
             "filesystem_endpoint"     : "file://bridges2.psc.xsede.org/"
         },
         "gsissh"                      :


### PR DESCRIPTION
This PR adds the `interactive` entry to XSEDE-Bridges2 resource config.