### PR TITLE
ensure retval copy, unique task IDs

### DIFF
--- a/examples/misc/raptor.py
+++ b/examples/misc/raptor.py
@@ -50,6 +50,7 @@ def func_mpi(comm, msg, sleep):
     import time
     print('hello %d/%d: %s' % (comm.rank, comm.size, msg))
     time.sleep(sleep)
+    return 'func_mpi retval'
 
 
 # ------------------------------------------------------------------------------
@@ -63,7 +64,7 @@ def func_non_mpi(a, sleep):
     t = math.exp(a * b)
     print('func_non_mpi')
     time.sleep(sleep)
-    return t
+    return 'func_non_mpi retval'
 
 
 # ------------------------------------------------------------------------------
@@ -309,7 +310,8 @@ if __name__ == '__main__':
             tmgr.wait_tasks(uids=[t.uid for t in tasks])
 
             for task in tasks:
-                report.info('%s [%s]: %s' % (task.uid, task.state, task.stdout))
+                report.info('id: %s [%s]:\n    out: %s\n    ret: %s\n'
+                      % (task.uid, task.state, task.stdout, task.return_value))
 
     finally:
         session.close(download=True)

--- a/examples/misc/raptor.py
+++ b/examples/misc/raptor.py
@@ -62,7 +62,7 @@ def func_non_mpi(a, sleep):
     import time
     b = random.random()
     t = math.exp(a * b)
-    print('func_non_mpi')
+    print('func_non_mpi: %.1f' % t)
     time.sleep(sleep)
     return 'func_non_mpi retval'
 

--- a/examples/misc/raptor_master.py
+++ b/examples/misc/raptor_master.py
@@ -121,7 +121,6 @@ class MyMaster(rp.raptor.Master):
                 'ranks'     : 2,
                 'function'  : bson,
                 'scheduler' : 'master.000000'}))
-            self._log.info('bson %s : %s : %s' % (tds[-1]['uid'], len(bson), bson))
 
             bson = func_non_mpi(i + 1, sleep=self._sleep)
             tds.append(rp.TaskDescription({
@@ -131,7 +130,6 @@ class MyMaster(rp.raptor.Master):
                 'ranks'     : 1,
                 'function'  : bson,
                 'scheduler' : 'master.000000'}))
-            self._log.info('bson %s : %s : %s' % (tds[-1]['uid'], len(bson), bson))
 
             tds.append(rp.TaskDescription({
                 'uid'       : 'task.eval.m.%06d' % i,
@@ -234,10 +232,11 @@ class MyMaster(rp.raptor.Master):
     # --------------------------------------------------------------------------
     #
     def result_cb(self, tasks):
-        """Log results.
+        '''
+        Log results.
 
         Log file is named by the master tasks UID.
-        """
+        '''
         for task in tasks:
 
             mode = task['description']['mode']

--- a/examples/misc/raptor_master.py
+++ b/examples/misc/raptor_master.py
@@ -217,7 +217,7 @@ class MyMaster(rp.raptor.Master):
             # for each `function` mode task, submit one more `proc` mode request
             if mode == rp.TASK_FUNCTION:
                 self.submit_tasks(rp.TaskDescription(
-                    {'uid'       : uid.replace('call', 'extra'),
+                    {'uid'       : 'extra' + uid,
                    # 'timeout'   : 10,
                      'mode'      : rp.TASK_PROC,
                      'ranks'     : 2,
@@ -244,7 +244,6 @@ class MyMaster(rp.raptor.Master):
             self._collected[mode] += 1
 
             # NOTE: `state` will be `AGENT_EXECUTING`
-            self._log.info('=== out: %s', task['stdout'])
             self._log.info('result_cb  %s: %s [%s] [%s]',
                             task['uid'],
                             task['state'],
@@ -252,9 +251,9 @@ class MyMaster(rp.raptor.Master):
                             task['return_value'])
 
             # Note that stdout is part of the master task result.
-            print('result_cb %s: %s %s %s' % (task['uid'], task['state'],
-                                              task['stdout'],
-                                              task['return_value']))
+            print('id: %s [%s]:\n    out: %s\n    ret: %s\n'
+                 % (task['uid'], task['state'], task['stdout'],
+                    task['return_value']))
 
 
     # --------------------------------------------------------------------------

--- a/examples/misc/raptor_worker.py
+++ b/examples/misc/raptor_worker.py
@@ -59,6 +59,8 @@ class MyWorker(rp.raptor.MPIWorker):
 
         print(task['stdout'])
 
+        return 'my_hello retval'
+
 
 # ------------------------------------------------------------------------------
 

--- a/src/radical/pilot/raptor/worker_mpi.py
+++ b/src/radical/pilot/raptor/worker_mpi.py
@@ -497,7 +497,6 @@ class _Worker(mt.Thread):
                         self._prof.prof('unschedule_start', uid=uid)
                         rank_result_q.put(task)
 
-
         except:
             self._log.exception('work thread failed [%s]', self._rank)
 
@@ -1153,6 +1152,7 @@ class MPIWorker(Worker):
 
         print('hello: %s' % msg)
         time.sleep(sleep)
+        return 'hello retval'
 
 
     # --------------------------------------------------------------------------
@@ -1161,6 +1161,7 @@ class MPIWorker(Worker):
 
         print('hello %d/%d: %s' % (comm.rank, comm.size, msg))
         time.sleep(sleep)
+        return 'hello_mpi retval'
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/pilot/task.py
+++ b/src/radical/pilot/task.py
@@ -162,8 +162,6 @@ class Task(object):
                     raise RuntimeError('invalid state transition %s: %s -> %s'
                             % (self.uid, current, target))
 
-        self._state = target
-
         # we update all fields
         # FIXME: well, not all really :/
         # FIXME: setattr is ugly...  we should maintain all state in a dict.

--- a/src/radical/pilot/task.py
+++ b/src/radical/pilot/task.py
@@ -167,9 +167,9 @@ class Task(object):
         # we update all fields
         # FIXME: well, not all really :/
         # FIXME: setattr is ugly...  we should maintain all state in a dict.
-        for key in ['state', 'stdout', 'stderr', 'exit_code', 'pilot',
+        for key in ['state', 'stdout', 'stderr', 'exit_code', 'return_value',
                     'endpoint_fs', 'resource_sandbox', 'session_sandbox',
-                    'pilot_sandbox', 'task_sandbox', 'client_sandbox',
+                    'pilot', 'pilot_sandbox', 'task_sandbox', 'client_sandbox',
                     'exception', 'exception_detail']:
 
             val = task_dict.get(key, None)


### PR DESCRIPTION
This PR makes sure the task retval gets copied back to the API level task object.  It also removes a UID collision in our raptor example.