### PR TITLE
MPIEXEC: rankfile collides with hostnames

### DIFF
--- a/src/radical/pilot/agent/launch_method/mpiexec.py
+++ b/src/radical/pilot/agent/launch_method/mpiexec.py
@@ -245,7 +245,8 @@ class MPIExec(LaunchMethod):
         if self._use_rf:
             rankfile     = self._get_rank_file(slots, uid, sbox)
             hosts        = set([slot['node_name'] for slot in slots])
-            cmd_options += '-H %s -rf %s' % (','.join(hosts), rankfile)
+          # cmd_options += '-H %s -rf %s' % (','.join(hosts), rankfile)
+            cmd_options += '-rf %s' % rankfile
 
         elif self._mpi_flavor == self.MPI_FLAVOR_PALS:
             hostfile     = self._get_host_file(slots, uid, sbox)


### PR DESCRIPTION
On delta, `mpiexec` does not like a rankfile specified and at the same time `-H` being used.  And in fact the information seems redundant as the hostnames are listed in the rankfile anyway.