### PR TITLE
Fix/proxy url

### DIFF
--- a/docs/source/envs.rst
+++ b/docs/source/envs.rst
@@ -9,6 +9,8 @@ environment variables. Those variables are exported in the shell from which you
 will launch your RP application. Usually, environment variables can be set using
 the `export <https://manpages.org/export>`_ command.
 
+.. note:: All the variables are optional. You can set them to change/enhance the behavior of RP, depending on your requirements.
+
 .. warning:: Tables are large, scroll to the right to see the whole table.
 
 End user
@@ -57,6 +59,9 @@ End user
     * - .. envvar:: RADICAL_DEFAULT_PROFILE_DIR
       - Directory where to store profiles/traces
       - $PWD
+    * - .. envvar:: RADICAL_PILOT_PROXY_URL
+      - Proxy to facilitate communication between the client machine, i.e., the host where the application created this Session instance, and the target resource, i.e., the host where the pilot agent/s is/are running and where the workload is being executed.
+      - {NOT_SET}
 
 Logger
 ------

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -645,11 +645,11 @@ class Session(rs.Session):
 
         # check if an external proxy was epcified for the session.
         if self._proxy_url:
-           self._log.debug('use proxy at %s' % self._proxy_url)
-           return
+            self._log.debug('use proxy at %s' % self._proxy_url)
+            return
 
        # check if an external proxy was specified in the environment
-       elif 'RADICAL_PILOT_PROXY_URL' in os.environ:
+        elif 'RADICAL_PILOT_PROXY_URL' in os.environ:
             self._proxy_url = os.environ['RADICAL_PILOT_PROXY_URL']
             self._log.debug('found proxy at %s' % self._proxy_url)
 

--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -643,23 +643,26 @@ class Session(rs.Session):
 
         assert self._role == self._PRIMARY
 
-        # check if an external proxy is being used.  If so we are done.
+        # check if an external proxy was epcified for the session.
         if self._proxy_url:
-            self._log.debug('use proxy at %s' % self._proxy_url)
-            return
+           self._log.debug('use proxy at %s' % self._proxy_url)
+           return
 
-        self._proxy_url = os.environ.get('RADICAL_PILOT_PROXY_URL')
-        if self._proxy_url:
+       # check if an external proxy was specified in the environment
+       elif 'RADICAL_PILOT_PROXY_URL' in os.environ:
+            self._proxy_url = os.environ['RADICAL_PILOT_PROXY_URL']
             self._log.debug('found proxy at %s' % self._proxy_url)
-            return
 
         # no luck - start an embedded proxy
-        self._proxy_event  = mt.Event()
-        self._proxy_thread = mt.Thread(target=self._run_proxy)
-        self._proxy_thread.daemon = True
-        self._proxy_thread.start()
+        else:
+            self._proxy_event  = mt.Event()
+            self._proxy_thread = mt.Thread(target=self._run_proxy)
+            self._proxy_thread.daemon = True
+            self._proxy_thread.start()
 
-        self._proxy_event.wait()
+            self._proxy_event.wait()
+
+
         assert self._proxy_url
 
         # the proxy url becomes part of the session cfg


### PR DESCRIPTION
Using an external proxy URL caused `self._proxy` to remain uninitialized.
This fixes #3143 