### PR TITLE
SRUN-Bridges2 

### DIFF
--- a/src/radical/pilot/configs/resource_access.json
+++ b/src/radical/pilot/configs/resource_access.json
@@ -25,7 +25,8 @@
         "virtenv_mode"                : "create",
         "python_dist"                 : "default",
         "launch_methods"              : {
-                                         "order" : ["MPIRUN"],
+                                         "order" : ["SRUN", "MPIRUN"],
+                                         "SRUN"  : {},
                                          "MPIRUN": {"pre_exec_cached": ["module load slurm",
                                                                         "module load gcc",
                                                                         "module load openmpi"]}


### PR DESCRIPTION
This PR adds `SRUN` to the `Bridges2` config file and makes it the default. 

As per discussion with @andre-merzky, `MPIRUN` suffers from high launching overheads at least at the moment.