### PR TITLE
Modify resource_anl.json to support polaris machine on ANL.

### DIFF
--- a/src/radical/pilot/configs/resource_anl.json
+++ b/src/radical/pilot/configs/resource_anl.json
@@ -63,6 +63,62 @@
         "lfs_size_per_node"           : 0
     },
 
+    "polaris": {
+        "description"                 : "AMD EPYC Milan 7543P 32 core CPU with four Nvidia A100 GPUs, 560 nodes",
+        "notes"                       : "Local instance of MongoDB and pre-set VE should be used.",
+        "schemas"                     : ["local"],
+        "local"                       :
+        {	
+            "job_manager_endpoint"    : "pbspro://localhost/",
+            "filesystem_endpoint"     : "file://localhost/"
+        },
+        "default_queue"               : "debug-scaling",
+        "resource_manager"            : "PBSPRO",
+        "agent_config"                : "default",
+        "agent_scheduler"             : "CONTINUOUS",
+        "agent_spawner"               : "POPEN",
+        "launch_methods"              : {
+                                         "order" : ["MPIEXEC"],
+                                         "MPIEXEC": {}
+                                        },
+	"pre_bootstrap_0"             : ["module load conda"
+					],					
+        "default_remote_workdir"      : "$HOME",
+        "virtenv_mode"                : "local",
+        "cores_per_node"              : 64,
+        "gpus_per_node"               : 4,
+	"system_architecture"         : {"options": ["filesystems=grand:home", "place=scatter"]},
+        "lfs_path_per_node"           : "/tmp",
+        "lfs_size_per_node"           : 0
+    },
+
+    "polaris_interactive": {
+        "description"                 : "AMD EPYC Milan 7543P 32 core CPU with four Nvidia A100 GPUs, 560 nodes",
+        "notes"                       : "Local instance of MongoDB and pre-set VE should be used.",
+        "schemas"                     : ["interactive"],
+        "interactive"                 :
+        {	
+            "job_manager_endpoint"    : "fork://localhost/",
+            "filesystem_endpoint"     : "file://localhost/"
+        },
+        "resource_manager"            : "PBSPRO",
+        "agent_config"                : "default",
+        "agent_scheduler"             : "CONTINUOUS",
+        "agent_spawner"               : "POPEN",
+        "launch_methods"              : {
+                                         "order" : ["MPIEXEC"],
+                                         "MPIEXEC": {}
+                                        },
+	"pre_bootstrap_0"             : ["module load conda"
+					],					
+        "default_remote_workdir"      : "$HOME",
+        "virtenv_mode"                : "local",
+        "cores_per_node"              : 64,
+        "gpus_per_node"               : 4,
+        "lfs_path_per_node"           : "/tmp",
+        "lfs_size_per_node"           : 0
+    },
+
     "arcticus": {
         "description"                 : "JLSE Aurora testbed; 17x Coyote Pass nodes, 2x XeHP_SDV",
         "notes"                       : "Duo two-factor login. Local instance of virtualenv should be used.",


### PR DESCRIPTION
Two new cases, polaris and polaris_interactive are added. These two are machines on ANL with pbspro rm. They are both tested with Tianle and Mikhail on polaris login node (for polaris) and polaris interactive node (for polaris_interactive).