### PR TITLE
remove unnecessary sleep in raptor_master example

### DIFF
--- a/examples/misc/raptor_master.py
+++ b/examples/misc/raptor_master.py
@@ -297,9 +297,6 @@ if __name__ == '__main__':
     out('submit')
     master.submit()
 
-    # let some time pass for client side tasks to complete
-    time.sleep(60)
-
     out('stop')
     # TODO: can be run from thread?
     master.stop()


### PR DESCRIPTION
remove unnecessary delay `time.sleep(60)` from `raptor_master.py`