### PR TITLE
Use a universal and unique identifier for registered callbacks.

### DIFF
--- a/src/radical/pilot/pilot.py
+++ b/src/radical/pilot/pilot.py
@@ -468,9 +468,9 @@ class Pilot(object):
             raise ValueError ("invalid pmgr metric '%s'" % metric)
 
         with self._cb_lock:
-            cb_name = cb.__name__
-            self._callbacks[metric][cb_name] = {'cb'      : cb,
-                                                'cb_data' : cb_data}
+            cb_id = id(cb)
+            self._callbacks[metric][cb_id] = {'cb'      : cb,
+                                              'cb_data' : cb_data}
 
 
     # --------------------------------------------------------------------------
@@ -480,23 +480,28 @@ class Pilot(object):
         if metric and metric not in rpc.PMGR_METRICS :
             raise ValueError ("invalid pmgr metric '%s'" % metric)
 
-        if   not metric                  : metrics = rpc.PMGR_METRICS
-        elif not isinstance(metric, list): metrics = [metric]
-        else                             : metrics = metric
+        if not metric:
+            metrics = rpc.PMGR_METRICS
+        elif isinstance(metric, list):
+            metrics =  metric
+        else:
+            metrics = [metric]
 
         with self._cb_lock:
 
             for metric in metrics:
 
-                if cb: to_delete = [cb.__name__]
-                else : to_delete = list(self._callbacks[metric].keys())
+                if cb:
+                    to_delete = [id(cb)]
+                else:
+                    to_delete = list(self._callbacks[metric].keys())
 
-                for cb_name in to_delete:
+                for cb_id in to_delete:
 
-                    if cb_name not in self._callbacks[metric]:
-                        raise ValueError("unknown callback '%s'" % cb_name)
+                    if cb_id not in self._callbacks[metric]:
+                        raise ValueError("unknown callback '%s'" % cb_id)
 
-                    del self._callbacks[metric][cb_name]
+                    del self._callbacks[metric][cb_id]
 
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
Allow distinct instances of defined callables to be used as Pilot callbacks, whether or not the `cb` objects have `__name__` attributes (such as for `functools.partial` instances). Normalize `Pilot.{un,}register_callback()`` with the updates to `PilotManager.{un,}register_callback()`` from c0085457.