### PR TITLE
initial checkin of csc.mahti resource config

### DIFF
--- a/src/radical/pilot/configs/resource_csc.json
+++ b/src/radical/pilot/configs/resource_csc.json
@@ -1,8 +1,7 @@
 {
     "mahti":
     {
-        "description"                 : "Short description of the resource",
-        "notes"                       : "Notes about resource usage",
+        "description"                 : "1404 CPU nodes",
 
         "schemas"                     : ["local", "batch", "interactive"],
         "local"                       :
@@ -26,11 +25,10 @@
 	"agent_config"                : "default",
         "agent_scheduler"             : "CONTINUOUS",
         "agent_spawner"               : "POPEN",
-        "default_remote_workdir"      : "$HOME",
+        "default_remote_workdir"      : "/scratch/project_%(pd.project)s",
 
         "pre_bootstrap_0"             : [
                                         "module load tykky",
-                                        "export PATH=</path/to/python/env>/bin:$PATH"
                                         ],
         "launch_methods"              : {
                                          "order"  : ["SRUN"],

--- a/src/radical/pilot/configs/resource_csc.json
+++ b/src/radical/pilot/configs/resource_csc.json
@@ -1,0 +1,44 @@
+{
+    "mahti":
+    {
+        "description"                 : "Short description of the resource",
+        "notes"                       : "Notes about resource usage",
+
+        "schemas"                     : ["local", "batch", "interactive"],
+        "local"                       :
+        {
+            "job_manager_endpoint"    : "slurm://mahti.csc.fi/",
+            "filesystem_endpoint"     : "file://mahti.csc.fi/"
+        },
+        "batch"                       : "interactive",
+        "interactive"                 :
+        {
+            "job_manager_endpoint"    : "fork://localhost/",
+            "filesystem_endpoint"     : "file://localhost/"
+        },
+
+        "default_queue"               : "test",
+        "resource_manager"            : "SLURM",
+
+        "cores_per_node"              : 64,
+        "gpus_per_node"               : 0,
+        
+	"agent_config"                : "default",
+        "agent_scheduler"             : "CONTINUOUS",
+        "agent_spawner"               : "POPEN",
+        "default_remote_workdir"      : "$HOME",
+
+        "pre_bootstrap_0"             : [
+                                        "module load tykky",
+                                        "export PATH=</path/to/python/env>/bin:$PATH"
+                                        ],
+        "launch_methods"              : {
+                                         "order"  : ["SRUN"],
+                                         "SRUN" : {
+                                         }
+                                        },
+
+        "python_dist"                 : "default",
+        "virtenv_mode"                : "local"
+    }
+}

--- a/src/radical/pilot/configs/resource_csc.json
+++ b/src/radical/pilot/configs/resource_csc.json
@@ -28,7 +28,7 @@
         "default_remote_workdir"      : "/scratch/project_%(pd.project)s",
 
         "pre_bootstrap_0"             : [
-                                        "module load tykky",
+                                        "module load tykky"
                                         ],
         "launch_methods"              : {
                                          "order"  : ["SRUN"],


### PR DESCRIPTION
Please take a look at line 33 of the json - I wanted to make the path to the python environment more generic and not the path to our project specific python environment - feel free to update how I included it there, or let me know if you want me to change it or discuss. 