### PR TITLE
Service Startup III

### DIFF
--- a/examples/misc/service_tasks.py
+++ b/examples/misc/service_tasks.py
@@ -22,6 +22,13 @@ def app():
         pilot = pmgr.submit_pilots(pdesc)
         tmgr.add_pilots(pilot)
 
+        pilot.register_service('ext_service', 'tcp://localhost:12345')
+
+        td = rp.TaskDescription({'executable': '/bin/date',
+                                 'services'  : ['ext_service']})
+        task = tmgr.submit_tasks(td)
+        tmgr.wait_tasks(task.uid)
+
         # ---------------------------------------------------------------------
         # start SERVICE instance and wait for startup info
         sd = rp.TaskDescription(

--- a/src/radical/pilot/agent/agent_0.py
+++ b/src/radical/pilot/agent/agent_0.py
@@ -213,8 +213,13 @@ class Agent_0(rpu.AgentComponent):
             self.rpc('prepare_env', env_name=env_name, env_spec=env_spec,
                                     rpc_addr=self._pid)
 
+        # launch predefined services
         for sd in self._cfg.services:
             self._launch_service(sd)
+
+        # allow registration of external services
+        self.register_rpc_handler('register_service', self._register_service,
+                                                      rpc_addr=self._pid)
 
         # listen for new tasks from the client
         self.register_input(rps.AGENT_STAGING_INPUT_PENDING,
@@ -681,6 +686,16 @@ class Agent_0(rpu.AgentComponent):
             # signal main thread when that the service is up
             self._log.debug('set service start event for %s', uid)
             self._service_start_evt.set()
+
+        return True
+
+
+    # --------------------------------------------------------------------------
+    #
+    def _register_service(self, uid, info):
+
+        # add info to registry (might be empty!)
+        self._reg['services.%s' % uid] = info
 
         return True
 

--- a/src/radical/pilot/pilot.py
+++ b/src/radical/pilot/pilot.py
@@ -690,6 +690,18 @@ class Pilot(object):
 
     # --------------------------------------------------------------------------
     #
+    def register_service(self, uid, info):
+        '''
+        Instead of running a service task and injecting the obtained service
+        info into other task environments, we can register an external service
+        with the pilot, and have the pilot inject the service info the same way.
+        '''
+
+        self.rpc('register_service', uid=uid, info=info)
+
+
+    # --------------------------------------------------------------------------
+    #
     def prepare_env(self, env_name, env_spec):
         """Prepare a virtual environment.
 


### PR DESCRIPTION
This PR supports external services: endpoint information are injected via `pilot.register_service(uid, info)`.