### PR TITLE
fix task environment setup for raptor tasks

### DIFF
--- a/src/radical/pilot/raptor/worker.py
+++ b/src/radical/pilot/raptor/worker.py
@@ -93,9 +93,10 @@ class Worker(object):
         self.register_mode(TASK_SHELL,    self._dispatch_shell)
 
         # prepare base env dict used for all tasks
+        # NOTE: raptor tasks run in the same environment as the raptor worker
         self._task_env = dict()
         for k,v in os.environ.items():
-            if k.startswith('RP_'):
+            if not k.startswith('RP_'):
                 self._task_env[k] = v
 
 
@@ -481,12 +482,14 @@ class Worker(object):
             uid  = task['uid']
             exe  = task['description']['executable']
             args = task['description'].get('arguments', list())
-            tenv = task['description'].get('environment', dict())
+            env  = ru.dict_merge(self._task_env,
+                                 task['description']['environment'],
+                                 ru.OVERWRITE)
 
             cmd  = '%s %s' % (exe, ' '.join([shlex.quote(arg) for arg in args]))
           # self._log.debug('proc: --%s--', args)
             self._prof.prof('rank_start', uid=uid)
-            proc = sp.Popen(cmd, env=tenv,  stdin=None,
+            proc = sp.Popen(cmd, env=env,  stdin=None,
                             stdout=sp.PIPE, stderr=sp.PIPE,
                             close_fds=True, shell=True)
             out, err = proc.communicate()
@@ -515,7 +518,9 @@ class Worker(object):
         try:
             uid = task['uid']
             cmd = task['description']['command']
-            env = task['description']['environment']
+            env = ru.dict_merge(self._task_env,
+                                task['description']['environment'],
+                                ru.OVERWRITE)
           # self._log.debug('shell: --%s--', cmd)
             self._prof.prof('rank_start', uid=uid)
             out, err, ret = ru.sh_callout(cmd, shell=True, env=env)

--- a/src/radical/pilot/raptor/worker.py
+++ b/src/radical/pilot/raptor/worker.py
@@ -482,9 +482,8 @@ class Worker(object):
             uid  = task['uid']
             exe  = task['description']['executable']
             args = task['description'].get('arguments', list())
-            env  = ru.dict_merge(self._task_env,
-                                 task['description']['environment'],
-                                 ru.OVERWRITE)
+            env  = dict(self._task_env)
+            env.update(task['description']['environment'])
 
             cmd  = '%s %s' % (exe, ' '.join([shlex.quote(arg) for arg in args]))
           # self._log.debug('proc: --%s--', args)
@@ -518,9 +517,9 @@ class Worker(object):
         try:
             uid = task['uid']
             cmd = task['description']['command']
-            env = ru.dict_merge(self._task_env,
-                                task['description']['environment'],
-                                ru.OVERWRITE)
+            env = dict(self._task_env)
+            env.update(task['description']['environment'])
+
           # self._log.debug('shell: --%s--', cmd)
             self._prof.prof('rank_start', uid=uid)
             out, err, ret = ru.sh_callout(cmd, shell=True, env=env)

--- a/src/radical/pilot/raptor/worker_mpi.py
+++ b/src/radical/pilot/raptor/worker_mpi.py
@@ -494,8 +494,8 @@ class MPIWorkerRank(mt.Thread):
                'RP_GTOD'            : os.environ['RP_GTOD'],
                'RP_PROF'            : os.environ['RP_PROF'],
                'RP_PROF_TGT'        : os.environ['RP_PROF_TGT'],
-               'RP_RANKS'           : 1,  # dispatch_mpi will oveerwrite this
-               'RP_RANK'            : 0,  # dispatch_mpi will oveerwrite this
+               'RP_RANKS'           : '1',  # dispatch_mpi will overwrite this
+               'RP_RANK'            : '0',  # dispatch_mpi will overwrite this
                })
 
         if task['description']['ranks'] > 1:

--- a/src/radical/pilot/task_description.py
+++ b/src/radical/pilot/task_description.py
@@ -162,12 +162,12 @@ class TaskDescription(ru.TypedDict):
         no additional resources (gpus, storage, memory).  `TASK_EXECUTABLE`
         should be used for all other tasks and is in fact the default.
         `TASK_SHELL` should only be used if the command to be run requires shell
-        specific functionality (e.g., pipes, I/O redirection) which cannot easily 
+        specific functionality (e.g., pipes, I/O redirection) which cannot easily
         be mapped to other task attributes.
 
         TASK_RAPTOR_MASTER and TASK_RAPTOR_WORKER are special types of tasks
         that define RAPTOR's master(s) and worker(s) components and their
-        resource requirements. They are launched by the Agent on one or more 
+        resource requirements. They are launched by the Agent on one or more
         nodes, depending on their requirements.
 
     .. py:attribute:: executable
@@ -707,6 +707,10 @@ class TaskDescription(ru.TypedDict):
         if self.cpu_process_type: pass
         if self.gpu_threads     : pass
         if self.gpu_thread_type : pass
+
+        if self.environment:
+            for k,v in self.environment.items():
+                self.environment[k] = str(v)
 
       # if self.mode in [TASK_SHELL, TASK_PROC]:
       #

--- a/src/radical/pilot/task_description.py
+++ b/src/radical/pilot/task_description.py
@@ -708,10 +708,6 @@ class TaskDescription(ru.TypedDict):
         if self.gpu_threads     : pass
         if self.gpu_thread_type : pass
 
-        if self.environment:
-            for k,v in self.environment.items():
-                self.environment[k] = str(v)
-
       # if self.mode in [TASK_SHELL, TASK_PROC]:
       #
       #     if self.get('cpu_processes', 1) * self.get('cpu_threads', 1) > 1:


### PR DESCRIPTION
Fixes #2889 

This PR ensures that Raptor tasks run in the same environment as the Raptor workers, but augmented with the task description's `environment` dict and the `RP_*` env settings.  The main fix is to invert the logic on the env copy in [src/radical/pilot/raptor/worker.py](https://github.com/radical-cybertools/radical.pilot/compare/devel...fix/raptor_task_env#diff-46e45bab41a4e5fd127d4bdfe1d6a0cb408bee1bff7928f642b3dc0c83659ee5) line 99.