### PR TITLE
remove space for function invocation

### DIFF
--- a/examples/data_staging/io_staging_dict.py
+++ b/examples/data_staging/io_staging_dict.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
         # always clean up the session, no matter if we caught an exception or
         # not.
         print("closing session")
-        session.close ()
+        session.close()
 
         # the above is equivalent to
         #


### PR DESCRIPTION
Remove typo in the `staging` example.