### PR TITLE
removed `codecov` from test requirements

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,7 +6,6 @@ pytest-timeout
 pylint
 flake8
 flake8-per-file-ignores
-codecov
 coverage
 psutil
 pudb


### PR DESCRIPTION
`codecov` is represented by GitHub actions