### PR TITLE
Un-hide "Utilities and helpers" section in API reference.

### DIFF
--- a/docs/source/apidoc.rst
+++ b/docs/source/apidoc.rst
@@ -63,7 +63,7 @@ Task
    :members:
 
 Utilities and helpers
----------------------
+=====================
 .. automodule:: radical.pilot.utils.component
    :members:
 .. automodule:: radical.pilot.utils.db_utils


### PR DESCRIPTION
The "Utilities and helpers" section of `apidoc.rst` was nested in the "Tasks and TaskManagers" section (presumably by accident), and so did not appear in the left side-bar with other major categories of API documentation. This change elevates the heading one level to be equal with the other major sections.