### PR TITLE
Feature/task error details

### DIFF
--- a/src/radical/pilot/agent/executing/flux.py
+++ b/src/radical/pilot/agent/executing/flux.py
@@ -239,69 +239,77 @@ class Flux(AgentExecutingComponent) :
             while not self._term.is_set():
 
                 active = False
+                tasks  = list()
+                events = list()
+
 
                 try:
                     for task in self._task_q.get_nowait():
-
-                        active = True
-                        try:
-
-                            flux_id = task['flux_id']
-                            assert flux_id not in tasks
-                            tasks[flux_id] = task
-
-                            # handle and purge cached events for that task
-                            if flux_id in events:
-                                if self.handle_events(task, events[flux_id]):
-                                    # task completed - purge data
-                                    # NOTE: this assumes events are ordered
-                                    if flux_id in events: del events[flux_id]
-                                    if flux_id in tasks : del tasks[flux_id]
-
-                        except Exception:
-
-                            self._log.exception("error collecting Task")
-                            if task['stderr'] is None:
-                                task['stderr'] = ''
-                            task['stderr'] += '\nPilot cannot collect task:\n'
-                            task['stderr'] += '\n'.join(ru.get_exception_trace())
-
-                            # can't rely on the executor base to free the task resources
-                            self._prof.prof('unschedule_start', uid=task['uid'])
-                            self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
-
-                            self.advance(task, rps.FAILED, publish=True, push=False)
+                        tasks.append(task)
 
                 except queue.Empty:
                     # nothing found -- no problem, check if we got some events
                     pass
 
-                try:
+                for task in tasks:
 
-                    for event in self._event_q.get_nowait():
+                    active = True
+                    try:
 
-                        flux_id = event[0]  # event: flux_id, flux_state
+                        flux_id = task['flux_id']
+                        assert flux_id not in tasks
+                        tasks[flux_id] = task
 
-                        if flux_id in tasks:
-
-                            # known task - handle events
-                            if self.handle_events(tasks[flux_id], [event]):
+                        # handle and purge cached events for that task
+                        if flux_id in events:
+                            if self.handle_events(task, events[flux_id]):
                                 # task completed - purge data
                                 # NOTE: this assumes events are ordered
                                 if flux_id in events: del events[flux_id]
                                 if flux_id in tasks : del tasks[flux_id]
 
-                        else:
-                            # unknown task, store events for later
-                            if flux_id not in events:
-                                events[flux_id] = list()
-                            events[flux_id].append(event)
+                    except Exception as e:
 
-                    active = True
+                        self._log.exception("error collecting Task")
+                        task['exception']        = repr(e)
+                        task['exception_detail'] = \
+                                         '\n'.join(ru.get_exception_trace())
 
+                        # can't rely on the executor base to free the
+                        # task resources
+                        self._prof.prof('unschedule_start', uid=task['uid'])
+                        self.publish(rpc.AGENT_UNSCHEDULE_PUBSUB, task)
+
+                        self.advance(task, rps.FAILED, publish=True, push=False)
+
+
+                try:
+                    for event in self._event_q.get_nowait():
+                        events.append(event)
                 except queue.Empty:
                     # nothing found -- no problem, check if we got some tasks
                     pass
+
+                for event in events:
+
+                    active = True
+                    flux_id = event[0]  # event: flux_id, flux_state
+
+                    if flux_id in tasks:
+
+                        # known task - handle events
+                        if self.handle_events(tasks[flux_id], [event]):
+                            # task completed - purge data
+                            # NOTE: this assumes events are ordered
+                            if flux_id in events: del events[flux_id]
+                            if flux_id in tasks : del tasks[flux_id]
+
+                    else:
+                        # unknown task, store events for later
+                        if flux_id not in events:
+                            events[flux_id] = list()
+                        events[flux_id].append(event)
+
 
                 if not active:
                     time.sleep(0.01)

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -102,16 +102,10 @@ class Popen(AgentExecutingComponent):
                 self._prof.prof('task_start', uid=task['uid'])
                 self._handle_task(task)
 
-            except Exception:
-                # append the startup error to the tasks stderr.  This is
-                # not completely correct (as this text is not produced
-                # by the task), but it seems the most intuitive way to
-                # communicate that error to the application/user.
+            except Exception as e:
                 self._log.exception("error running Task")
-                if task['stderr'] is None:
-                    task['stderr'] = ''
-                task['stderr'] += '\nPilot cannot start task:\n'
-                task['stderr'] += '\n'.join(ru.get_exception_trace())
+                task['exception']        = repr(e)
+                task['exception_detail'] = ru.get_exception_trace()
 
                 # can't rely on the executor base to free the task resources
                 self._prof.prof('unschedule_start', uid=task['uid'])
@@ -489,7 +483,9 @@ class Popen(AgentExecutingComponent):
 
                 if exit_code != 0:
                     # The task failed - fail after staging output
-                    task['target_state'] = rps.FAILED
+                    task['exception']        = 'RuntimeError("non-zero exit code")'
+                    task['exception_detail'] = 'exit code: %s' % exit_code
+                    task['target_state'    ] = rps.FAILED
 
                 else:
                     # The task finished cleanly, see if we need to deal with

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -105,7 +105,7 @@ class Popen(AgentExecutingComponent):
             except Exception as e:
                 self._log.exception("error running Task")
                 task['exception']        = repr(e)
-                task['exception_detail'] = ru.get_exception_trace()
+                task['exception_detail'] = '\n'.join(ru.get_exception_trace())
 
                 # can't rely on the executor base to free the task resources
                 self._prof.prof('unschedule_start', uid=task['uid'])

--- a/src/radical/pilot/agent/executing/sleep.py
+++ b/src/radical/pilot/agent/executing/sleep.py
@@ -71,16 +71,10 @@ class Sleep(AgentExecutingComponent) :
                 self._prof.prof('task_start', uid=task['uid'])
                 self._handle_task(task)
 
-            except Exception:
-                # append the startup error to the tasks stderr.  This is
-                # not completely correct (as this text is not produced
-                # by the task), but it seems the most intuitive way to
-                # communicate that error to the application/user.
+            except Exception as e:
                 self._log.exception("error running Task")
-                if task['stderr'] is None:
-                    task['stderr'] = ''
-                task['stderr'] += '\nPilot cannot start task:\n'
-                task['stderr'] += '\n'.join(ru.get_exception_trace())
+                task['exception']        = repr(e)
+                task['exception_detail'] = ru.get_exception_trace()
 
                 # can't rely on the executor base to free the task resources
                 self._prof.prof('unschedule_start', uid=task['uid'])

--- a/src/radical/pilot/agent/executing/sleep.py
+++ b/src/radical/pilot/agent/executing/sleep.py
@@ -74,7 +74,7 @@ class Sleep(AgentExecutingComponent) :
             except Exception as e:
                 self._log.exception("error running Task")
                 task['exception']        = repr(e)
-                task['exception_detail'] = ru.get_exception_trace()
+                task['exception_detail'] = '\n'.join(ru.get_exception_trace())
 
                 # can't rely on the executor base to free the task resources
                 self._prof.prof('unschedule_start', uid=task['uid'])

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -5,7 +5,6 @@ __license__   = 'MIT'
 import copy
 import time
 import queue
-import pprint
 
 import threading          as mt
 import multiprocessing    as mp

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -372,6 +372,11 @@ class AgentSchedulingComponent(rpu.Component):
                     del self._raptor_tasks[name]
 
                     self._log.debug('fail %d tasks: %d', len(tasks), name)
+
+                    for task in tasks:
+                        task['exception']        = 'RuntimeError("raptor gone")'
+                        task['exception_detail'] = 'raptor queue disappeared'
+
                     self.advance(tasks, state=rps.FAILED,
                                         publish=True, push=False)
 
@@ -853,10 +858,11 @@ class AgentSchedulingComponent(rpu.Component):
 
             except Exception as e:
 
-                task['stderr']       = str(e)
-                task['control']      = 'tmgr_pending'
-                task['target_state'] = 'FAILED'
-                task['$all']         = True
+                task['control']          = 'tmgr_pending'
+                task['exception']        = repr(e)
+                task['exception_detail'] = ru.get_exception_trace()
+                task['target_state']     = 'FAILED'
+                task['$all']             = True
 
                 self._log.exception('scheduling failed for %s', task['uid'])
 
@@ -985,37 +991,39 @@ class AgentSchedulingComponent(rpu.Component):
         attempt to allocate cores/gpus for a specific task.
         '''
 
-        uid = task['uid']
-      # td  = task['description']
+        try:
+            uid = task['uid']
+          # td  = task['description']
 
-      # self._prof.prof('schedule_try', uid=uid)
-        slots = self.schedule_task(task)
-        if not slots:
+          # self._prof.prof('schedule_try', uid=uid)
+            slots = self.schedule_task(task)
+            if not slots:
 
-            # schedule failure
-          # self._prof.prof('schedule_fail', uid=uid)
+                # schedule failure
+              # self._prof.prof('schedule_fail', uid=uid)
 
-            # if schedule fails while no other task is scheduled, then the
-            # `schedule_task` will never be able to succeed - fail that task
-            if self._active_cnt == 0:
-                self._log.error('task cannot be scheduled ever: %s',
-                        pprint.pformat(task['description']))
-                raise RuntimeError('insufficient resources')
+                # if schedule fails while no other task is scheduled, then the
+                # `schedule_task` will never be able to succeed - fail that task
+                if self._active_cnt == 0:
+                    raise RuntimeError('insufficient resources')
 
-            return False
+            self._active_cnt += 1
 
-        self._active_cnt += 1
+            # the task was placed, we need to reflect the allocation in the
+            # nodelist state (BUSY) and pass placement to the task, to have
+            # it enacted by the executor
+            self._change_slot_states(slots, rpc.BUSY)
+            task['slots'] = slots
 
-        # the task was placed, we need to reflect the allocation in the
-        # nodelist state (BUSY) and pass placement to the task, to have
-        # it enacted by the executor
-        self._change_slot_states(slots, rpc.BUSY)
-        task['slots'] = slots
+            self.slot_status('after scheduled task', task['uid'])
 
-        self.slot_status('after scheduled task', task['uid'])
+            # got an allocation, we can go off and launch the process
+            self._prof.prof('schedule_ok', uid=uid)
 
-        # got an allocation, we can go off and launch the process
-        self._prof.prof('schedule_ok', uid=uid)
+        except Exception as e:
+            task['exception']        = repr(e)
+            task['exception_detail'] = ru.get_exception_trace()
+            raise
 
         return True
 

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -713,7 +713,8 @@ class AgentSchedulingComponent(rpu.Component):
       #                                           len(unscheduled), len(failed))
 
         for task, error in failed:
-            task['exception']    = 'RuntimeError(%s)' % error
+            error                = error.replace('"', '\\"')
+            task['exception']    = 'RuntimeError("%s")' % error
             task['control']      = 'tmgr_pending'
             task['target_state'] = 'FAILED'
             task['$all']         = True

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -714,7 +714,7 @@ class AgentSchedulingComponent(rpu.Component):
       #                                           len(unscheduled), len(failed))
 
         for task, error in failed:
-            task['stderr']       = error
+            task['exception']    = 'RuntimeError(%s)' % error
             task['control']      = 'tmgr_pending'
             task['target_state'] = 'FAILED'
             task['$all']         = True

--- a/src/radical/pilot/agent/scheduler/base.py
+++ b/src/radical/pilot/agent/scheduler/base.py
@@ -860,7 +860,7 @@ class AgentSchedulingComponent(rpu.Component):
 
                 task['control']          = 'tmgr_pending'
                 task['exception']        = repr(e)
-                task['exception_detail'] = ru.get_exception_trace()
+                task['exception_detail'] = '\n'.join(ru.get_exception_trace())
                 task['target_state']     = 'FAILED'
                 task['$all']             = True
 
@@ -1005,7 +1005,9 @@ class AgentSchedulingComponent(rpu.Component):
                 # if schedule fails while no other task is scheduled, then the
                 # `schedule_task` will never be able to succeed - fail that task
                 if self._active_cnt == 0:
-                    raise RuntimeError('insufficient resources')
+                    raise RuntimeError('task can never be scheduled')
+
+                return False
 
             self._active_cnt += 1
 
@@ -1022,7 +1024,7 @@ class AgentSchedulingComponent(rpu.Component):
 
         except Exception as e:
             task['exception']        = repr(e)
-            task['exception_detail'] = ru.get_exception_trace()
+            task['exception_detail'] = '\n'.join(ru.get_exception_trace())
             raise
 
         return True

--- a/src/radical/pilot/agent/staging_output/default.py
+++ b/src/radical/pilot/agent/staging_output/default.py
@@ -113,7 +113,7 @@ class Default(AgentStagingOutputComponent):
                 self._log.exception('staging prep error')
                 task['target_state']     = rps.FAILED
                 task['exception']        = repr(e)
-                task['exception_detail'] = ru.get_exception_trace()
+                task['exception_detail'] = '\n'.join(ru.get_exception_trace())
 
 
         if no_staging_tasks:
@@ -128,7 +128,7 @@ class Default(AgentStagingOutputComponent):
                 self._log.exception('staging error')
                 task['target_state']     = rps.FAILED
                 task['exception']        = repr(e)
-                task['exception_detail'] = ru.get_exception_trace()
+                task['exception_detail'] = '\n'.join(ru.get_exception_trace())
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/agent/staging_output/default.py
+++ b/src/radical/pilot/agent/staging_output/default.py
@@ -68,52 +68,67 @@ class Default(AgentStagingOutputComponent):
 
         for task in ru.as_list(tasks):
 
-            uid = task['uid']
+            try:
+                uid = task['uid']
 
-            # From here on, any state update will hand control over to the tmgr
-            # again.  The next task update should thus push *all* task details,
-            # not only state.
-            task['$all']    = True
-            task['control'] = 'tmgr_pending'
+                # From here on, any state update will hand control over to the tmgr
+                # again.  The next task update should thus push *all* task details,
+                # not only state.
+                task['$all']    = True
+                task['control'] = 'tmgr_pending'
 
-            # we always dig for stdout/stderr
-            self._handle_task_stdio(task)
+                # we always dig for stdout/stderr
+                self._handle_task_stdio(task)
 
-            # NOTE: all tasks get here after execution, even those which did not
-            #       finish successfully.  We do that so that we can make
-            #       stdout/stderr available for failed tasks (see
-            #       _handle_task_stdio above).  But we don't need to perform any
-            #       other staging for those tasks, and in fact can make them
-            #       final.
-            if task['target_state'] != rps.DONE \
-                    and not task['description'].get('stage_on_error'):
-                task['state'] = task['target_state']
-                self._log.debug('task %s skips staging: %s', uid, task['state'])
-                no_staging_tasks.append(task)
-                continue
+                # NOTE: all tasks get here after execution, even those which did not
+                #       finish successfully.  We do that so that we can make
+                #       stdout/stderr available for failed tasks (see
+                #       _handle_task_stdio above).  But we don't need to perform any
+                #       other staging for those tasks, and in fact can make them
+                #       final.
+                if task['target_state'] != rps.DONE \
+                        and not task['description'].get('stage_on_error'):
+                    task['state'] = task['target_state']
+                    self._log.debug('task %s skips staging: %s', uid, task['state'])
+                    no_staging_tasks.append(task)
+                    continue
 
-            # check if we have any staging directives to be enacted in this
-            # component
-            actionables = list()
-            for sd in task['description'].get('output_staging', []):
-                if sd['action'] in [rpc.LINK, rpc.COPY, rpc.MOVE]:
-                    actionables.append(sd)
+                # check if we have any staging directives to be enacted in this
+                # component
+                actionables = list()
+                for sd in task['description'].get('output_staging', []):
+                    if sd['action'] in [rpc.LINK, rpc.COPY, rpc.MOVE]:
+                        actionables.append(sd)
 
-            if actionables:
-                # this task needs some staging
-                staging_tasks.append([task, actionables])
-            else:
-                # this task does not need any staging at this point, and can be
-                # advanced
-                task['state'] = rps.TMGR_STAGING_OUTPUT_PENDING
-                no_staging_tasks.append(task)
+                if actionables:
+                    # this task needs some staging
+                    staging_tasks.append([task, actionables])
+                else:
+                    # this task does not need any staging at this point, and can be
+                    # advanced
+                    task['state'] = rps.TMGR_STAGING_OUTPUT_PENDING
+                    no_staging_tasks.append(task)
+
+            except Exception as e:
+                self._log.exception('staging prep error')
+                task['target_state']     = rps.FAILED
+                task['exception']        = repr(e)
+                task['exception_detail'] = ru.get_exception_trace()
+
 
         if no_staging_tasks:
             self._advance_tasks(no_staging_tasks, rps.TMGR_STAGING_OUTPUT_PENDING,
                                 publish=True, push=True)
 
         for task, actionables in staging_tasks:
-            self._handle_task_staging(task, actionables)
+            try:
+                self._handle_task_staging(task, actionables)
+
+            except Exception as e:
+                self._log.exception('staging error')
+                task['target_state']     = rps.FAILED
+                task['exception']        = repr(e)
+                task['exception_detail'] = ru.get_exception_trace()
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/pilot_manager.py
+++ b/src/radical/pilot/pilot_manager.py
@@ -524,8 +524,10 @@ class PilotManager(rpu.Component):
                 for sd in arg['sds']:
                     uid = sd['uid']
                     if uid in self._active_sds:
-                        self._active_sds[uid]['state']     = sd['state']
-                        self._active_sds[uid]['exception'] = sd['exception']
+                        active_sd = self._active_sds[uid]
+                        active_sd['state']            = sd['state']
+                        active_sd['exception']        = sd['exception']
+                        active_sd['exception_detail'] = sd['exception_detail']
 
         return True
 

--- a/src/radical/pilot/pilot_manager.py
+++ b/src/radical/pilot/pilot_manager.py
@@ -455,8 +455,8 @@ class PilotManager(rpu.Component):
         if rps.FAILED in sd_states:
             errs = list()
             for uid in self._active_sds:
-                if self._active_sds[uid].get('error'):
-                    errs.append(self._active_sds[uid]['error'])
+                if self._active_sds[uid].get('exception'):
+                    errs.append(self._active_sds[uid]['exception'])
 
             if errs:
                 raise RuntimeError('pilot staging failed: %s' % errs)
@@ -499,8 +499,8 @@ class PilotManager(rpu.Component):
         if rps.FAILED in sd_states:
             errs = list()
             for uid in self._active_sds:
-                if self._active_sds[uid].get('error'):
-                    errs.append(self._active_sds[uid]['error'])
+                if self._active_sds[uid].get('exception'):
+                    errs.append(self._active_sds[uid]['exception'])
 
             if errs:
                 raise RuntimeError('pilot staging failed: %s' % errs)
@@ -524,8 +524,8 @@ class PilotManager(rpu.Component):
                 for sd in arg['sds']:
                     uid = sd['uid']
                     if uid in self._active_sds:
-                        self._active_sds[uid]['state'] = sd['state']
-                        self._active_sds[uid]['error'] = sd['error']
+                        self._active_sds[uid]['state']     = sd['state']
+                        self._active_sds[uid]['exception'] = sd['exception']
 
         return True
 

--- a/src/radical/pilot/pmgr/launching/base.py
+++ b/src/radical/pilot/pmgr/launching/base.py
@@ -1104,8 +1104,12 @@ class PMGRLaunchingComponent(rpu.Component):
 
             with self._sds_lock:
                 for sd in arg['sds']:
-                    if sd['uid'] in self._active_sds:
-                        self._active_sds[sd['uid']]['state'] = sd['state']
+                    uid = sd['uid']
+                    if uid in self._active_sds:
+                        active_sd = self._active_sds[uid]
+                        active_sd['state']            = sd['state']
+                        active_sd['exception']        = sd['exception']
+                        active_sd['exception_detail'] = sd['exception_detail']
 
         return True
 

--- a/src/radical/pilot/pmgr/launching/psi_j.py
+++ b/src/radical/pilot/pmgr/launching/psi_j.py
@@ -159,8 +159,6 @@ class PilotLauncherPSIJ(PilotLauncherBase):
             attr.project_name   = proj
             attr.reservation_id = res
 
-            self._log.debug('=== rt: %s', jd.runtime)
-
             spec = psij.JobSpec()
             spec.attributes  = attr
             spec.executable  = jd.executable

--- a/src/radical/pilot/raptor/worker_default.py
+++ b/src/radical/pilot/raptor/worker_default.py
@@ -11,7 +11,8 @@ import multiprocessing   as mp
 
 import radical.utils     as ru
 
-from .worker import Worker
+from .worker  import Worker
+from ..states import FAILED
 
 
 # ------------------------------------------------------------------------------
@@ -569,12 +570,10 @@ class DefaultWorker(Worker):
                 # free resources again for failed task
                 self._dealloc(task)
 
-                res = {'req': task['uid'],
-                       'out': None,
-                       'err': 'req_cb error: %s' % e,
-                       'ret': 1}
+                task['exception']        = repr(e)
+                task['exception_detail'] = ru.get_exception_trace()
 
-                self._res_put.put(res)
+                self._res_put.put(task)
 
 
     # --------------------------------------------------------------------------
@@ -608,8 +607,17 @@ class DefaultWorker(Worker):
                 os.environ['CUDA_VISIBLE_DEVICES'] = \
                              ','.join(str(i) for i in task['slots']['gpus'])
 
-            out, err, ret, val = self._modes[mode](task.get('data'))
-            res = [task, str(out), str(err), int(ret), val]
+            out = None
+            err = None
+            ret = 1
+            val = None
+            exc = [None, None]
+            try:
+                out, err, ret, val = self._modes[mode](task.get('data'))
+            except Exception as e:
+                exc = [repr(e), ru.get_exception_trace()]
+
+            res = [task, str(out), str(err), int(ret), val, exc]
 
             with res_lock:
                 self._result_queue.put(res)
@@ -625,13 +633,6 @@ class DefaultWorker(Worker):
             tout = task.get('timeout')
             self._log.debug('dispatch with tout %s', tout)
 
-          # result = self._modes[mode](task.get('data'))
-          # self._log.debug('got result: task %s: %s', task['uid'], result)
-          # out, err, ret, val = result
-          # # TODO: serialize `val`?
-          # res = [task, str(out), str(err), int(ret), val]
-          # self._result_queue.put(res)
-
             res_lock = mp.Lock()
             dispatcher = mp.Process(target=_dispatch_proc, args=(res_lock,))
             dispatcher.daemon = True
@@ -645,7 +646,9 @@ class DefaultWorker(Worker):
                     out = None
                     err = 'timeout (>%s)' % tout
                     ret = 1
-                    res = [task, str(out), str(err), int(ret), None]
+                    val = None
+                    exc = ['TimeoutError("task timed out")', None]
+                    res = [task, str(out), str(err), int(ret), val, exc]
                     self._log.debug('put 2 result: task %s', task['uid'])
                     self._result_queue.put(res)
                     self._log.debug('dispatcher killed: %s', task['uid'])
@@ -656,7 +659,9 @@ class DefaultWorker(Worker):
             out = None
             err = 'dispatch failed: %s' % e
             ret = 1
-            res = [task, str(out), str(err), int(ret), None]
+            val = None
+            exc = [repr(e), ru.get_exception_trace()]
+            res = [task, str(out), str(err), int(ret), val, exc]
             self._log.debug('put 3 result: task %s', task['uid'])
             self._result_queue.put(res)
 
@@ -696,31 +701,26 @@ class DefaultWorker(Worker):
     #
     def _result_cb(self, result):
 
-        try:
-            task, out, err, ret, val = result
-            self._log.debug('result cb: task %s', task['uid'])
+        task, out, err, ret, val, exc = result
+        self._log.debug('result cb: task %s', task['uid'])
 
-            with self._plock:
-                pid  = task['pid']
-                del self._pool[pid]
+        with self._plock:
+            pid  = task['pid']
+            del self._pool[pid]
 
-            # free resources again for the task
-            self._dealloc(task)
+        # free resources again for the task
+        self._dealloc(task)
 
-            res = {'req': task['uid'],
-                   'out': out,
-                   'err': err,
-                   'ret': ret,
-                   'val': val}
+        task['stdout']           = out
+        task['stderr']           = err
+        task['exit_code']        = ret
+        task['return_value']     = val
+        task['exception']        = exc[0]
+        task['exception_detail'] = exc[1]
 
-            self._res_put.put(res)
-            self.task_post_exec(task)
-            self._prof.prof('req_stop', uid=task['uid'], msg=self._uid)
-
-        except:
-            self._log.exception('result cb failed')
-            raise
-
+        self._res_put.put(task)
+        self.task_post_exec(task)
+        self._prof.prof('req_stop', uid=task['uid'], msg=self._uid)
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/raptor/worker_default.py
+++ b/src/radical/pilot/raptor/worker_default.py
@@ -571,7 +571,7 @@ class DefaultWorker(Worker):
                 self._dealloc(task)
 
                 task['exception']        = repr(e)
-                task['exception_detail'] = ru.get_exception_trace()
+                task['exception_detail'] = '\n'.join(ru.get_exception_trace())
 
                 self._res_put.put(task)
 
@@ -615,7 +615,7 @@ class DefaultWorker(Worker):
             try:
                 out, err, ret, val = self._modes[mode](task.get('data'))
             except Exception as e:
-                exc = [repr(e), ru.get_exception_trace()]
+                exc = [repr(e), '\n'.join(ru.get_exception_trace())]
 
             res = [task, str(out), str(err), int(ret), val, exc]
 
@@ -660,7 +660,7 @@ class DefaultWorker(Worker):
             err = 'dispatch failed: %s' % e
             ret = 1
             val = None
-            exc = [repr(e), ru.get_exception_trace()]
+            exc = [repr(e), '\n'.join(ru.get_exception_trace())]
             res = [task, str(out), str(err), int(ret), val, exc]
             self._log.debug('put 3 result: task %s', task['uid'])
             self._result_queue.put(res)

--- a/src/radical/pilot/raptor/worker_default.py
+++ b/src/radical/pilot/raptor/worker_default.py
@@ -12,7 +12,6 @@ import multiprocessing   as mp
 import radical.utils     as ru
 
 from .worker  import Worker
-from ..states import FAILED
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/pilot/raptor/worker_mpi.py
+++ b/src/radical/pilot/raptor/worker_mpi.py
@@ -261,7 +261,8 @@ class _TaskPuller(mt.Thread):
 
                     except Exception as e:
                         self._log.exception('failed to place task')
-                        task['error'] = str(e)
+                        task['exception']        = repr(e)
+                        task['exception_detail'] = ru.get_exception_trace()
                         worker_result_q.put(task)
 
         except:
@@ -472,20 +473,22 @@ class _Worker(mt.Thread):
                         out, err, ret, val, exc = self._dispatch(task)
                         self._prof.prof('exec_stop', uid=uid)
 
-                        task['error']        = None
-                        task['stdout']       = out
-                        task['stderr']       = err
-                        task['exit_code']    = ret
-                        task['return_value'] = val
-                        task['exception']    = exc
+                        task['error']            = None
+                        task['stdout']           = out
+                        task['stderr']           = err
+                        task['exit_code']        = ret
+                        task['return_value']     = val
+                        task['exception']        = exc[0]
+                        task['exception_detail'] = exc[1]
 
                     except Exception as e:
-                        task['error']        = repr(e)
-                        task['stdout']       = ''
-                        task['stderr']       = str(e)
-                        task['exit_code']    = -1
-                        task['return_value'] = None
-                        task['exception']    = [e.__class__.__name__, str(e)]
+                        task['error']            = repr(e)
+                        task['stdout']           = ''
+                        task['stderr']           = str(e)
+                        task['exit_code']        = -1
+                        task['return_value']     = None
+                        task['exception']        = repr(e)
+                        task['exception_detail'] = ru.get_exception_trace()
                         self._log.exception('recv err  %s  to  0' % (task['uid']))
 
                     finally:
@@ -542,7 +545,7 @@ class _Worker(mt.Thread):
             err = 'MPI setup failed'
             ret = 1
             val = None
-            exc = None
+            exc = (None, None)
             return out, err, ret, val, exc
 
         task['description']['environment']['RP_RANK']   = str(comm.rank)
@@ -609,7 +612,7 @@ class _Worker(mt.Thread):
         kwargs  = task['description'].get('kwargs', {})
         py_func = False
 
-        self._log.debug('=== orig args: %s : %s', args, kwargs)
+        self._log.debug('orig args: %s : %s', args, kwargs)
 
         # check if we have a serialized object
         self._log.debug('func serialized: %d: %s', len(func), func)
@@ -693,12 +696,12 @@ class _Worker(mt.Thread):
             sys.stderr = strerr = io.StringIO()
 
             self._prof.prof('rank_start', uid=uid)
-            self._log.debug('=== to call %s: %s : %s', to_call, args, kwargs)
+            self._log.debug('to call %s: %s : %s', to_call, args, kwargs)
             val = to_call(*args, **kwargs)
             self._prof.prof('rank_stop', uid=uid)
             out = strout.getvalue()
             err = strerr.getvalue()
-            exc = None
+            exc = (None, None)
             ret = 0
 
         except Exception as e:
@@ -706,7 +709,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\ncall failed: %s' % e)
-            exc = ru.get_exception_trace()
+            exc = (repr(e), ru.get_exception_trace())
             ret = 1
 
         finally:
@@ -726,7 +729,7 @@ class _Worker(mt.Thread):
 
             os.environ = old_env
 
-        self._log.debug('=== %s: got %s', uid, out)
+        self._log.debug('%s: got %s', uid, out)
 
         return out, err, ret, val, exc
 
@@ -766,7 +769,7 @@ class _Worker(mt.Thread):
             self._prof.prof('rank_stop', uid=uid)
             out = strout.getvalue()
             err = strerr.getvalue()
-            exc = None
+            exc = (None, None)
             ret = 0
 
         except Exception as e:
@@ -774,7 +777,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\neval failed: %s' % e)
-            exc = ru.get_exception_trace()
+            exc = (repr(e), ru.get_exception_trace())
             ret = 1
 
         finally:
@@ -833,7 +836,7 @@ class _Worker(mt.Thread):
             val = loc['result']
             out = strout.getvalue()
             err = strerr.getvalue()
-            exc = None
+            exc = (None, None)
             ret = 0
 
         except Exception as e:
@@ -841,7 +844,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\nexec failed: %s' % e)
-            exc = ru.get_exception_trace()
+            exc = (repr(e), ru.get_exception_trace())
             ret = 1
 
         finally:
@@ -880,14 +883,14 @@ class _Worker(mt.Thread):
                             close_fds=True, shell=True)
             out, err = proc.communicate()
             ret      = proc.returncode
-            exc      = None
+            exc      = (None, None)
             self._prof.prof('rank_stop', uid=uid)
 
         except Exception as e:
             self._log.exception('proc failed: %s' % task['uid'])
             out = None
             err = 'exec failed: %s' % e
-            exc = ru.get_exception_trace()
+            exc = (repr(e), ru.get_exception_trace())
             ret = 1
 
         return out, err, ret, None, exc
@@ -908,14 +911,14 @@ class _Worker(mt.Thread):
           # self._log.debug('shell: --%s--', cmd)
             self._prof.prof('rank_start', uid=uid)
             out, err, ret = ru.sh_callout(cmd, shell=True, env=env)
-            exc = None
+            exc = (None, None)
             self._prof.prof('rank_stop', uid=uid)
 
         except Exception as e:
             self._log.exception('_shell failed: %s' % task['uid'])
             out = None
             err = 'shell failed: %s' % e
-            exc = ru.get_exception_trace()
+            exc = (repr(e), ru.get_exception_trace())
             ret = 1
 
       # os.environ = old_env
@@ -1123,7 +1126,7 @@ class MPIWorker(Worker):
             val = to_call(*args, **kwargs)
             out = strout.getvalue()
             err = strerr.getvalue()
-            exc = None
+            exc = (None, None)
             ret = 0
 
         except Exception as e:
@@ -1131,7 +1134,7 @@ class MPIWorker(Worker):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\ncall failed: %s' % e)
-            exc = ru.get_exception_trace()
+            exc = (repr(e), ru.get_exception_trace())
             ret = 1
 
         finally:

--- a/src/radical/pilot/raptor/worker_mpi.py
+++ b/src/radical/pilot/raptor/worker_mpi.py
@@ -474,7 +474,6 @@ class _Worker(mt.Thread):
                         out, err, ret, val, exc = self._dispatch(task)
                         self._prof.prof('exec_stop', uid=uid)
 
-                        task['error']            = None
                         task['stdout']           = out
                         task['stderr']           = err
                         task['exit_code']        = ret
@@ -483,7 +482,6 @@ class _Worker(mt.Thread):
                         task['exception_detail'] = exc[1]
 
                     except Exception as e:
-                        task['error']            = repr(e)
                         task['stdout']           = ''
                         task['stderr']           = str(e)
                         task['exit_code']        = -1

--- a/src/radical/pilot/raptor/worker_mpi.py
+++ b/src/radical/pilot/raptor/worker_mpi.py
@@ -262,7 +262,8 @@ class _TaskPuller(mt.Thread):
                     except Exception as e:
                         self._log.exception('failed to place task')
                         task['exception']        = repr(e)
-                        task['exception_detail'] = ru.get_exception_trace()
+                        task['exception_detail'] = \
+                                             '\n'.join(ru.get_exception_trace())
                         worker_result_q.put(task)
 
         except:
@@ -488,7 +489,8 @@ class _Worker(mt.Thread):
                         task['exit_code']        = -1
                         task['return_value']     = None
                         task['exception']        = repr(e)
-                        task['exception_detail'] = ru.get_exception_trace()
+                        task['exception_detail'] = \
+                                             '\n'.join(ru.get_exception_trace())
                         self._log.exception('recv err  %s  to  0' % (task['uid']))
 
                     finally:
@@ -709,7 +711,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\ncall failed: %s' % e)
-            exc = (repr(e), ru.get_exception_trace())
+            exc = (repr(e), '\n'.join(ru.get_exception_trace()))
             ret = 1
 
         finally:
@@ -777,7 +779,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\neval failed: %s' % e)
-            exc = (repr(e), ru.get_exception_trace())
+            exc = (repr(e), '\n'.join(ru.get_exception_trace()))
             ret = 1
 
         finally:
@@ -844,7 +846,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\nexec failed: %s' % e)
-            exc = (repr(e), ru.get_exception_trace())
+            exc = (repr(e), '\n'.join(ru.get_exception_trace()))
             ret = 1
 
         finally:
@@ -890,7 +892,7 @@ class _Worker(mt.Thread):
             self._log.exception('proc failed: %s' % task['uid'])
             out = None
             err = 'exec failed: %s' % e
-            exc = (repr(e), ru.get_exception_trace())
+            exc = (repr(e), '\n'.join(ru.get_exception_trace()))
             ret = 1
 
         return out, err, ret, None, exc
@@ -918,7 +920,7 @@ class _Worker(mt.Thread):
             self._log.exception('_shell failed: %s' % task['uid'])
             out = None
             err = 'shell failed: %s' % e
-            exc = (repr(e), ru.get_exception_trace())
+            exc = (repr(e), '\n'.join(ru.get_exception_trace()))
             ret = 1
 
       # os.environ = old_env
@@ -1134,7 +1136,7 @@ class MPIWorker(Worker):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\ncall failed: %s' % e)
-            exc = (repr(e), ru.get_exception_trace())
+            exc = (repr(e), '\n'.join(ru.get_exception_trace()))
             ret = 1
 
         finally:

--- a/src/radical/pilot/raptor/worker_mpi.py
+++ b/src/radical/pilot/raptor/worker_mpi.py
@@ -706,7 +706,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\ncall failed: %s' % e)
-            exc = [e.__class__.__qualname__, str(e)]
+            exc = ru.get_exception_trace()
             ret = 1
 
         finally:
@@ -774,7 +774,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\neval failed: %s' % e)
-            exc = [e.__class__.__name__, str(e)]
+            exc = ru.get_exception_trace()
             ret = 1
 
         finally:
@@ -841,7 +841,7 @@ class _Worker(mt.Thread):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\nexec failed: %s' % e)
-            exc = [e.__class__.__name__, str(e)]
+            exc = ru.get_exception_trace()
             ret = 1
 
         finally:
@@ -887,7 +887,7 @@ class _Worker(mt.Thread):
             self._log.exception('proc failed: %s' % task['uid'])
             out = None
             err = 'exec failed: %s' % e
-            exc = [e.__class__.__name__, str(e)]
+            exc = ru.get_exception_trace()
             ret = 1
 
         return out, err, ret, None, exc
@@ -915,7 +915,7 @@ class _Worker(mt.Thread):
             self._log.exception('_shell failed: %s' % task['uid'])
             out = None
             err = 'shell failed: %s' % e
-            exc = [e.__class__.__name__, str(e)]
+            exc = ru.get_exception_trace()
             ret = 1
 
       # os.environ = old_env
@@ -1131,7 +1131,7 @@ class MPIWorker(Worker):
             val = None
             out = strout.getvalue()
             err = strerr.getvalue() + ('\ncall failed: %s' % e)
-            exc = [e.__class__.__name__, str(e)]
+            exc = ru.get_exception_trace()
             ret = 1
 
         finally:

--- a/src/radical/pilot/staging_directives.py
+++ b/src/radical/pilot/staging_directives.py
@@ -68,8 +68,7 @@ def expand_staging_directives(sds: Union[str, Dict[str, Any], List[str]]
 
             # FIXME: ns = session ID
             expanded = {
-                    'uid'             : ru.generate_id('sd.%(item_counter)06d',
-                                                       ru.ID_CUSTOM, ns='foo'),
+                    'uid'             : ru.generate_id('sd', ru.ID_SIMPLE),
                     'source'          : src.strip(),
                     'target'          : tgt.strip(),
                     'action'          : DEFAULT_ACTION,

--- a/src/radical/pilot/staging_directives.py
+++ b/src/radical/pilot/staging_directives.py
@@ -67,13 +67,17 @@ def expand_staging_directives(sds: Union[str, Dict[str, Any], List[str]]
             else           : src, tgt = sd, os.path.basename(ru.Url(sd).path)
 
             # FIXME: ns = session ID
-            expanded = {'source':   src.strip(),
-                        'target':   tgt.strip(),
-                        'action':   DEFAULT_ACTION,
-                        'flags':    DEFAULT_FLAGS,
-                        'priority': DEFAULT_PRIORITY,
-                        'uid':      ru.generate_id('sd.%(item_counter)06d',
-                                                    ru.ID_CUSTOM, ns='foo')}
+            expanded = {
+                    'uid'             : ru.generate_id('sd.%(item_counter)06d',
+                                                       ru.ID_CUSTOM, ns='foo'),
+                    'source'          : src.strip(),
+                    'target'          : tgt.strip(),
+                    'action'          : DEFAULT_ACTION,
+                    'flags'           : DEFAULT_FLAGS,
+                    'priority'        : DEFAULT_PRIORITY,
+                    'exception'       : None,
+                    'exception_detail': None
+            }
 
         elif isinstance(sd, dict):
 
@@ -108,12 +112,16 @@ def expand_staging_directives(sds: Union[str, Dict[str, Any], List[str]]
             elif isinstance(flags, str):
                 raise ValueError('use RP constants for staging flags!')
 
-            expanded = {'uid':      ru.generate_id('sd'),
-                        'source':   source,
-                        'target':   target,
-                        'action':   action,
-                        'flags':    flags,
-                        'priority': priority}
+            expanded = {
+                    'uid'             : ru.generate_id('sd'),
+                    'source'          : source,
+                    'target'          : target,
+                    'action'          : action,
+                    'flags'           : flags,
+                    'priority'        : priority,
+                    'exception'       : None,
+                    'exception_detail': None
+            }
 
         else:
             raise Exception("Unknown directive: %s (%s)" % (sd, type(sd)))

--- a/src/radical/pilot/task.py
+++ b/src/radical/pilot/task.py
@@ -83,6 +83,7 @@ class Task(object):
         self._stderr           = None
         self._return_value     = None
         self._exception        = None
+        self._exception_detail            = None
         self._pilot            = descr.get('pilot')
         self._endpoint_fs      = None
         self._resource_sandbox = None
@@ -196,6 +197,7 @@ class Task(object):
             'stderr':           self.stderr,
             'return_value':     self.return_value,
             'exception':        self.exception,
+            'exception_detail': self.exception_detail,
             'pilot':            self.pilot,
             'endpoint_fs':      self.endpoint_fs,
             'resource_sandbox': self.resource_sandbox,
@@ -399,6 +401,24 @@ class Task(object):
         '''
 
         return self._exception
+
+
+    # --------------------------------------------------------------------------
+    #
+    @property
+    def exception_detail(self):
+        '''
+        Returns additional information about the exception which caused this
+        task to enter FAILED state.
+
+        If this property is queried before the task has reached
+        'DONE' or 'FAILED' state it will always return None.
+
+        **Returns:**
+            * str
+        '''
+
+        return self._exception_detail
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/task.py
+++ b/src/radical/pilot/task.py
@@ -83,7 +83,7 @@ class Task(object):
         self._stderr           = None
         self._return_value     = None
         self._exception        = None
-        self._exception_detail            = None
+        self._exception_detail = None
         self._pilot            = descr.get('pilot')
         self._endpoint_fs      = None
         self._resource_sandbox = None
@@ -169,7 +169,8 @@ class Task(object):
         # FIXME: setattr is ugly...  we should maintain all state in a dict.
         for key in ['state', 'stdout', 'stderr', 'exit_code', 'pilot',
                     'endpoint_fs', 'resource_sandbox', 'session_sandbox',
-                    'pilot_sandbox', 'task_sandbox', 'client_sandbox']:
+                    'pilot_sandbox', 'task_sandbox', 'client_sandbox',
+                    'exception', 'exception_detail']:
 
             val = task_dict.get(key, None)
             if val is not None:
@@ -386,18 +387,15 @@ class Task(object):
     @property
     def exception(self):
         '''
-        Returns an exception if such one was raised by a task representing
-        a function call or some code, or None otherwise.
+        Returns an string representation (`__repr__`) of the exception which
+        caused the task's `FAILED` state if such one was raised while managing
+        or executing the task.
 
         If this property is queried before the task has reached
         'DONE' or 'FAILED' state it will always return None.
 
-        If the exception type cannot be created, a base exception will be
-        returned with the error message set to `type: msg` where `type` is the
-        original exception type and `msg` the original error message.
-
         **Returns:**
-            * Exception
+            * str
         '''
 
         return self._exception

--- a/src/radical/pilot/task_manager.py
+++ b/src/radical/pilot/task_manager.py
@@ -314,6 +314,7 @@ class TaskManager(rpu.Component):
 
         for pilot in pilots:
 
+            pid   = pilot.uid
             state = pilot.state
 
             if state in rps.FINAL:
@@ -349,7 +350,10 @@ class TaskManager(rpu.Component):
                 to_restart = list()
                 for task in tasks:
 
+                    task['exception']        = 'RuntimeError("pilot died")'
+                    task['exception_detail'] = 'pilot %s is final' % pid
                     task['state'] = rps.FAILED
+
                     if not task['description'].get('restartable'):
                         self._log.debug('task %s not restartable', task['uid'])
                         continue

--- a/src/radical/pilot/tmgr/staging_input/default.py
+++ b/src/radical/pilot/tmgr/staging_input/default.py
@@ -280,7 +280,7 @@ class Default(TMGRStagingInputComponent):
                 # staging failed - do not pass task to agent
                 task['control']          = 'tmgr'
                 task['exception']        = repr(e)
-                task['exception_detail'] = ru.get_exception_trace()
+                task['exception_detail'] = '\n'.join(ru.get_exception_trace())
                 to_fail.append(task)
 
         if to_fail:

--- a/src/radical/pilot/tmgr/staging_input/default.py
+++ b/src/radical/pilot/tmgr/staging_input/default.py
@@ -275,9 +275,12 @@ class Default(TMGRStagingInputComponent):
         for task,actionables in staging_tasks:
             try:
                 self._handle_task(task, actionables)
-            except:
+
+            except Exception as e:
                 # staging failed - do not pass task to agent
-                task['control'] = 'tmgr'
+                task['control']          = 'tmgr'
+                task['exception']        = repr(e)
+                task['exception_detail'] = ru.get_exception_trace()
                 to_fail.append(task)
 
         if to_fail:

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -1143,7 +1143,8 @@ class Component(object):
                     if state:
                         for thing in things:
                             thing['exception']        = repr(e)
-                            thing['exception_detail'] = ru.get_exception_trace()
+                            thing['exception_detail'] = \
+                                             '\n'.join(ru.get_exception_trace())
                         self.advance(things, rps.FAILED, publish=True,
                                                          push=False)
 

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -1142,8 +1142,8 @@ class Component(object):
 
                     if state:
                         for thing in things:
-                            thing['error'].append('failed in %s.work_cb [%s]'
-                                    % (self._uid, repr(e)))
+                            thing['exception']        = repr(e)
+                            thing['exception_detail'] = ru.get_exception_trace()
                         self.advance(things, rps.FAILED, publish=True,
                                                          push=False)
 

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -1134,13 +1134,16 @@ class Component(object):
                     with self._work_lock:
                         self._workers[state](things)
 
-                except Exception:
+                except Exception as e:
 
                     # this is not fatal -- only the 'things' fail, not
                     # the component
                     self._log.exception("work %s failed", self._workers[state])
 
                     if state:
+                        for thing in things:
+                            thing['error'].append('failed in %s.work_cb [%s]'
+                                    % (self._uid, repr(e)))
                         self.advance(things, rps.FAILED, publish=True,
                                                          push=False)
 

--- a/src/radical/pilot/worker/stager.py
+++ b/src/radical/pilot/worker/stager.py
@@ -78,7 +78,7 @@ class Stager(rpu.Worker):
         except Exception as e:
             for sd in sds:
                 sd['exception']        = repr(e)
-                sd['exception_detail'] = ru.get_exception_trace()
+                sd['exception_detail'] = '\n'.join(ru.get_exception_trace())
                 sd['state']            = rps.FAILED
                 self._log.exception('staging failed')
 

--- a/src/radical/pilot/worker/stager.py
+++ b/src/radical/pilot/worker/stager.py
@@ -77,8 +77,9 @@ class Stager(rpu.Worker):
 
         except Exception as e:
             for sd in sds:
-                sd['state'] = rps.FAILED
-                sd['error'] = str(e)
+                sd['exception']        = repr(e)
+                sd['exception_detail'] = ru.get_exception_trace()
+                sd['state']            = rps.FAILED
                 self._log.exception('staging failed')
 
         finally:

--- a/src/radical/pilot/worker/stager.py
+++ b/src/radical/pilot/worker/stager.py
@@ -99,9 +99,6 @@ class Stager(rpu.Worker):
 
             # TODO: respect flags in directive
 
-            # make sure that `error` field exists
-            sd['error'] = None
-
             action  = sd['action']
             flags   = sd['flags']
             uid     = sd['uid']


### PR DESCRIPTION
This PR makes the reporting of task errors outside of the logging mechanism more consistent: exceptions and exception details are exposed as task attributes, the `task.stdout` field will not be overloaded with this information anymore but is now fully reserved for actual task output (starting from the launch script level).

Note that radical-cybertools/radical.saga/pull/857 makes the resulting information much more useful when the exceptions originate on the SAGA level.