### PR TITLE
separate ve activation and env settings

### DIFF
--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -789,6 +789,8 @@ virtenv_setup()
         echo "do not update virtenv $virtenv"
     fi
 
+    virtenv_eval
+
     # install RP
     if test "$RP_INSTALL_LOCK" = 'TRUE'
     then
@@ -857,10 +859,15 @@ virtenv_activate()
     PATH="$RP_PATH:$PATH"
     export PATH
 
+}
+
+
+# ------------------------------------------------------------------------------
+#
+virtenv_eval()
+{
     # make sure we use the new python binary
     rehash
-
-  # prefix="$virtenv/rp_install"
 
     # make sure the lib path into the prefix conforms to the python conventions
     VE_MOD_PREFIX=`$PYTHON -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())'`
@@ -1023,14 +1030,17 @@ virtenv_create()
     fi
     PIP="$PYTHON -m pip"
 
-    # make sure the new pip version is used (but keep the python executable)
-    rehash "$PYTHON"
-
     # update required base modules
     # of the RADICAL stack
     run_cmd "update  venv" \
-            "$PIP --no-cache-dir install --upgrade pip setuptools wheel" \
+            "pip --no-cache-dir install --upgrade pip setuptools wheel" \
          || echo "Couldn't update venv! Lets see how far we get ..."
+
+    # make sure the new pip version is used (but keep the python executable)
+    rehash
+
+    # collect ve info
+    virtenv_eval
 
     profile_event 've_create_stop'
 }
@@ -1049,6 +1059,7 @@ virtenv_update()
 
     # activate the virtualenv
     virtenv_activate "$virtenv" "$python_dist"
+    virtenv_eval
 
     profile_event 've_update_stop'
 }
@@ -1536,6 +1547,7 @@ rehash "$PYTHON"
 virtenv_setup    "$PILOT_ID"    "$VIRTENV" "$VIRTENV_MODE" \
                  "$PYTHON_DIST"
 virtenv_activate "$VIRTENV" "$PYTHON_DIST"
+virtenv_eval
 create_deactivate
 
 # ------------------------------------------------------------------------------

--- a/src/radical/pilot/agent/bootstrap_0.sh
+++ b/src/radical/pilot/agent/bootstrap_0.sh
@@ -1028,7 +1028,6 @@ virtenv_create()
                 "easy_install pip" \
              || echo "Couldn't install pip! Uh oh...."
     fi
-    PIP="$PYTHON -m pip"
 
     # update required base modules
     # of the RADICAL stack
@@ -1036,7 +1035,7 @@ virtenv_create()
             "pip --no-cache-dir install --upgrade pip setuptools wheel" \
          || echo "Couldn't update venv! Lets see how far we get ..."
 
-    # make sure the new pip version is used (but keep the python executable)
+    # make sure the new pip version is used
     rehash
 
     # collect ve info


### PR DESCRIPTION
A recent python  or pip or venv or whatever change screwed with our bootstrapper: `distutils` were not installed by default.  In this PR the bootstrapper ensures that it *is* installed before being used.