### PR TITLE
some bash versions require EOL cont for bracketed calls

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -1650,10 +1650,10 @@ get_tunnel(){
 
     if test -z "$BIND_ADDRESS"
     then
-        BIND_ADDRESS=$(ip addr
-                     | grep 'state UP' -A2
-                     | grep 'inet'
-                     | awk '{print $2}'
+        BIND_ADDRESS=$(ip addr             \
+                     | grep 'state UP' -A2 \
+                     | grep 'inet'         \
+                     | awk '{print $2}'    \
                      | cut -f1 -d'/')
       # BIND_ADDRESS="127.0.0.1"
     fi


### PR DESCRIPTION
No idea why, but recently my new system started complaining about a shell syntax error.  I guess this went unnoticed before because of some leniency in the bash parser.  Either way, this PR fixes the syntax error.