### PR TITLE
added option `--exact` for Rivanna (SRun LM)

### DIFF
--- a/docs/source/supported/rivanna.rst
+++ b/docs/source/supported/rivanna.rst
@@ -42,6 +42,13 @@ General description
    Please refer to this `link <https://www.rc.virginia.edu/userinfo/rivanna/overview/#system-details>`_
    for more information about the resources per node.
 
+.. note::
+
+   If you run RADICAL-Pilot in the "interactive" mode
+   (``pilot_description.access_schema = 'interactive'``), make sure that you use
+   option ``--exclusive`` (`SLURM exclusive <https://slurm.schedmd.com/sbatch.html#OPT_exclusive>`_)
+   in your batch script or within a command to start an interactive session.
+
 Setup execution environment
 ===========================
 

--- a/src/radical/pilot/agent/launch_method/srun.py
+++ b/src/radical/pilot/agent/launch_method/srun.py
@@ -39,6 +39,10 @@ class Srun(LaunchMethod):
 
         self._command : str  = ''
         self._traverse: bool = bool('princeton.traverse' in lm_cfg['resource'])
+        self._exact   : bool = False
+
+        if 'uva.rivanna' in lm_cfg['resource']:
+            self._exact = True
 
         LaunchMethod.__init__(self, name, lm_cfg, rm_info, log, prof)
 
@@ -147,13 +151,17 @@ class Srun(LaunchMethod):
             if slots['ranks'][0]['gpu_map']:
                 gpus_per_task = len(slots['ranks'][0]['gpu_map'][0])
 
+        mapping = ''
+        if self._exact:
+            mapping += '--exact '
+
         if self._traverse:
-            mapping = '--ntasks=%d '        % n_tasks \
-                    + '--cpus-per-task=%d ' % n_task_threads \
-                    + '--ntasks-per-core=1 --distribution="arbitrary"'
+            mapping += '--ntasks=%d '        % n_tasks \
+                    +  '--cpus-per-task=%d ' % n_task_threads \
+                    +  '--ntasks-per-core=1 --distribution="arbitrary"'
         else:
-            mapping = '--nodes %d ' % n_nodes \
-                    + '--ntasks %d' % n_tasks
+            mapping += '--nodes %d ' % n_nodes \
+                    +  '--ntasks %d' % n_tasks
 
             if n_task_threads:
                 mapping += ' --cpus-per-task %d' % n_task_threads

--- a/src/radical/pilot/configs/resource_uva.json
+++ b/src/radical/pilot/configs/resource_uva.json
@@ -24,8 +24,8 @@
         "agent_scheduler"             : "CONTINUOUS",
         "agent_spawner"               : "POPEN",
         "launch_methods"              : {
-                                         "order": ["MPIRUN"],
-                                         "MPIRUN" : {}
+                                         "order": ["SRUN"],
+                                         "SRUN" : {}
                                         },
         "pre_bootstrap_0"             : [
                                         "module load gcc/9.2.0",
@@ -33,9 +33,7 @@
                                         "module load python/3.7.7"
                                         ],
         "default_remote_workdir"      : "/scratch/$USER",
-        "python_dist"                 : "default",
-        "virtenv_dist"                : "default",
-        "virtenv_mode"                : "create",
-        "rp_version"                  : "local"
+        "virtenv_mode"                : "local",
+        "system_architecture"         : {"exclusive": true}
     }
 }

--- a/tests/unit_tests/test_lm/test_cases/task.000019.json
+++ b/tests/unit_tests/test_lm/test_cases/task.000019.json
@@ -1,0 +1,46 @@
+
+{
+    "task": {
+        "uid"               : "task.000019",
+        "description": {
+            "executable"    : "/bin/sleep",
+            "arguments"     : ["12"],
+            "ranks"         : 4,
+            "cores_per_rank": 2,
+            "threading_type": ""
+        },
+        "task_sandbox_path" : "/tmp"
+    },
+
+    "setup": {
+        "lm": {
+            "slots": {
+                "ranks": [
+                    {
+                        "node_name" : "node1",
+                        "node_id"   : "00001",
+                        "core_map"  : [[0, 1], [2, 3], [4, 5], [6, 7]],
+                        "gpu_map"   : [],
+                        "lfs"       : 0,
+                        "mem"       : 0
+                    }
+                ],
+                "partition_id"   : null,
+                "cores_per_node" : 28,
+                "gpus_per_node"  : 0,
+                "lfs_per_node"   : 0,
+                "mem_per_node"   : 0
+            },
+            "exact": true
+        }
+    },
+
+    "results": {
+        "lm": {
+            "srun": {
+                "launch_cmd" : "srun --exact --nodes 1 --ntasks 4 --cpus-per-task 2 --mem 0 --nodelist=node1",
+                "rank_exec"  : "/bin/sleep \"12\""
+            }
+        }
+    }
+}

--- a/tests/unit_tests/test_lm/test_srun.py
+++ b/tests/unit_tests/test_lm/test_srun.py
@@ -121,6 +121,8 @@ class TestSrun(TestCase):
         test_cases = setUp('lm', 'srun')
         for task, result in test_cases:
 
+            lm_srun._exact = task.get('exact', False)
+
             if result == 'RuntimeError':
                 with self.assertRaises(RuntimeError):
                     lm_srun.get_launch_cmds(task, '')


### PR DESCRIPTION
Me and @AymenFJA tested this solution, proposed by the Rihanna support team, on Rivanna, and it allows to run multiple SRUNs concurrently on a single node