### PR TITLE
Keep two startup modes for RP: non-batch and batch

### DIFF
--- a/src/radical/pilot/configs/resource_llnl.json
+++ b/src/radical/pilot/configs/resource_llnl.json
@@ -1,14 +1,11 @@
 {
     "lassen": {
         "description"                 : "Unclassified Sierra system (arch: IBM Power9, NVIDIA TeslaV100)",
-        "default_schema"              : "local",
-        "schemas"                     : {
-            "local"                   : {
-                "job_manager_hop"     : "fork://localhost/",
-                "job_manager_endpoint": "lsf://localhost/",
-                "filesystem_endpoint" : "file://localhost/"
-            }
-        },
+
+        "job_manager_hop"             : "fork://localhost/",
+        "job_manager_endpoint"        : "lsf://localhost/",
+        "filesystem_endpoint"         : "file://localhost/",
+
         "default_queue"               : "pbatch",
         "resource_manager"            : "LSF",
         "agent_scheduler"             : "CONTINUOUS",

--- a/src/radical/pilot/pilot_description.py
+++ b/src/radical/pilot/pilot_description.py
@@ -11,7 +11,6 @@ from .task_description import TaskDescription
 
 UID               = 'uid'
 RESOURCE          = 'resource'
-ACCESS_SCHEMA     = 'access_schema'
 QUEUE             = 'queue'
 JOB_NAME          = 'job_name'
 PROJECT           = 'project'
@@ -71,11 +70,6 @@ class PilotDescription(ru.TypedDict):
             configuration is loaded from the config file once the `PilotDescription`
             is passed to :meth:`radical.pilot.PilotManager.submit_pilots`. If the
             key doesn't exist, an exception :class:`ValueError` is raised.
-        access_schema (str, optional): The key of an access mechanism to use.
-            The valid access mechanism is defined in the resource configuration.
-            See :doc:`/tutorials/configuration`. The first ``schema`` defined
-            in the resource configuration is used by
-            default, if no *access_schema* is specified.
         runtime (int, optional): The maximum run time (wall-clock time) in **minutes** of
             the pilot. Default 10.
         sandbox (str, optional): The working ("sandbox") directory of the pilot agent.
@@ -157,7 +151,6 @@ class PilotDescription(ru.TypedDict):
     _schema = {
         UID             : str        ,
         RESOURCE        : str        ,
-        ACCESS_SCHEMA   : str        ,
         RUNTIME         : int        ,
         APP_COMM        : [str]      ,
         SANDBOX         : str        ,
@@ -181,7 +174,6 @@ class PilotDescription(ru.TypedDict):
     _defaults = {
         UID             : None       ,
         RESOURCE        : None       ,
-        ACCESS_SCHEMA   : None       ,
         RUNTIME         : 10         ,
         APP_COMM        : []         ,
         SANDBOX         : None       ,

--- a/src/radical/pilot/resource_description.py
+++ b/src/radical/pilot/resource_description.py
@@ -6,8 +6,6 @@ import radical.utils as ru
 
 DESCRIPTION            = 'description'
 NOTES                  = 'notes'
-DEFAULT_SCHEMA         = 'default_schema'
-SCHEMAS                = 'schemas'
 JOB_MANAGER_ENDPOINT   = 'job_manager_endpoint'
 JOB_MANAGER_HOP        = 'job_manager_hop'
 FILESYSTEM_ENDPOINT    = 'filesystem_endpoint'
@@ -42,23 +40,6 @@ TASK_PRE_EXEC          = 'task_pre_exec'
 
 # ------------------------------------------------------------------------------
 #
-class AccessSchema(ru.TypedDict):
-
-    _schema = {
-        JOB_MANAGER_ENDPOINT: str,
-        JOB_MANAGER_HOP     : str,
-        FILESYSTEM_ENDPOINT : str,
-    }
-
-    _defaults = {
-        JOB_MANAGER_ENDPOINT: None,
-        JOB_MANAGER_HOP     : None,
-        FILESYSTEM_ENDPOINT : None,
-    }
-
-
-# ------------------------------------------------------------------------------
-#
 class ResourceDescription(ru.TypedDict):
     '''
     docstrings goes here
@@ -67,11 +48,7 @@ class ResourceDescription(ru.TypedDict):
     _schema = {
         DESCRIPTION            : str        ,
         NOTES                  : str        ,
-        DEFAULT_SCHEMA         : str        ,
-        SCHEMAS                : {str: AccessSchema},
 
-        # FIXME: AM - need to resolve since in Session it is moved into RD
-        #        `_get_resource_sandbox` -> `KeyError: 'filesystem_endpoint'`
         JOB_MANAGER_ENDPOINT   : str        ,
         JOB_MANAGER_HOP        : str        ,
         FILESYSTEM_ENDPOINT    : str        ,
@@ -107,11 +84,7 @@ class ResourceDescription(ru.TypedDict):
     _defaults = {
         DESCRIPTION            : ''          ,
         NOTES                  : ''          ,
-        DEFAULT_SCHEMA         : ''          ,
-        SCHEMAS                : list()      ,
 
-        # FIXME: AM - need to resolve since in Session it is moved into RD
-        #        `_get_resource_sandbox` -> `KeyError: 'filesystem_endpoint'`
         JOB_MANAGER_ENDPOINT   : None        ,
         JOB_MANAGER_HOP        : None        ,
         FILESYSTEM_ENDPOINT    : None        ,


### PR DESCRIPTION
I would like to propose to clean up "schemas" and to have just 2 startup modes, which would be determined by RP automatically: non-batch (the current "local" schema, which later will be transformed into batch-launcher) and batch (default way to start RP apps). 

Thus, we don't need to have "schemas" and we will have only one "schema" for non-batch mode, and when RP determines that it is a batch mode, then it overwrites corresponding attributes (`job_manager_endpoint`, `filesystem_endpoint`). And we will remove all "remote submission" schemas that we don't support anymore.

p.s. this is a partial PR to demonstrate the proposal, if we are all agree then we'll work on this PR to make it complete.