### PR TITLE
simplify serialization code

### DIFF
--- a/src/radical/pilot/utils/serializer.py
+++ b/src/radical/pilot/utils/serializer.py
@@ -30,71 +30,38 @@ def serialize_obj(obj):
     '''
     serialize object
     '''
-    result    = None
-    exception = None
 
     if callable(obj):
         try:
-            result = dill.dumps(obj)
-        except Exception as e:
-            exception = e
-
-        # if we fail, then pikle it by reference
-        if result is None:
+            return dill.dumps(obj)
+        except:
+            # if we fail, then pickle it by reference
             # see issue: https://github.com/uqfoundation/dill/issues/128
-            try:
-                result = dill.dumps(obj, byref = True)
-            except Exception as e:
-                exception = e
+            return dill.dumps(obj, byref = True)
 
     else:
         try:
-            result = dill.dumps(obj, recurse = True)
-        except Exception as e:
-            exception = e
-
-        if result is None:
+            return dill.dumps(obj, recurse = True)
+        except:
+            # if we fail, then pickle it by reference
             # see issue: https://github.com/uqfoundation/dill/issues/128
-            try:
-                result = dill.dumps(obj, byref = True)
-            except Exception as e:
-                exception = e
-
-    if result is None:
-        raise Exception("object %s is not serializable") from exception
-
-    return  result
+            return dill.dumps(obj, byref = True)
 
 
 # ------------------------------------------------------------------------------
 #
-def serialize_file(obj):
+def serialize_file(obj, fname=None):
     '''
     serialize object to file
     '''
 
+    if not fname:
+        fname = _obj_file_path
+
     # FIXME: assign unique path and id for the pickled file
     #        to avoid overwriting to the same file
-
-    result    = None
-    exception = None
-
-    kwargs = {}
-    if not callable(obj):
-        kwargs['recurse'] = True
-
-    try:
-        with open(_obj_file_path, 'wb') as f:
-            dill.dump(obj, f, **kwargs)
-
-    except Exception as e:
-        exception = e
-
-    else:
-        result = _obj_file_path
-
-    if result is None:
-        raise Exception('object is not serializable') from exception
+    with open(fname, 'wb') as f:
+        f.write(serialize_obj(obj))
 
     return _obj_file_path
 
@@ -105,66 +72,33 @@ def deserialize_file(fname):
     '''
     Deserialize object from file
     '''
-    result = None
 
-    # check if we have a valid file
-    if not os.path.isfile(fname):
-        return None
-
-    try:
-        with open(fname, 'rb') as f:
-            result = dill.load(f)
-    except Exception as e:
-        raise Exception ("failed to deserialize object from file") from e
-
-    if result is None:
-        raise RuntimeError('failed to deserialize')
-    return result
+    with open(fname, 'rb') as f:
+        return dill.load(f)
 
 
 # ------------------------------------------------------------------------------
 #
-def deserialize_obj(obj):
+def deserialize_obj(data):
     '''
     Deserialize object from str.
-
-    Raises
-    ------
-    TypeError
-        if object cannot be deserialized.
-    ValueError
-        if no result is found.
-
     '''
-    result = None
 
-    try:
-        result = dill.loads(obj)
-    except Exception as e:
-        raise TypeError("failed to deserialize from object") from e
-
-    # Ref https://github.com/radical-cybertools/radical.pilot/pull/ \
-    #                        2615#discussion_r870356482
-    assert result is not None
-    return result
+    return dill.loads(data)
 
 
 # ------------------------------------------------------------------------------
 #
 def serialize_bson(obj):
 
-    result = codecs.encode(pickle.dumps(obj), "base64").decode()
-
-    return result
+    return codecs.encode(pickle.dumps(obj), "base64").decode()
 
 
 # ------------------------------------------------------------------------------
 #
 def deserialize_bson(obj):
 
-    result = pickle.loads(codecs.decode(obj.encode(), "base64"))
-
-    return result
+    return pickle.loads(codecs.decode(obj.encode(), "base64"))
 
 
 # ------------------------------------------------------------------------------

--- a/tests/unit_tests/test_serializer.py
+++ b/tests/unit_tests/test_serializer.py
@@ -42,15 +42,17 @@ class TestSerializer(TestCase):
 
         # raise exception
 
+        with self.assertRaises(Exception):
+            serializer.deserialize_file('test')
+
         import dill
 
         def mock_dump(*args, **kwargs):
-            raise Exception
+            raise Exception('foo')
 
-        with mock.patch.object(dill, 'dump', mock_dump):
-            with self.assertRaises(Exception) as exc:
+        with mock.patch.object(dill, 'dumps', mock_dump):
+            with self.assertRaises(Exception):
                 serializer.serialize_file('test')
-            self.assertIn('object is not serializable', str(exc.exception))
             os.unlink(_obj_file_path)
 
 


### PR DESCRIPTION
I stumbled through the (de)serialization code again.  I still think we really overcomplicate things there, so I did another attempt at simplification.  Please try to convince me where the simpler code behaves different...  Thanks for indulging me :-)