### PR TITLE
fixed `Task._update` method (`description` attribute)

### DIFF
--- a/src/radical/pilot/task.py
+++ b/src/radical/pilot/task.py
@@ -178,7 +178,7 @@ class Task(object):
                 setattr(self, "_%s" % key, val)
 
         # RP's internal processes may update metadata
-        if task_dict['description'].get('metadata'):
+        if task_dict.get('description', {}).get('metadata'):
             self._descr['metadata'] = task_dict['description']['metadata']
 
         # callbacks are not invoked here anymore, but are bulked in the tmgr


### PR DESCRIPTION
Race condition regarding having `description` attribute within `task_dict`

p.s., I couldn't spot from where specifically it comes, for most cases it is not the issue, but for some tasks it breaks the update process

Example of the error message
```
1702539334.001 : tmgr.0000            : 423200 : 140732555587952 : ERROR    : callback error
Traceback (most recent call last):
  File "/gpfs/alpine/csc449/world-shared/soma/summit/ve_workflow/lib/python3.8/site-packages/radical/utils/zmq/pubsub.py", line 304, in _listener
    cb(topic, msg)
  File "/gpfs/alpine/csc449/world-shared/soma/summit/ve_workflow/lib/python3.8/site-packages/radical/pilot/task_manager.py", line 358, in _state_sub_cb
    self._update_tasks(tasks)
  File "/gpfs/alpine/csc449/world-shared/soma/summit/ve_workflow/lib/python3.8/site-packages/radical/pilot/task_manager.py", line 402, in _update_tasks
    self._tasks[uid]._update(task_dict)
  File "/gpfs/alpine/csc449/world-shared/soma/summit/ve_workflow/lib/python3.8/site-packages/radical/pilot/task.py", line 181, in _update
    if task_dict['description'].get('metadata'):
KeyError: 'description'
```