### PR TITLE
Fix/component sync

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -32,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .
       - name: run examples
-        timeout-minutes: 15
+        timeout-minutes: 10
         run: |
           export RADICAL_LOG_LVL=DEBUG_9
           export RADICAL_PROFILE=True
@@ -60,10 +60,16 @@ jobs:
           $RP_ROOT/examples/10_pre_and_post_exec.py
           $RP_ROOT/examples/11_task_input_data_tar.py
           $RP_ROOT/examples/11_task_input_folder.py
-      - name: upload example_artifacts
+
+      - name: prepare example_artifacts
+        if:   always()
+        run: |
+            tar zcf /home/runner/example_artifacts.tgz /home/runner/radical.pilot.sandbox/
+
+      - name: prepare example_artifacts
         if:   always()
         uses: actions/upload-artifact@v3
         with:
             name: example_artifacts
-            path: /home/runner/radical.pilot.sandbox/
+            path: /home/runner/example_artifacts.tgz
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -45,9 +45,6 @@ jobs:
           mkdir example_artifacts/
           cd example_artifacts/
           radical-stack
-          pwd
-          ls -l $HOME
-          ls -l /home/runner || echo 'no runner home'
           ../examples/00_getting_started.py
           ../examples/09_mpi_tasks.py
           ../examples/01_task_details.py

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -42,26 +42,28 @@ jobs:
           export RADICAL_UTILS_ZMQ_LOG_LVL=INFO
           export RADICAL_UTILS_HEARTBEAT_LOG_LVL=INFO
           . testenv/bin/activate
-          mkdir example_artifacts/
-          cd example_artifacts/
+          export RP_ROOT=$(pwd)
+          export BASE=/home/runner/radical.pilot.sandbox/
+          mkdir -p $BASE/client_sessions
+          cd $BASE/client_sessions
           radical-stack
-          ../examples/00_getting_started.py
-          ../examples/09_mpi_tasks.py
-          ../examples/01_task_details.py
-          ../examples/02_failing_tasks.py
-          ../examples/03_multiple_pilots.py
-          ../examples/04_scheduler_selection.py
-          ../examples/05_task_input_data.py
-          ../examples/06_task_output_data.py
-          ../examples/07_shared_task_data.py
-          ../examples/08_task_environment.py
-          ../examples/10_pre_and_post_exec.py
-          ../examples/11_task_input_data_tar.py
-          ../examples/11_task_input_folder.py
+          $RP_ROOT/examples/00_getting_started.py
+          $RP_ROOT/examples/09_mpi_tasks.py
+          $RP_ROOT/examples/01_task_details.py
+          $RP_ROOT/examples/02_failing_tasks.py
+          $RP_ROOT/examples/03_multiple_pilots.py
+          $RP_ROOT/examples/04_scheduler_selection.py
+          $RP_ROOT/examples/05_task_input_data.py
+          $RP_ROOT/examples/06_task_output_data.py
+          $RP_ROOT/examples/07_shared_task_data.py
+          $RP_ROOT/examples/08_task_environment.py
+          $RP_ROOT/examples/10_pre_and_post_exec.py
+          $RP_ROOT/examples/11_task_input_data_tar.py
+          $RP_ROOT/examples/11_task_input_folder.py
       - name: upload example_artifacts
         if:   always()
         uses: actions/upload-artifact@v3
         with:
             name: example_artifacts
-            path: example_artifacts
+            path: /home/runner/radical.pilot.sandbox/
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -25,6 +25,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          sudo apt update
+          sudo apt install -y openmpi-bin
           python -m venv testenv
           . testenv/bin/activate
           python -m pip install --upgrade pip setuptools wheel
@@ -32,8 +34,6 @@ jobs:
       - name: run examples
         timeout-minutes: 15
         run: |
-          sudo apt update
-          sudo apt install -y openmpi-bin
           export RADICAL_LOG_LVL=DEBUG_9
           export RADICAL_PROFILE=True
           export RADICAL_DEBUG=TRUE
@@ -44,6 +44,10 @@ jobs:
           . testenv/bin/activate
           mkdir example_artifacts/
           cd example_artifacts/
+          radical-stack
+          pwd
+          ls -l $HOME
+          ls -l /home/runner || echo 'no runner home'
           ../examples/00_getting_started.py
           ../examples/09_mpi_tasks.py
           ../examples/01_task_details.py

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
             tar zcf /home/runner/example_artifacts.tgz /home/runner/radical.pilot.sandbox/
 
-      - name: prepare example_artifacts
+      - name: upload example_artifacts
         if:   always()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,19 +197,7 @@ jobs:
           mkdir -p $BASE/client_sessions
           cd $BASE/client_sessions
           radical-stack
-          $RP_ROOT/examples/00_getting_started.py
-          $RP_ROOT/examples/09_mpi_tasks.py
-          $RP_ROOT/examples/01_task_details.py
-          $RP_ROOT/examples/02_failing_tasks.py
-          $RP_ROOT/examples/03_multiple_pilots.py
-          $RP_ROOT/examples/04_scheduler_selection.py
-          $RP_ROOT/examples/05_task_input_data.py
-          $RP_ROOT/examples/06_task_output_data.py
-          $RP_ROOT/examples/07_shared_task_data.py
-          $RP_ROOT/examples/08_task_environment.py
-          $RP_ROOT/examples/10_pre_and_post_exec.py
-          $RP_ROOT/examples/11_task_input_data_tar.py
-          $RP_ROOT/examples/11_task_input_folder.py
+          for f in $RP_ROOT/examples/[01]*.py; do echo "=== $f"; $f; done
 
       - name: prepare example_artifacts
         if:   always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y openmpi
+          sudo apt install -y openmpi-bin libopenmpi-dev
           sudo apt install -y texlive cm-super
           sudo apt install -y texlive-fonts-extra texlive-extra-utils dvipng
           sudo apt install -y texlive-fonts-recommended texlive-latex-extra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
             path: sessions_analytics
             retention-days: 5
 
-  examples
+  examples:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,70 @@ jobs:
             path: sessions_analytics
             retention-days: 5
 
+  examples
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.12' ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y openmpi
+          sudo apt install -y texlive cm-super
+          sudo apt install -y texlive-fonts-extra texlive-extra-utils dvipng
+          sudo apt install -y texlive-fonts-recommended texlive-latex-extra
+          python -m venv testenv
+          . testenv/bin/activate
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -r requirements-ci.txt
+          radical-stack
+      - name: run examples
+        timeout-minutes: 10
+        run: |
+          export RADICAL_LOG_LVL=DEBUG_9
+          export RADICAL_PROFILE=True
+          export RADICAL_DEBUG=TRUE
+          export RADICAL_DEBUG_HELPER=TRUE
+          export RADICAL_REPORT=TRUE
+          export RADICAL_UTILS_ZMQ_LOG_LVL=INFO
+          export RADICAL_UTILS_HEARTBEAT_LOG_LVL=INFO
+          . testenv/bin/activate
+          export RP_ROOT=$(pwd)
+          export BASE=/home/runner/radical.pilot.sandbox/
+          mkdir -p $BASE/client_sessions
+          cd $BASE/client_sessions
+          radical-stack
+          $RP_ROOT/examples/00_getting_started.py
+          $RP_ROOT/examples/09_mpi_tasks.py
+          $RP_ROOT/examples/01_task_details.py
+          $RP_ROOT/examples/02_failing_tasks.py
+          $RP_ROOT/examples/03_multiple_pilots.py
+          $RP_ROOT/examples/04_scheduler_selection.py
+          $RP_ROOT/examples/05_task_input_data.py
+          $RP_ROOT/examples/06_task_output_data.py
+          $RP_ROOT/examples/07_shared_task_data.py
+          $RP_ROOT/examples/08_task_environment.py
+          $RP_ROOT/examples/10_pre_and_post_exec.py
+          $RP_ROOT/examples/11_task_input_data_tar.py
+          $RP_ROOT/examples/11_task_input_folder.py
+
+      - name: prepare example_artifacts
+        if:   always()
+        run: |
+            tar zcf /home/runner/example_artifacts.tgz /home/runner/radical.pilot.sandbox/
+
+      - name: upload example_artifacts
+        if:   always()
+        uses: actions/upload-artifact@v3
+        with:
+            name: example_artifacts
+            path: /home/runner/example_artifacts.tgz
+
+

--- a/bin/radical-pilot-bridge
+++ b/bin/radical-pilot-bridge
@@ -6,15 +6,13 @@ __license__   = "MIT"
 
 import os
 import sys
-import time
 
-import threading       as mt
 import setproctitle    as spt
 import multiprocessing as mp
 
 import radical.utils   as ru
 
-from radical.pilot.messages import HeartbeatMessage
+from radical.pilot.messages import ComponentStartedMessage
 
 
 # ------------------------------------------------------------------------------
@@ -28,27 +26,8 @@ def main(sid, reg_addr, uid, ppid, evt):
       - name: name of the bridge
       - kind: type of bridge (`pubsub` or `queue`)
 
-    If the config contains a `heartbeat` section, that section must be formatted
-    as follows:
-
-        {
-          'from'    : 'uid',
-          'addr_pub': 'addr_pub',
-          'addr_sub': 'addr_sub',
-          'interval': <float>,
-          'timeout' : <float>
-        }
-
-    If that section exists, the process will daemonize and heartbeats are used
-    to manage the bridge lifetime: the lifetime of this bridge is then dependent
-    on receiving heartbeats from the given `uid`: after `timeout` seconds of no
-    heartbeats arriving, the bridge will terminate.  The bridge itself will
-    publish heartbeats every `interval` seconds on the heartbeat channel under
-    its own uid.
-
-    If the heartbeat section is not present in the config file, the components
-    lifetime is expected to be explicitly managed, i.e., that this wrapper
-    process hosting the bridge is terminated externally.
+    The config will also contain a `cmgr_url` entry which points to the cmgr
+    this component should register with.
 
     The config file may contain other entries which are passed to the bridge
     and are interpreted by the bridge implementation.
@@ -105,11 +84,8 @@ def wrapped_main(sid, reg_addr, uid, log, prof, ppid, evt):
     pwatcher.watch(int(ppid))
     pwatcher.watch(os.getpid())
 
-    term = mt.Event()
-    reg  = ru.zmq.RegistryClient(url=reg_addr)
-
-    hb_cfg = ru.TypedDict(reg['heartbeat'])
-    b_cfg  = ru.TypedDict(reg['bridges.%s.cfg' % uid])
+    reg   = ru.zmq.RegistryClient(url=reg_addr)
+    b_cfg = ru.TypedDict(reg['bridges.%s.cfg' % uid])
 
     # create the instance and begin to work
     bridge = ru.zmq.Bridge.create(uid, cfg=b_cfg)
@@ -119,48 +95,13 @@ def wrapped_main(sid, reg_addr, uid, log, prof, ppid, evt):
 
     reg.close()
     bridge.start()
-
     evt.set()
 
-    # re-enable the test below if timing issues crop up
-  # if 'pubsub' in uid:
-  #     d = ru.zmq.test_pubsub(bridge.channel, bridge.addr_pub, bridge.addr_sub)
-
-    # bridge runs - send heartbeats so that cmgr knows about it
-    hb_pub = ru.zmq.Publisher('heartbeat', hb_cfg.addr_pub, log=log, prof=prof)
-
-    def hb_beat_cb():
-        hb_pub.put('heartbeat', HeartbeatMessage(uid=uid))
-
-    def hb_term_cb(hb_uid):
-        bridge.stop()
-        term.set()
-        return False
-
-    hb = ru.Heartbeat(uid=uid,
-                      timeout=hb_cfg.timeout,
-                      interval=hb_cfg.interval,
-                      beat_cb=hb_beat_cb,
-                      term_cb=hb_term_cb,
-                      log=log)
-    hb.start()
-
-    # always watch out for session heartbeat
-    hb.watch(uid=sid)
-
-    # react on session heartbeats
-    def hb_sub_cb(topic, msg):
-        hb_msg = HeartbeatMessage(from_dict=msg)
-        if hb_msg.uid == sid:
-            hb.beat(uid=sid)
-
-    ru.zmq.Subscriber('heartbeat', hb_cfg.addr_sub,
-                      topic='heartbeat', cb=hb_sub_cb,
-                      log=log, prof=prof)
+    pipe = ru.zmq.Pipe(mode=ru.zmq.MODE_PUSH, url=b_cfg.cmgr_url)
+    pipe.put(ComponentStartedMessage(uid=uid))
 
     # all is set up - we can sit idle 'til end of time.
-    while not term.is_set():
-        time.sleep(1)
+    bridge.wait()
 
 
 # ------------------------------------------------------------------------------

--- a/bin/radical-pilot-component
+++ b/bin/radical-pilot-component
@@ -6,16 +6,13 @@ __license__   = "MIT"
 
 import os
 import sys
-import time
 
-import threading       as mt
 import setproctitle    as spt
 import multiprocessing as mp
 
 import radical.utils   as ru
 import radical.pilot   as rp
 
-from radical.pilot.messages import HeartbeatMessage
 
 # ------------------------------------------------------------------------------
 #
@@ -28,27 +25,8 @@ def main(sid, reg_addr, uid, ppid, evt):
       - name: name of the component
       - kind: type of component
 
-    If the config contains a `heartbeat` section, that section must be formatted
-    as follows:
-
-        {
-          'from'    : 'uid',
-          'addr_pub': 'addr_pub',
-          'addr_sub': 'addr_sub',
-          'interval': <float>,
-          'timeout' : <float>
-        }
-
-    If that section exists, the process will daemonize and heartbeats are used
-    to manage the bridge lifetime: the lifetime of this bridge is then dependent
-    on receiving heartbeats from the given `uid`: after `timeout` seconds of no
-    heartbeats arriving, the bridge will terminate.  The bridge itself will
-    publish heartbeats every `interval` seconds on the heartbeat channel under
-    its own uid.
-
-    If the heartbeat section is not present in the config file, the components
-    lifetime is expected to be explicitly managed, i.e., that this wrapper
-    process hosting the bridge is terminated externally.
+    The config will also contain a `cmgr_url` entry which points to the cmgr
+    this component should register with.
 
     The config file may contain other entries which are passed to the component
     and are interpreted by the component implementation.
@@ -79,15 +57,10 @@ def wrapped_main(sid, reg_addr, uid, log, prof, ppid, evt):
     pwatcher.watch(int(ppid))
     pwatcher.watch(os.getpid())
 
-    term = mt.Event()
-    reg  = ru.zmq.RegistryClient(url=reg_addr)
-
-    hb_cfg = ru.TypedDict(reg['heartbeat'])
-    c_cfg  = ru.TypedDict(reg['components.%s.cfg' % uid])
+    reg   = ru.zmq.RegistryClient(url=reg_addr)
+    c_cfg = ru.TypedDict(reg['components.%s.cfg' % uid])
 
     reg.close()
-
-    evt.set()
 
     # start a non-primary session
     session = rp.Session(uid=sid, cfg=c_cfg,
@@ -96,38 +69,7 @@ def wrapped_main(sid, reg_addr, uid, log, prof, ppid, evt):
     # create the instance and begin to work
     comp = rp.utils.BaseComponent.create(c_cfg, session)
     comp.start()
-
-    # component runs - send heartbeats so that session knows about it
-    hb_pub = ru.zmq.Publisher('heartbeat', hb_cfg.addr_pub, log=log, prof=prof)
-
-    def hb_beat_cb():
-        hb_pub.put('heartbeat', HeartbeatMessage(uid=uid))
-
-    def hb_term_cb(hb_uid):
-        comp.stop()
-        term.set()
-        return False
-
-    hb = ru.Heartbeat(uid=uid,
-                      timeout=hb_cfg.timeout,
-                      interval=hb_cfg.interval,
-                      beat_cb=hb_beat_cb,
-                      term_cb=hb_term_cb,
-                      log=log)
-    hb.start()
-
-    # always watch out for session heartbeat
-    hb.watch(uid=sid)
-
-    # react on session heartbeats
-    def hb_sub_cb(topic, msg):
-        hb_msg = HeartbeatMessage(from_dict=msg)
-        if hb_msg.uid == sid:
-            hb.beat(uid=sid)
-
-    ru.zmq.Subscriber('heartbeat', hb_cfg.addr_sub,
-                      topic='heartbeat', cb=hb_sub_cb,
-                      log=log, prof=prof)
+    evt.set()
 
     # all is set up - we can sit idle 'til end of time.
     comp.wait()

--- a/bin/radical-pilot-component
+++ b/bin/radical-pilot-component
@@ -130,8 +130,7 @@ def wrapped_main(sid, reg_addr, uid, log, prof, ppid, evt):
                       log=log, prof=prof)
 
     # all is set up - we can sit idle 'til end of time.
-    while not term.is_set():
-        time.sleep(1)
+    comp.wait()
 
 
 # ------------------------------------------------------------------------------

--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -45,7 +45,9 @@ if __name__ == '__main__':
         # read the config used for resource details
         config = ru.read_json('%s/config.json' %
                               os.path.dirname(__file__)).get(resource, {})
+        print('=== create pmgr')
         pmgr   = rp.PilotManager(session=session)
+        print('=== got pmgr')
         tmgr   = rp.TaskManager(session=session)
 
         report.header('submit pilots')

--- a/src/radical/pilot/agent/executing/base.py
+++ b/src/radical/pilot/agent/executing/base.py
@@ -156,7 +156,7 @@ class AgentExecutingComponent(rpu.AgentComponent):
         `self._cancel_task(task)`.  That has to be implemented by al executors.
         '''
 
-        while True:
+        while not self._term.is_set():
 
             # check once per second at most
             time.sleep(1)

--- a/src/radical/pilot/messages.py
+++ b/src/radical/pilot/messages.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import radical.utils as ru
 
+
 # ------------------------------------------------------------------------------
 #
 class RPBaseMessage(ru.Message):
@@ -11,9 +12,14 @@ class RPBaseMessage(ru.Message):
     # rpc distinguishes messages which are forwarded to the proxy bridge and
     # those which are not and thus remain local to the module they originate in.
 
-    _schema   = {'fwd'      : bool}
-    _defaults = {'_msg_type': 'rp_msg',
-                 'fwd'      : False}
+    _msg_type = 'rp_msg'
+    _schema   = {'fwd': bool}
+    _defaults = {'fwd': False}
+
+    @classmethod
+    def register(cls):
+        cls._defaults['_msg_type'] = cls._msg_type
+        ru.Message.register_msg_type(cls._msg_type, cls)
 
 
     # we do not register this message type - it is not supposed to be used
@@ -22,31 +28,30 @@ class RPBaseMessage(ru.Message):
 
 # ------------------------------------------------------------------------------
 #
-class HeartbeatMessage(RPBaseMessage):
+class ComponentStartedMessage(RPBaseMessage):
 
-    # heartbeat messages are never forwarded
+    # startup messages are never forwarded
 
-    _schema   = {'uid'      : str}
-    _defaults = {'_msg_type': 'heartbeat',
-                 'fwd'      : False,
-                 'uid'      : None}
+    _msg_type = 'component_start'
+    _schema   = {'uid': str}
+    _defaults = {'fwd': False,
+                 'uid': None}
 
 
-ru.Message.register_msg_type('heartbeat', HeartbeatMessage)
+ComponentStartedMessage.register()
 
 
 # ------------------------------------------------------------------------------
 #
 class RPCRequestMessage(RPBaseMessage):
 
+    _msg_type = 'rpc_req'
     _schema   = {'uid'      : str,   # uid of message
                  'addr'     : str,   # who is expected to act on the request
                  'cmd'      : str,   # rpc command
                  'args'     : list,  # rpc command arguments
                  'kwargs'   : dict}  # rpc command named arguments
-    _defaults = {
-                 '_msg_type': 'rpc_req',
-                 'fwd'      : True,
+    _defaults = {'fwd'      : True,
                  'uid'      : None,
                  'addr'     : None,
                  'cmd'      : None,
@@ -54,20 +59,20 @@ class RPCRequestMessage(RPBaseMessage):
                  'kwargs'   : {}}
 
 
-
-ru.Message.register_msg_type('rpc_req', RPCRequestMessage)
+RPCRequestMessage.register()
 
 
 # ------------------------------------------------------------------------------
 #
 class RPCResultMessage(RPBaseMessage):
 
+    _msg_type = 'rpc_res'
     _schema   = {'uid'      : str,  # uid of rpc call
                  'val'      : Any,  # return value (`None` by default)
                  'out'      : str,  # stdout
                  'err'      : str,  # stderr
                  'exc'      : str}  # raised exception representation
-    _defaults = {'_msg_type': 'rpc_res',
+    _defaults = {'_msg_type': _msg_type,
                  'fwd'      : True,
                  'uid'      : None,
                  'val'      : None,
@@ -90,7 +95,7 @@ class RPCResultMessage(RPBaseMessage):
         super().__init__(from_dict, **kwargs)
 
 
-ru.Message.register_msg_type('rpc_res', RPCResultMessage)
+RPCResultMessage.register()
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/pilot/pilot_manager.py
+++ b/src/radical/pilot/pilot_manager.py
@@ -123,7 +123,10 @@ class PilotManager(rpu.ClientComponent):
         cfg.heartbeat      = session.cfg.heartbeat
         cfg.client_sandbox = session._get_client_sandbox()
 
+        print('pmgr init')
+
         super().__init__(cfg, session=session)
+        print('pmgr start')
         self.start()
 
         self._log.info('started pmgr %s', self._uid)

--- a/src/radical/pilot/utils/__init__.py
+++ b/src/radical/pilot/utils/__init__.py
@@ -35,7 +35,6 @@ if os.uname()[0] == 'Darwin':
 from .prof_utils        import *
 from .misc              import *
 from .session           import *
-from .bridge            import *
 from .component         import *
 from .component_manager import *
 from .serializer        import *

--- a/src/radical/pilot/utils/__init__.py
+++ b/src/radical/pilot/utils/__init__.py
@@ -35,6 +35,7 @@ if os.uname()[0] == 'Darwin':
 from .prof_utils        import *
 from .misc              import *
 from .session           import *
+from .bridge            import *
 from .component         import *
 from .component_manager import *
 from .serializer        import *

--- a/src/radical/pilot/utils/component.py
+++ b/src/radical/pilot/utils/component.py
@@ -236,7 +236,7 @@ class BaseComponent(object):
     def wait(self):
 
         while not self._term.is_set():
-            time.sleep(1)
+            time.sleep(0.1)
 
 
     # --------------------------------------------------------------------------

--- a/tests/unit_tests/test_executing/test_base.py
+++ b/tests/unit_tests/test_executing/test_base.py
@@ -75,10 +75,15 @@ class TestBaseExecuting(TestCase):
             'resource_manager': 'FORK',
             'agent_spawner'   : 'POPEN'})
 
-        ec._log               = ec._prof               = mock.Mock()
-        ec.work               = ec.control_cb          = mock.Mock()
-        ec.register_input     = ec.register_output     = mock.Mock()
-        ec.register_publisher = ec.register_subscriber = mock.Mock()
+        ec._term               = mock.Mock()
+        ec._log                = mock.Mock()
+        ec._prof               = mock.Mock()
+        ec.work                = mock.Mock()
+        ec.control_cb          = mock.Mock()
+        ec.register_input      = mock.Mock()
+        ec.register_output     = mock.Mock()
+        ec.register_publisher  = mock.Mock()
+        ec.register_subscriber = mock.Mock()
 
         mocked_rm.create.return_value = mocked_rm
         ec.initialize()


### PR DESCRIPTION
This PR cleans up the component startup synchronization by using a zmq pipe instead of heartbeat messages.  The latter became superfluous as we have competing termination mechanisms in place: pwatcher, termination commands, and heartbeats.  The latter now got removed to avoid conflicts in termination procedures.