### PR TITLE
removed `gpus_per_node` from Bridges config

### DIFF
--- a/src/radical/pilot/configs/resource_access.json
+++ b/src/radical/pilot/configs/resource_access.json
@@ -349,7 +349,6 @@
         "virtenv_mode"                : "create",
         "python_dist"                 : "anaconda",
         "task_pre_exec"               : [],
-        "gpus_per_node"               : 8,
         "system_architecture"         : {"gpu": "v100"}
     }
 }


### PR DESCRIPTION
Let SAGA handle GPUs
- whenever user requests GPUs, corresponding request goes to SAGA
https://github.com/radical-cybertools/radical.pilot/blob/6a73b0a8b3f248a567ff3928d1b80509038ff6e5/src/radical/pilot/pmgr/launching/base.py#L809
- SAGA configures batch script accordingly
https://github.com/radical-cybertools/radical.saga/blob/58db9a76d2aa18388646de02d86997be7197a523/src/radical/saga/adaptors/slurm/slurm_job.py#L577
https://github.com/radical-cybertools/radical.saga/blob/58db9a76d2aa18388646de02d86997be7197a523/src/radical/saga/adaptors/slurm/slurm_job.py#L723-L727

Bridges2 has a separate queue for GPUs nodes, but having `gpus_per_node` in the config, triggers SAGA always to put a request for GPUs into a batch script