### PR TITLE
Start RM before starting Session components (`agent_0`)

### DIFF
--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -421,11 +421,9 @@ class Session(rs.Session):
         def_cfg.report_dir  = self._cfg.path
         def_cfg.profile_dir = self._cfg.path
 
-        self._prof = self._get_profiler(name=self._uid)
+        self._log  = self._get_logger  (name=self._uid, cfg=self._cfg)
+        self._prof = self._get_profiler(name=self._uid, cfg=self._cfg)
         self._rep  = self._get_reporter(name=self._uid)
-        self._log  = self._get_logger  (name=self._uid,
-                                        level=self._cfg.get('log_lvl'),
-                                        debug=self._cfg.get('debug_lvl'))
 
         from . import version_detail as rp_version_detail
         self._log.info('radical.pilot version: %s', rp_version_detail)
@@ -474,11 +472,9 @@ class Session(rs.Session):
         def_cfg.report_dir  = self._cfg.path
         def_cfg.profile_dir = self._cfg.path
 
-        self._prof = self._get_profiler(name=self._uid)
+        self._log  = self._get_logger  (name=self._uid, cfg=self._cfg)
+        self._prof = self._get_profiler(name=self._uid, cfg=self._cfg)
         self._rep  = self._get_reporter(name=self._uid)
-        self._log  = self._get_logger  (name=self._uid,
-                                        level=self._cfg.get('log_lvl'),
-                                        debug=self._cfg.get('debug_lvl'))
 
         from . import version_detail as rp_version_detail
         self._log.info('radical.pilot version: %s', rp_version_detail)
@@ -504,11 +500,9 @@ class Session(rs.Session):
         def_cfg.report_dir  = self._cfg.path
         def_cfg.profile_dir = self._cfg.path
 
-        self._prof = self._get_profiler(name=self._uid)
+        self._log  = self._get_logger  (name=self._uid, cfg=self._cfg)
+        self._prof = self._get_profiler(name=self._uid, cfg=self._cfg)
         self._rep  = self._get_reporter(name=self._uid)
-        self._log  = self._get_logger  (name=self._uid,
-                                        level=self._cfg.get('log_lvl'),
-                                        debug=self._cfg.get('debug_lvl'))
 
         from . import version_detail as rp_version_detail
         self._log.info('radical.pilot version: %s', rp_version_detail)
@@ -1030,16 +1024,17 @@ class Session(rs.Session):
 
     # --------------------------------------------------------------------------
     #
-    def _get_logger(self, name, level=None, debug=None):
+    @staticmethod
+    def _get_logger(name, cfg, level=None, debug=None):
         """Get the Logger instance.
 
         This is a thin wrapper around `ru.Logger()` which makes sure that
         log files end up in a separate directory with the name of `session.uid`.
         """
-        log = ru.Logger(name=name, ns='radical.pilot', path=self._cfg.path,
-                         targets=['.'], level=level, debug=debug)
-
-        return log
+        return ru.Logger(name=name, ns='radical.pilot',
+                         path=cfg.path, targets=['.'],
+                         level=level or cfg.get('log_lvl'),
+                         debug=debug or cfg.get('debug_lvl'))
 
 
     # --------------------------------------------------------------------------
@@ -1059,16 +1054,14 @@ class Session(rs.Session):
 
     # --------------------------------------------------------------------------
     #
-    def _get_profiler(self, name):
+    @staticmethod
+    def _get_profiler(name, cfg):
         """Get the Profiler instance.
 
         This is a thin wrapper around `ru.Profiler()` which makes sure that
         log files end up in a separate directory with the name of `session.uid`.
         """
-
-        prof = ru.Profiler(name=name, ns='radical.pilot', path=self._cfg.path)
-
-        return prof
+        return ru.Profiler(name=name, ns='radical.pilot', path=cfg.path)
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -199,10 +199,8 @@ class Component(object):
         if self._owner == self.uid:
             self._owner = 'root'
 
-        self._prof = self._session._get_profiler(name=self.uid)
-        self._log  = self._session._get_logger  (name=self.uid,
-                                                 level=self._cfg.get('log_lvl'),
-                                                 debug=self._cfg.get('debug_lvl'))
+        self._prof = self._session._get_profiler(name=self.uid, cfg=self._cfg)
+        self._log  = self._session._get_logger  (name=self.uid, cfg=self._cfg)
 
         self._q    = None
         self._in   = None


### PR DESCRIPTION
With the current setup, RM initialization happens in components first, before it happens in `agent_0`, but should be in opposite
```
(ve.rp) [matitov@login12.frontier pilot.0000]$ grep -r "RM init from" ./*
./agent_0.log:1698866658.513 : agent_0              : 25861 : 140737179934528 : DEBUG    : RM init from registry
./agent_executing.0000.log:1698866634.720 : agent_executing.0000 : 26039 : 140735520786176 : DEBUG    : RM init from scratch
./agent_scheduling.0000.log:1698866634.720 : agent_scheduling.0000 : 26054 : 140735520786176 : DEBUG    : RM init from scratch
```

Because of that I had an issue with LM initialization, which requires `self._configure` to run during its `self._init_from_scratch` method

And this is an example that LM's `self._configure` was called in Scheduler first
```
grep "DVM ready" ../*
../agent_scheduling.0000.log:1698866639.153 : agent_scheduling.0000 : 26313 : 140732819072768 : DEBUG    : prte-0 output: b'DVM ready'
```
---
Thus, with this PR I tried to reorder RM and Session initializations, but looks like RM suppose to be in between the following Session's calls...
https://github.com/radical-cybertools/radical.pilot/blob/e2a38170ab377d707c7242bd85ba772b3a7d4975/src/radical/pilot/session.py#L281-L286
... after starting registry, but before starting components

@andre-merzky Andre, what should we do here?