### PR TITLE
added rank env variable for MPIExec LM

### DIFF
--- a/src/radical/pilot/agent/launch_method/mpiexec.py
+++ b/src/radical/pilot/agent/launch_method/mpiexec.py
@@ -218,6 +218,7 @@ class MPIExec(LaunchMethod):
         # FIXME: we know the MPI flavor, so make this less guesswork
 
         ret  = 'test -z "$MPI_RANK"  || export RP_RANK=$MPI_RANK\n'
+        ret += 'test -z "$PMI_RANK"  || export RP_RANK=$PMI_RANK\n'
         ret += 'test -z "$PMIX_RANK" || export RP_RANK=$PMIX_RANK\n'
 
         if self._mpt:

--- a/src/radical/pilot/agent/launch_method/mpiexec.py
+++ b/src/radical/pilot/agent/launch_method/mpiexec.py
@@ -218,8 +218,9 @@ class MPIExec(LaunchMethod):
         # FIXME: we know the MPI flavor, so make this less guesswork
 
         ret  = 'test -z "$MPI_RANK"  || export RP_RANK=$MPI_RANK\n'
-        ret += 'test -z "$PMI_RANK"  || export RP_RANK=$PMI_RANK\n'
         ret += 'test -z "$PMIX_RANK" || export RP_RANK=$PMIX_RANK\n'
+        ret += 'test -z "$PMI_ID"    || export RP_RANK=$PMI_ID\n'
+        ret += 'test -z "$PMI_RANK"  || export RP_RANK=$PMI_RANK\n'
 
         if self._mpt:
             ret += 'test -z "$MPT_MPI_RANK" || export RP_RANK=$MPT_MPI_RANK\n'

--- a/tests/unit_tests/test_lm/test_mpiexec.py
+++ b/tests/unit_tests/test_lm/test_mpiexec.py
@@ -184,6 +184,7 @@ class TestMPIExec(TestCase):
 
         command = lm_mpiexec.get_rank_cmd()
         self.assertIn('$MPI_RANK', command)
+        self.assertIn('$PMI_RANK', command)
         self.assertIn('$PMIX_RANK', command)
         self.assertNotIn('$MPT_MPI_RANK', command)
 

--- a/tests/unit_tests/test_lm/test_mpiexec.py
+++ b/tests/unit_tests/test_lm/test_mpiexec.py
@@ -183,9 +183,10 @@ class TestMPIExec(TestCase):
         lm_mpiexec._mpt = False
 
         command = lm_mpiexec.get_rank_cmd()
-        self.assertIn('$MPI_RANK', command)
-        self.assertIn('$PMI_RANK', command)
+        self.assertIn('$MPI_RANK',  command)
         self.assertIn('$PMIX_RANK', command)
+        self.assertIn('$PMI_ID',    command)
+        self.assertIn('$PMI_RANK',  command)
         self.assertNotIn('$MPT_MPI_RANK', command)
 
         # special case - MPT


### PR DESCRIPTION
use env variable `PMI_RANK` (and/or `PMI_ID`) - [source](https://learn.microsoft.com/en-us/powershell/high-performance-computing/environment-variables-for-the-mpiexec-command?view=hpc19-ps#BKMK_PMIEnvironmentVariables), [source](https://www.intel.com/content/www/us/en/develop/documentation/inspector-user-guide-windows/top/mpi-applications-support/support-of-non-intel-mpi-implementations.html)

p.s. this is the case for Polaris@ALCF