### PR TITLE
increase raptor's heartbeat time

### DIFF
--- a/src/radical/pilot/raptor/master.py
+++ b/src/radical/pilot/raptor/master.py
@@ -47,8 +47,8 @@ class Master(rpu.Component):
         self._term       = mt.Event()  # termination signal
         self._thread     = None        # run loop
 
-        self._hb_freq    = 10          # check worker heartbetas every n seconds
-        self._hb_timeout = 15          # consider worker dead after 15 seconds
+        self._hb_freq    = 1000        # check worker heartbetas every n seconds
+        self._hb_timeout = 150         # consider worker dead after 15 seconds
 
         cfg              = self._get_config(cfg)
         self._session    = Session(cfg=cfg, uid=cfg.sid, _primary=False)

--- a/src/radical/pilot/raptor/master.py
+++ b/src/radical/pilot/raptor/master.py
@@ -47,7 +47,7 @@ class Master(rpu.Component):
         self._term       = mt.Event()  # termination signal
         self._thread     = None        # run loop
 
-        self._hb_freq    = 100         # check worker heartbetas every n seconds
+        self._hb_freq    = 1000        # check worker heartbetas every n seconds
         self._hb_timeout = 150         # consider worker dead after 150 seconds
 
         cfg              = self._get_config(cfg)

--- a/src/radical/pilot/raptor/master.py
+++ b/src/radical/pilot/raptor/master.py
@@ -47,8 +47,8 @@ class Master(rpu.Component):
         self._term       = mt.Event()  # termination signal
         self._thread     = None        # run loop
 
-        self._hb_freq    = 1000        # check worker heartbetas every n seconds
-        self._hb_timeout = 150         # consider worker dead after 15 seconds
+        self._hb_freq    = 100         # check worker heartbetas every n seconds
+        self._hb_timeout = 150         # consider worker dead after 150 seconds
 
         cfg              = self._get_config(cfg)
         self._session    = Session(cfg=cfg, uid=cfg.sid, _primary=False)


### PR DESCRIPTION
This PR should fix the issue of workers ranks dying if they do not join within a specific time period. Thus, this PR increases the master time to check on the worker.

related https://github.com/radical-cybertools/other_activities/issues/59