### PR TITLE
make it simpler to assign session IDs to experiments.

### DIFF
--- a/src/radical/pilot/session.py
+++ b/src/radical/pilot/session.py
@@ -229,7 +229,8 @@ class Session(object):
 
         # if user did not set a uid, we need to generate a new ID
         if not self._uid:
-            self._uid = ru.generate_id('rp.session', mode=ru.ID_PRIVATE)
+            base = os.environ.get('RP_SID_BASE', 'rp.session')
+            self._uid = ru.generate_id(base, mode=ru.ID_PRIVATE)
 
         # we still call `_init_cfg` to complete missing config settings
         # FIXME: completion only needed by `PRIMARY`


### PR DESCRIPTION
Example:

    export RP_SID_BASE=flux_256nodes_64ktasks_2partitions
    ./my_experiment.py
    ./my_experiment.py

will result in these two session IDs:
    flux_256nodes_64ktasks_2partitions.0000
    flux_256nodes_64ktasks_2partitions.0001

etc, thus making sessions easily recognicable and easy to match to experiments.