### PR TITLE
Split LMs for Summit among dedicated configurations 

### DIFF
--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -136,8 +136,55 @@
         "agent_scheduler"             : "CONTINUOUS",
         "agent_spawner"               : "POPEN",
         "launch_methods"              : {
-                                         "order" : ["MPIRUN", "JSRUN"],
-                                         "MPIRUN": {},
+                                         "order" : ["MPIRUN"],
+                                         "MPIRUN": {}
+                                        },
+        "pre_bootstrap_0"             : [
+                                         "module unload py-pip",
+                                         "module unload py-virtualenv",
+                                         "module unload py-setuptools",
+                                         "module unload xl",
+                                         "module unload xalt",
+                                         "module load   gcc/9.1.0",
+                                         "module load   libzmq/4.3.3",
+                                         "module load   python/3.7-anaconda3"
+                                        ],
+        "pre_bootstrap_1"             : ["module load   gcc/9.1.0",
+                                         "module load   libzmq/4.3.3",
+                                         "module load   python/3.7-anaconda3",
+                                         "ulimit -u 65536"
+                                        ],
+        "default_remote_workdir"      : "$MEMBERWORK/%(pd.project)s",
+        "python_dist"                 : "default",
+        "virtenv_dist"                : "default",
+        "virtenv_mode"                : "create",
+        "rp_version"                  : "local",
+        "cores_per_node"              : 42,
+        "gpus_per_node"               : 6,
+        "blocked_cores"               : [],
+        "blocked_gpus"                : [],
+        "lfs_path_per_node"           : "/tmp",
+        "lfs_size_per_node"           : 0,
+        "system_architecture"         : {"smt": 1,
+                                         "options": ["gpumps", "nvme"]}
+    },
+
+    "summit_jsrun": {
+        "description"                 : "4608 nodes with 2 IBM POWER9 CPUs and 6 NVIDIA Volta V100 GPUs",
+        "notes"                       : "Requires RSA SecurID and uses local virtual env",
+        "schemas"                     : ["local"],
+        "local"                       : {
+            "job_manager_hop"         : "fork://localhost/",
+            "job_manager_endpoint"    : "lsf://localhost/",
+            "filesystem_endpoint"     : "file://localhost/"
+        },
+        "default_queue"               : "batch",
+        "resource_manager"            : "LSF",
+        "agent_config"                : "default",
+        "agent_scheduler"             : "CONTINUOUS",
+        "agent_spawner"               : "POPEN",
+        "launch_methods"              : {
+                                         "order" : ["JSRUN"],
                                          "JSRUN" : {
                                              "pre_exec_cached": [
                                                # "module unload xl",

--- a/tests/unit_tests/test_launcher/test_launcher.py
+++ b/tests/unit_tests/test_launcher/test_launcher.py
@@ -1,8 +1,5 @@
 # pylint: disable=protected-access, no-value-for-parameter, unused-argument
 
-__copyright__ = "Copyright 2020, http://radical.rutgers.edu"
-__license__   = "MIT"
-
 import os
 
 from unittest import TestCase
@@ -145,10 +142,13 @@ class TestLauncher(TestCase):
         # default value is {}
         self.assertEqual(pilot['jd_dict'].system_architecture, {})
 
-        # value for "ornl.summit" is 4
-        resource = 'ornl.summit'
-        rcfg = configs.ornl.summit
-        component._prepare_pilot(resource, rcfg, pilot, {}, '')
+        # value for "ornl.summit" is 1 (with MPIRun LM)
+        component._prepare_pilot('ornl.summit', configs.ornl.summit,
+                                 pilot, {}, '')
+        self.assertEqual(pilot['jd_dict'].system_architecture['smt'], 1)
+        # value for "ornl.summit_jsrun" is 4 (with JSRun LM)
+        component._prepare_pilot('ornl.summit_jsrun', configs.ornl.summit_jsrun,
+                                 pilot, {}, '')
         self.assertEqual(pilot['jd_dict'].system_architecture['smt'], 4)
 
 


### PR DESCRIPTION
Configurations for Summit
- `ornl.summit` will set MPIRun LM
- `ornl.summit_jsrun` will set JSRun LM


@andre-merzky should we set `"virtenv_mode"                : "local",` for default Summit config (`ornl.summit`)?