### PR TITLE
Set `blocked_cores/gpus` part of `system_architecture` in resource config

### DIFF
--- a/src/radical/pilot/agent/resource_manager/base.py
+++ b/src/radical/pilot/agent/resource_manager/base.py
@@ -217,14 +217,15 @@ class ResourceManager(object):
         rm_info.lfs_per_node     = self._cfg.lfs_size_per_node
         rm_info.lfs_path         = ru.expand_env(self._cfg.lfs_path_per_node)
 
-        rcfg = self._cfg.resource_cfg
-        rm_info.mem_per_node     = rcfg.mem_per_node or 0
-        rm_info.threads_per_core = int(os.environ.get('RADICAL_SMT') or
-                                       rcfg.get('system_architecture', {}).
-                                            get('smt', 1))
-
         rm_info.threads_per_gpu  = 1
         rm_info.mem_per_gpu      = None
+
+        rcfg                     = self._cfg.resource_cfg
+        rm_info.mem_per_node     = rcfg.mem_per_node or 0
+
+        system_architecture      = rcfg.get('system_architecture', {})
+        rm_info.threads_per_core = int(os.environ.get('RADICAL_SMT') or
+                                       system_architecture.get('smt', 1))
 
         # let the specific RM instance fill out the RMInfo attributes
         rm_info = self._init_from_scratch(rm_info)
@@ -245,9 +246,9 @@ class ResourceManager(object):
         assert alloc_nodes >= rm_info.requested_nodes
 
         # however, the config can override core and gpu detection,
-        # and decide to block some resources
-        blocked_cores = self._cfg.resource_cfg.blocked_cores or []
-        blocked_gpus  = self._cfg.resource_cfg.blocked_gpus  or []
+        # and decide to block some resources (part of the core specialization)
+        blocked_cores = system_architecture.blocked_cores or []
+        blocked_gpus  = system_architecture.blocked_gpus  or []
 
         self._log.info('blocked cores: %s' % blocked_cores)
         self._log.info('blocked gpus : %s' % blocked_gpus)

--- a/src/radical/pilot/agent/resource_manager/base.py
+++ b/src/radical/pilot/agent/resource_manager/base.py
@@ -247,8 +247,8 @@ class ResourceManager(object):
 
         # however, the config can override core and gpu detection,
         # and decide to block some resources (part of the core specialization)
-        blocked_cores = system_architecture.blocked_cores or []
-        blocked_gpus  = system_architecture.blocked_gpus  or []
+        blocked_cores = system_architecture.get('blocked_cores', [])
+        blocked_gpus  = system_architecture.get('blocked_gpus',  [])
 
         self._log.info('blocked cores: %s' % blocked_cores)
         self._log.info('blocked gpus : %s' % blocked_gpus)

--- a/src/radical/pilot/configs/resource_access.json
+++ b/src/radical/pilot/configs/resource_access.json
@@ -164,8 +164,6 @@
                                              ]
                                          }
                                         },
-      # "blocked_cores"               : [64, 65, 66, 67],
-      # "blocked_gpus"                : [0],
         "pre_bootstrap_0"             : ["module load TACC",
                                          "module load intel/18.0.0",
                                          "module load python3/3.7.0"
@@ -174,7 +172,10 @@
         "rp_version"                  : "local",
         "virtenv_mode"                : "create",
         "python_dist"                 : "default",
-        "task_pre_exec"               : []
+        "system_architecture"         : {
+                                       # "blocked_cores" : [64, 65, 66, 67],
+                                       # "blocked_gpus"  : [0]
+                                        }
     },
 
     "stampede2_ibrun": {

--- a/src/radical/pilot/configs/resource_ornl.json
+++ b/src/radical/pilot/configs/resource_ornl.json
@@ -67,12 +67,10 @@
         "agent_spawner"               : "POPEN",
         "launch_methods"              : {
                                          "order": ["SRUN"],
-                                         "SRUN" : {
-                                             "pre_exec_cached": [
-                                             ]
-                                         }
+                                         "SRUN" : {}
                                         },
-        "pre_bootstrap_0"             : ["module load cray-python"
+        "pre_bootstrap_0"             : [
+                                         "module load cray-python"
                                         ],
         "pre_bootstrap_1"             : [
                                         ],
@@ -82,8 +80,12 @@
         "gpus_per_node"               : 8,
         "lfs_path_per_node"           : "/tmp",
         "lfs_size_per_node"           : 0,
-        "system_architecture"         : {"smt": 2}
-      # Possible options within "system_architecture" - "options": ["nvme"]
+        "system_architecture"         : {
+                                         "smt"           : 2,
+                                       # "options"       : ["nvme"],
+                                         "blocked_cores" : [],
+                                         "blocked_gpus"  : []
+                                        }
     },
 
     "spock": {
@@ -101,10 +103,7 @@
         "agent_spawner"               : "POPEN",
         "launch_methods"              : {
                                          "order": ["SRUN"],
-                                         "SRUN" : {
-                                             "pre_exec_cached": [
-                                             ]
-                                         }
+                                         "SRUN" : {}
                                         },
         "pre_bootstrap_0"             : [
                                          "module load cray-python"
@@ -117,8 +116,12 @@
         "gpus_per_node"               : 4,
         "lfs_path_per_node"           : "/tmp",
         "lfs_size_per_node"           : 0,
-        "system_architecture"         : {"smt": 2}
-      # Possible options within "system_architecture" - "options": ["nvme"]
+        "system_architecture"         : {
+                                         "smt"           : 2,
+                                       # "options"       : ["nvme"],
+                                         "blocked_cores" : [],
+                                         "blocked_gpus"  : []
+                                        }
     },
 
     "summit": {
@@ -140,18 +143,13 @@
                                          "MPIRUN": {}
                                         },
         "pre_bootstrap_0"             : [
-                                         "module unload py-pip",
-                                         "module unload py-virtualenv",
-                                         "module unload py-setuptools",
-                                         "module unload xl",
-                                         "module unload xalt",
-                                         "module load   gcc/9.1.0",
-                                         "module load   libzmq/4.3.3",
-                                         "module load   python/3.7-anaconda3"
+                                         "module unload xl xalt",
+                                         "module load   gcc/9.1.0 libzmq/4.3.3",
+                                         "module load   python/3.8-anaconda3"
                                         ],
-        "pre_bootstrap_1"             : ["module load   gcc/9.1.0",
-                                         "module load   libzmq/4.3.3",
-                                         "module load   python/3.7-anaconda3",
+        "pre_bootstrap_1"             : [
+                                         "module load   gcc/9.1.0 libzmq/4.3.3",
+                                         "module load   python/3.8-anaconda3",
                                          "ulimit -u 65536"
                                         ],
         "default_remote_workdir"      : "$MEMBERWORK/%(pd.project)s",
@@ -161,12 +159,14 @@
         "rp_version"                  : "local",
         "cores_per_node"              : 42,
         "gpus_per_node"               : 6,
-        "blocked_cores"               : [],
-        "blocked_gpus"                : [],
         "lfs_path_per_node"           : "/tmp",
         "lfs_size_per_node"           : 0,
-        "system_architecture"         : {"smt": 1,
-                                         "options": ["gpumps", "nvme"]}
+        "system_architecture"         : {
+                                         "smt"           : 1,
+                                         "options"       : ["gpumps", "nvme"],
+                                         "blocked_cores" : [],
+                                         "blocked_gpus"  : []
+                                        }
     },
 
     "summit_jsrun": {
@@ -187,24 +187,18 @@
                                          "order" : ["JSRUN"],
                                          "JSRUN" : {
                                              "pre_exec_cached": [
-                                               # "module unload xl",
-                                               # "module unload xalt"
+                                               # "module unload xl xalt"
                                              ]
                                          }
                                         },
         "pre_bootstrap_0"             : [
-                                         "module unload py-pip",
-                                         "module unload py-virtualenv",
-                                         "module unload py-setuptools",
-                                         "module unload xl",
-                                         "module unload xalt",
-                                         "module load   gcc/9.1.0",
-                                         "module load   libzmq/4.3.3",
-                                         "module load   python/3.7-anaconda3"
+                                         "module unload xl xalt",
+                                         "module load   gcc/9.1.0 libzmq/4.3.3",
+                                         "module load   python/3.8-anaconda3"
                                         ],
-        "pre_bootstrap_1"             : ["module load   gcc/9.1.0",
-                                         "module load   libzmq/4.3.3",
-                                         "module load   python/3.7-anaconda3",
+        "pre_bootstrap_1"             : [
+                                         "module load   gcc/9.1.0 libzmq/4.3.3",
+                                         "module load   python/3.8-anaconda3",
                                          "ulimit -u 65536"
                                         ],
         "default_remote_workdir"      : "$MEMBERWORK/%(pd.project)s",
@@ -214,12 +208,14 @@
         "rp_version"                  : "local",
         "cores_per_node"              : 42,
         "gpus_per_node"               : 6,
-        "blocked_cores"               : [],
-        "blocked_gpus"                : [],
         "lfs_path_per_node"           : "/tmp",
         "lfs_size_per_node"           : 0,
-        "system_architecture"         : {"smt": 4,
-                                         "options": ["gpumps", "nvme"]}
+        "system_architecture"         : {
+                                         "smt"           : 4,
+                                         "options"       : ["gpumps", "nvme"],
+                                         "blocked_cores" : [],
+                                         "blocked_gpus"  : []
+                                        }
     },
 
     "summit_interactive": {
@@ -245,26 +241,19 @@
                                          }
                                         },
         "pre_bootstrap_0"             : [
-                                         "module unload py-pip",
-                                         "module unload py-virtualenv",
-                                         "module unload py-setuptools",
-                                         "module unload xl",
-                                         "module unload xalt",
-                                         "module load   gcc/9.1.0",
-                                         "module load   libzmq/4.3.3",
-                                         "module load   python/3.7-anaconda3"
+                                         "module unload xl xalt",
+                                         "module load   gcc/9.1.0 libzmq/4.3.3",
+                                         "module load   python/3.8-anaconda3"
                                         ],
-        "pre_bootstrap_1"             : ["module load   gcc/9.1.0",
-                                         "module load   libzmq/4.3.3",
-                                         "module load   python/3.7-anaconda3",
+        "pre_bootstrap_1"             : [
+                                         "module load   gcc/9.1.0 libzmq/4.3.3",
+                                         "module load   python/3.8-anaconda3",
                                          "ulimit -u 65536"
                                         ],
         "default_remote_workdir"      : "$MEMBERWORK/${LSB_PROJECT_NAME,,}",
         "virtenv_mode"                : "local",
         "cores_per_node"              : 42,
         "gpus_per_node"               : 6,
-        "blocked_cores"               : [],
-        "blocked_gpus"                : [],
         "lfs_path_per_node"           : "/tmp",
         "lfs_size_per_node"           : 0
     },
@@ -291,7 +280,7 @@
                                              "pre_exec_cached": [
                                                  "module unload xl xalt spectrum-mpi",
                                                  "module load   gcc/9.1.0",
-                                                 "module load   python/3.7-anaconda3",
+                                                 "module load   python/3.8-anaconda3",
                                                  "module use    /sw/summit/ums/ompix/gcc/9.1.0/modules",
                                                # "module use    /sw/summit/ums/ompix/DEVELOP/gcc/9.1.0/modules",
                                                # "module load   prrte/master"
@@ -301,28 +290,32 @@
                                          }
                                         },
         "pre_bootstrap_0"             : [
-            "module unload xl xalt spectrum-mpi",
-            "module load   gcc/9.1.0",
-            "module load   python/3.7-anaconda3",
-            "module use    /sw/summit/ums/ompix/gcc/9.1.0/modules",
-            "module load   prrte/2.0.2"
-        ],
+                                         "module unload xl xalt spectrum-mpi",
+                                         "module load   gcc/9.1.0",
+                                         "module load   python/3.8-anaconda3",
+                                         "module use    /sw/summit/ums/ompix/gcc/9.1.0/modules",
+                                         "module load   prrte/2.0.2"
+                                        ],
         "pre_bootstrap_1"             : [
-            "module unload xl xalt spectrum-mpi",
-            "module load   gcc/9.1.0",
-            "module load   python/3.7-anaconda3",
-            "module use    /sw/summit/ums/ompix/gcc/9.1.0/modules",
-            "module load   prrte/2.0.2",
-            "ulimit -u 65536"
-        ],
+                                         "module unload xl xalt spectrum-mpi",
+                                         "module load   gcc/9.1.0",
+                                         "module load   python/3.8-anaconda3",
+                                         "module use    /sw/summit/ums/ompix/gcc/9.1.0/modules",
+                                         "module load   prrte/2.0.2",
+                                         "ulimit -u 65536"
+                                        ],
         "default_remote_workdir"      : "$MEMBERWORK/%(pd.project)s",
         "virtenv_mode"                : "local",
         "cores_per_node"              : 42,
         "gpus_per_node"               : 6,
         "lfs_path_per_node"           : "/tmp",
         "lfs_size_per_node"           : 0,
-        "system_architecture"         : {"smt": 4,
-                                         "options": ["gpumps", "nvme"]}
+        "system_architecture"         : {
+                                         "smt"           : 4,
+                                         "options"       : ["gpumps", "nvme"],
+                                         "blocked_cores" : [],
+                                         "blocked_gpus"  : []
+                                        }
     }
 }
 

--- a/src/radical/pilot/pmgr/launching/base.py
+++ b/src/radical/pilot/pmgr/launching/base.py
@@ -579,8 +579,6 @@ class PMGRLaunchingComponent(rpu.Component):
         virtenv                 = rcfg.get('virtenv',      default_virtenv)
         cores_per_node          = rcfg.get('cores_per_node', 0)
         gpus_per_node           = rcfg.get('gpus_per_node',  0)
-        blocked_cores           = rcfg.get('blocked_cores', [])
-        blocked_gpus            = rcfg.get('blocked_gpus',  [])
         lfs_path_per_node       = rcfg.get('lfs_path_per_node')
         lfs_size_per_node       = rcfg.get('lfs_size_per_node', 0)
         python_dist             = rcfg.get('python_dist')
@@ -593,6 +591,10 @@ class PMGRLaunchingComponent(rpu.Component):
         mandatory_args          = rcfg.get('mandatory_args', [])
         system_architecture     = rcfg.get('system_architecture', {})
         services               += rcfg.get('services', [])
+
+        # part of the core specialization settings
+        blocked_cores           = system_architecture.get('blocked_cores', [])
+        blocked_gpus            = system_architecture.get('blocked_gpus',  [])
 
         self._log.debug(pprint.pformat(rcfg))
 

--- a/tests/unit_tests/test_rm/test_cases/test_cores_gpus_map.json
+++ b/tests/unit_tests/test_rm/test_cases/test_cores_gpus_map.json
@@ -65,8 +65,11 @@
             "cores_per_node"    : 8,
             "gpus_per_node"     : 2,
             "lfs_size_per_node" : 0,
-            "resource_cfg"      : {"mem_per_node"  : 128,
-                                   "blocked_cores" : []}
+            "resource_cfg"      : {
+                                   "mem_per_node"       : 128,
+                                   "system_architecture": {
+                                       "blocked_cores"  : []
+                                   }}
         },
         {
             "nodes"             : 1,
@@ -75,9 +78,12 @@
             "cores_per_node"    : 12,
             "gpus_per_node"     : 2,
             "lfs_size_per_node" : 0,
-            "resource_cfg"      : {"mem_per_node"  : 128,
-                                   "blocked_cores" : [0, 2],
-                                   "blocked_gpus"  : [1]}
+            "resource_cfg"      : {
+                                   "mem_per_node"       : 128,
+                                   "system_architecture": {
+                                       "blocked_cores"  : [0, 2],
+                                       "blocked_gpus"   : [1]
+                                   }}
         },
         {
             # requested more NODES than allocated
@@ -87,9 +93,12 @@
             "cores_per_node"    : 12,
             "gpus_per_node"     : 2,
             "lfs_size_per_node" : 0,
-            "resource_cfg"      : {"mem_per_node"  : 128,
-                                   "blocked_cores" : [0, 2],
-                                   "blocked_gpus"  : [1]}
+            "resource_cfg"      : {
+                                   "mem_per_node"       : 128,
+                                   "system_architecture": {
+                                       "blocked_cores"  : [0, 2],
+                                       "blocked_gpus"   : [1]
+                                   }}
         },
         {
             # requested more CORES than allocated
@@ -99,9 +108,12 @@
             "cores_per_node"    : 12,
             "gpus_per_node"     : 2,
             "lfs_size_per_node" : 0,
-            "resource_cfg"      : {"mem_per_node"  : 128,
-                                   "blocked_cores" : [0, 2],
-                                   "blocked_gpus"  : [1]}
+            "resource_cfg"      : {
+                                   "mem_per_node"       : 128,
+                                   "system_architecture": {
+                                       "blocked_cores"  : [0, 2],
+                                       "blocked_gpus"   : [1]
+                                   }}
         }
     ],
     "result": [


### PR DESCRIPTION
Parameter `system_architecture` is provided to SAGA and its sub-parameter `blocked_cores` is used to define a core specialization (currently with focus on SLURM adaptor - RS PR [#870](https://github.com/radical-cybertools/radical.saga/pull/870))