### PR TITLE
allow oversubscribe on localhost

### DIFF
--- a/.github/workflows/run-rp-notebook.yml
+++ b/.github/workflows/run-rp-notebook.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           TARGET_PATH: ${{ format('{0}/{1}/{2}', inputs.documentation-path, inputs.notebook-path, inputs.notebook-name) }}
           RADICAL_LOG_LVL: DEBUG
+          RADICAL_PILOT_OVERSUBSCRIBE=1
         timeout-minutes: 10
         # continue-on-error: true
         run: |

--- a/.github/workflows/run-rp-notebook.yml
+++ b/.github/workflows/run-rp-notebook.yml
@@ -51,7 +51,6 @@ jobs:
         env:
           TARGET_PATH: ${{ format('{0}/{1}/{2}', inputs.documentation-path, inputs.notebook-path, inputs.notebook-name) }}
           RADICAL_LOG_LVL: DEBUG
-          RADICAL_PILOT_OVERSUBSCRIBE=1
         timeout-minutes: 10
         # continue-on-error: true
         run: |

--- a/docs/source/tutorials/raptor_mpi.ipynb
+++ b/docs/source/tutorials/raptor_mpi.ipynb
@@ -59,7 +59,7 @@
     "\n",
     "# submit a pilot\n",
     "pilot = pmgr.submit_pilots(rp.PilotDescription({'resource'     : 'local.localhost',\n",
-    "                                                'cores'        : 17,\n",
+    "                                                'cores'        : 4,\n",
     "                                                'runtime'      : 30,\n",
     "                                                'exit_on_error': False}))\n",
     "\n",
@@ -132,7 +132,7 @@
     "raptor_descr = {'mode'        : rp.RAPTOR_MASTER,\n",
     "                'named_env'   : 'raptor_ve'}\n",
     "worker_descr = {'mode'        : rp.RAPTOR_WORKER,\n",
-    "                'ranks'       : 10,\n",
+    "                'ranks'       : 2,\n",
     "                'named_env'   : 'raptor_ve',\n",
     "                'raptor_class': 'MPIWorker'}\n",
     "\n",
@@ -181,7 +181,7 @@
    "source": [
     "# create a minimal MPI function task\n",
     "td = rp.TaskDescription({'mode'    : rp.TASK_FUNCTION,\n",
-    "                         'ranks'   : 4,\n",
+    "                         'ranks'   : 2,\n",
     "                         'function': func_mpi(None, msg='mpi_task.0')})\n",
     "mpi_task = raptor.submit_tasks([td])[0]"
    ]
@@ -233,7 +233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/src/radical/pilot/agent/resource_manager/base.py
+++ b/src/radical/pilot/agent/resource_manager/base.py
@@ -251,10 +251,10 @@ class ResourceManager(object):
         rm_info.threads_per_core = int(os.environ.get('RADICAL_SMT') or
                                        system_architecture.get('smt', 1))
 
-
         rm_info.details = {
-                'exact'       : system_architecture.get('exclusive', False),
-                'n_partitions': system_architecture.get('n_partitions', 1)
+                'exact'        : system_architecture.get('exclusive', False),
+                'n_partitions' : system_architecture.get('n_partitions', 1),
+                'oversubscribe': system_architecture.get('oversubscribe', False)
         }
 
         # let the specific RM instance fill out the RMInfo attributes

--- a/src/radical/pilot/configs/resource_local.json
+++ b/src/radical/pilot/configs/resource_local.json
@@ -38,7 +38,8 @@
         "raptor"                      : {
                                          "hb_delay"     : 100,
                                          "hb_timeout"   : 400,
-                                         "hb_frequency" : 100}
+                                         "hb_frequency" : 100},
+        "system_architecture"         : {"oversubscribe": true}
     },
 
     "localhost_test": {

--- a/tests/unit_tests/test_launcher/test_launcher.py
+++ b/tests/unit_tests/test_launcher/test_launcher.py
@@ -68,6 +68,7 @@ class TestLauncher(TestCase):
         component._prof          = ru.Config(cfg={'enabled': False})
         component._sandboxes     = dict()
         component._root_dir      = '/radical_pilot_src'
+        component._rm_info       = ru.Config(cfg={'details': None})
 
         component._rp_version    = rp.version
 
@@ -131,8 +132,9 @@ class TestLauncher(TestCase):
         # test SMT (provided by env variable RADICAL_SMT or within the config's
         #           parameter "system_architecture")
 
-        # default value is {} (not set for "local.localhost")
-        self.assertEqual(pilot['jd_dict'].system_architecture, {})
+        # `system_architecture` should exist and be a dict
+        self.assertIsInstance(pilot['jd_dict'].system_architecture, dict)
+
         # value for "ornl.summit" is 1 (with MPIRun LM)
         component._prepare_pilot('ornl.summit',
                                  self._configs.ornl.summit,

--- a/tests/unit_tests/test_lm/test_mpiexec.py
+++ b/tests/unit_tests/test_lm/test_mpiexec.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # pylint: disable=protected-access, unused-argument, no-value-for-parameter
 
 import os
@@ -28,6 +30,7 @@ class TestMPIExec(TestCase):
 
         lm_mpiexec = MPIExec('', {}, None, None, None)
         lm_mpiexec.name = 'mpiexec'
+        lm_mpiexec._rm_info = ru.Config({'details': dict()})
 
         env    = {'test_env': 'test_value'}
         env_sh = 'env/lm_%s.sh' % lm_mpiexec.name.lower()
@@ -57,6 +60,7 @@ class TestMPIExec(TestCase):
                                          mocked_mpi_info, mocked_init):
 
         lm_mpiexec = MPIExec('', {}, None, None, None)
+        lm_mpiexec._rm_info = ru.Config({'details': dict()})
 
         for _flag in ['mpt', 'rsh']:
             lm_mpiexec.name = 'mpiexec_%s' % _flag
@@ -84,7 +88,7 @@ class TestMPIExec(TestCase):
     @mock.patch.object(MPIExec, '__init__', return_value=None)
     def test_init_from_info(self, mocked_init):
 
-        lm_mpiexec = MPIExec('', {}, None, None, None)
+        lm_mpiexec = MPIExec('', {}, {}, None, None)
 
         lm_info = {
             'env'        : {'test_env': 'test_value'},
@@ -94,6 +98,7 @@ class TestMPIExec(TestCase):
             'rsh'        : False,
             'use_rf'     : True,
             'use_hf'     : False,
+            'can_os'     : False,
             'ccmrun'     : '/bin/ccmrun',
             'dplace'     : '/bin/dplace',
             'omplace'    : '/bin/omplace',
@@ -108,6 +113,7 @@ class TestMPIExec(TestCase):
         self.assertEqual(lm_mpiexec._rsh,         lm_info['rsh'])
         self.assertEqual(lm_mpiexec._use_rf,      lm_info['use_rf'])
         self.assertEqual(lm_mpiexec._use_hf,      lm_info['use_hf'])
+        self.assertEqual(lm_mpiexec._can_os,      lm_info['can_os'])
         self.assertEqual(lm_mpiexec._ccmrun,      lm_info['ccmrun'])
         self.assertEqual(lm_mpiexec._dplace,      lm_info['dplace'])
         self.assertEqual(lm_mpiexec._omplace,     'omplace')
@@ -297,6 +303,7 @@ class TestMPIExec(TestCase):
         lm_mpiexec._use_hf  = False
         lm_mpiexec._omplace = ''
         lm_mpiexec._log     = mocked_logger
+        lm_mpiexec._rm_info = ru.Config({'details': dict()})
 
         test_cases = setUp('lm', 'mpiexec')
         for test_case in test_cases:
@@ -335,6 +342,7 @@ class TestMPIExec(TestCase):
         lm_mpiexec._omplace    = 'omplace'
         lm_mpiexec._mpi_flavor = lm_mpiexec.MPI_FLAVOR_OMPI
         lm_mpiexec._log        = mocked_logger
+        lm_mpiexec._rm_info    = ru.Config({'details': dict()})
 
         test_cases = setUp('lm', 'mpiexec_mpt')
         for task, result in test_cases:


### PR DESCRIPTION
The raptor_mpi tests hung because the GH CI VM did not have sufficient resources.  This PR now allows to oversubscribe resources on `local.localhost` (at least with `mpirun`, to be extended) to resolve this.