### PR TITLE
fixed task handling when cancelled

### DIFF
--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -370,6 +370,7 @@ class Popen(AgentExecutingComponent):
 
                 with self._check_lock:
                     if tid not in self._tasks:
+                        # task was canceled before, nothing to do
                         continue
                     try:
                         del self._tasks[tid]

--- a/src/radical/pilot/agent/executing/popen.py
+++ b/src/radical/pilot/agent/executing/popen.py
@@ -369,11 +369,12 @@ class Popen(AgentExecutingComponent):
                     pass
 
                 with self._check_lock:
-                    if tid in self._tasks:
-                        try:
-                            del self._tasks[tid]
-                        except KeyError:
-                            pass
+                    if tid not in self._tasks:
+                        continue
+                    try:
+                        del self._tasks[tid]
+                    except KeyError:
+                        pass
 
                 tasks_to_advance.append(task)
 

--- a/tests/unit_tests/test_executing/test_popen.py
+++ b/tests/unit_tests/test_executing/test_popen.py
@@ -211,6 +211,7 @@ class TestPopen(TestCase):
         self.assertNotIn(task['uid'], pex._tasks)
 
         # case 2: exit_code == 0
+        pex._tasks   = {task['uid']: task}
         task['proc'] = mock.Mock()
         task['proc'].poll.return_value = 0
         to_watch.append(task)
@@ -218,6 +219,7 @@ class TestPopen(TestCase):
         self.assertEqual(task['target_state'], rps.DONE)
 
         # case 3: exit_code == 1
+        pex._tasks   = {task['uid']: task}
         task['proc'] = mock.Mock()
         task['proc'].poll.return_value = 1
         to_watch.append(task)


### PR DESCRIPTION
when task is cancelled it shouldn't be handled within the `Popen._check_running` method

(*) revert back this change https://github.com/radical-cybertools/radical.pilot/commit/2e6f18653f69059fe5db846639812347e0ad8956