### PR TITLE
Update source of "napoleon" Sphinx extension.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,5 +2,3 @@
 -r requirements.txt
 
 sphinx>=5.1
-sphinxcontrib-napoleon
-


### PR DESCRIPTION
Ref https://github.com/sphinx-contrib/napoleon:
 "As of Sphinx 1.3, the napoleon extension will come packaged with
 Sphinx under sphinx.ext.napoleon. The sphinxcontrib.napoleon
 extension will continue to work with Sphinx <= 1.2"

The sphinx-contrib/napoleon repository is now in an archived state and the package it provides is increasingly incompatile with Python >= 3.9.